### PR TITLE
Allow DgsDataFetchingEnvironment as an argument to a DgsEntityFetcher

### DIFF
--- a/graphql-dgs-example-java/src/test/java/com/netflix/graphql/dgs/example/ExampleSpringBootTest.java
+++ b/graphql-dgs-example-java/src/test/java/com/netflix/graphql/dgs/example/ExampleSpringBootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.netflix.graphql.dgs.example;
 
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import com.netflix.graphql.dgs.example.datafetcher.*;
-import com.netflix.graphql.dgs.scalars.UploadScalar;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.lang.annotation.ElementType;
@@ -28,6 +27,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, UploadScalar.class, ConcurrentDataFetcher.class, RatingMutation.class, FileUploadMutation.class, DgsAutoConfiguration.class})
+@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, ConcurrentDataFetcher.class, RatingMutation.class, FileUploadMutation.class, DgsAutoConfiguration.class})
 public @interface ExampleSpringBootTest {
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidDgsEntityFetcher.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidDgsEntityFetcher.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.exceptions
+
+class InvalidDgsEntityFetcher(message: String): RuntimeException(message) {
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/MissingDgsEntityFetcherException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/MissingDgsEntityFetcherException.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.exceptions
+
+class MissingDgsEntityFetcherException(type: String): RuntimeException("Missing @DgsEntityFetcher for type $type") {
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,28 +18,25 @@ package com.netflix.graphql.dgs.federation
 
 import com.apollographql.federation.graphqljava._Entity
 import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
 import com.netflix.graphql.dgs.DgsFederationResolver
+import com.netflix.graphql.dgs.exceptions.InvalidDgsEntityFetcher
+import com.netflix.graphql.dgs.exceptions.MissingDgsEntityFetcherException
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.TypeResolver
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import java.util.concurrent.CompletableFuture
 import java.util.stream.Collectors
 import java.util.stream.Stream
 
 @DgsComponent
-open class DefaultDgsFederationResolver() : DgsFederationResolver {
-    constructor(providedDgsSchemaProvider: DgsSchemaProvider): this() {
-        dgsSchemaProvider = providedDgsSchemaProvider
-    }
+open class DefaultDgsFederationResolver(private val dgsSchemaProvider: DgsSchemaProvider) :
+    DgsFederationResolver {
 
     val logger: Logger = LoggerFactory.getLogger(DefaultDgsFederationResolver::class.java)
-
-    @Autowired
-    lateinit var dgsSchemaProvider: DgsSchemaProvider
 
     override fun entitiesFetcher(): DataFetcher<Any?> {
         return DataFetcher { env ->
@@ -49,29 +46,39 @@ open class DefaultDgsFederationResolver() : DgsFederationResolver {
 
     private fun dgsEntityFetchers(env: DataFetchingEnvironment): CompletableFuture<List<Any?>> {
         val resultList = env.getArgument<List<Map<String, Any>>>(_Entity.argumentName)
-                .stream()
-                .map { values ->
-                    val fetcher = dgsSchemaProvider.entityFetchers[values["__typename"]]
+            .stream()
+            .map { values ->
+                val typename = values["__typename"] ?: throw RuntimeException("__typename missing from arguments in federated query")
+                val fetcher = dgsSchemaProvider.entityFetchers[typename]
+                    ?: throw MissingDgsEntityFetcherException(typename.toString())
 
-                    val result = if (fetcher?.second?.parameterTypes?.contains(DataFetchingEnvironment::class.java) == true) {
-                        fetcher.second.invoke(fetcher.first, values, env)
+                if(!fetcher.second.parameterTypes.any { it.isAssignableFrom(Map::class.java)}) {
+                    throw InvalidDgsEntityFetcher("@DgsEntityFetcher ${fetcher.first::class.java.name}.${fetcher.second.name} is invalid. A DgsEntityFetcher must accept an argument of type Map<String, Object>")
+                }
+
+                val result =
+                    if (fetcher.second.parameterTypes.any { it.isAssignableFrom(DgsDataFetchingEnvironment::class.java)}) {
+                        fetcher.second.invoke(fetcher.first, values, DgsDataFetchingEnvironment(env))
                     } else {
-                        fetcher?.second?.invoke(fetcher.first, values)
+                        fetcher.second.invoke(fetcher.first, values)
                     }
 
-                    if (result is CompletableFuture<*>) {
-                        result
-                    } else {
-                        CompletableFuture.completedFuture(result)
-                    }
-                }.filter { it != null }
-                .collect(Collectors.toList())
+                if(result == null) {
+                    throw MissingDgsEntityFetcherException(typename.toString())
+                }
+
+                if (result is CompletableFuture<*>) {
+                    result
+                } else {
+                    CompletableFuture.completedFuture(result)
+                }
+            }.collect(Collectors.toList())
 
         return CompletableFuture.allOf(*resultList.toTypedArray()).thenApply {
             resultList.stream()
-                    .map { cf -> cf.join() }
-                    .flatMap { r -> if(r is Collection<*>) r.stream() else Stream.of(r) }
-                    .collect(Collectors.toList())
+                .map { cf -> cf.join() }
+                .flatMap { r -> if (r is Collection<*>) r.stream() else Stream.of(r) }
+                .collect(Collectors.toList())
         }
     }
 
@@ -83,10 +90,14 @@ open class DefaultDgsFederationResolver() : DgsFederationResolver {
         return TypeResolver { env ->
             val src: Any = env.getObject()
 
-            val typeName = if (typeMapping().containsKey(src::class.java)) typeMapping()[src::class.java] else src::class.java.simpleName
+            val typeName =
+                if (typeMapping().containsKey(src::class.java)) typeMapping()[src::class.java] else src::class.java.simpleName
             val type = env.schema.getObjectType(typeName)
             if (type == null) {
-                logger.warn("No type definition found for {}. You probably need to provide either a type mapping, or override DefaultDgsFederationResolver.typeResolver(). Alternatively make sure the type name in the schema and your Java model match", src::class.java.name)
+                logger.warn(
+                    "No type definition found for {}. You probably need to provide either a type mapping, or override DefaultDgsFederationResolver.typeResolver(). Alternatively make sure the type name in the schema and your Java model match",
+                    src::class.java.name
+                )
             }
 
             type

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsFederationResolverTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsFederationResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,46 @@
 
 package com.netflix.graphql.dgs
 
+import com.apollographql.federation.graphqljava._Entity
+import com.netflix.graphql.dgs.exceptions.MissingDgsEntityFetcherException
 import com.netflix.graphql.dgs.federation.DefaultDgsFederationResolver
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import graphql.TypeResolutionEnvironment
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.DataFetchingEnvironmentImpl
 import graphql.schema.GraphQLSchema
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.SchemaGenerator
 import graphql.schema.idl.SchemaParser
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.context.ApplicationContext
+import java.util.*
+import java.util.concurrent.CompletableFuture
 
+@Suppress("UNCHECKED_CAST")
+@ExtendWith(MockKExtension::class)
 class DgsFederationResolverTest {
+    @MockK
+    lateinit var applicationContextMock: ApplicationContext
+
+    lateinit var dgsSchemaProvider:DgsSchemaProvider
+
+    @BeforeEach
+    fun setup() {
+        dgsSchemaProvider = DgsSchemaProvider(
+                applicationContextMock,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty()
+        )
+    }
 
     @Test
     fun defaultTypeResolver() {
@@ -41,7 +71,7 @@ class DgsFederationResolverTest {
 
         val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
 
-        val type = DefaultDgsFederationResolver().typeResolver().getType(TypeResolutionEnvironment(Movie("123", "Stranger Things"), emptyMap(), null, null, graphQLSchema, null))
+        val type = DefaultDgsFederationResolver(dgsSchemaProvider).typeResolver().getType(TypeResolutionEnvironment(Movie("123", "Stranger Things"), emptyMap(), null, null, graphQLSchema, null))
         assertThat(type.name).isEqualTo("Movie")
     }
 
@@ -54,7 +84,7 @@ class DgsFederationResolverTest {
 
         val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
 
-        val type = DefaultDgsFederationResolver().typeResolver().getType(TypeResolutionEnvironment(Movie("123", "Stranger Things"), emptyMap(), null, null, graphQLSchema, null))
+        val type = DefaultDgsFederationResolver(dgsSchemaProvider).typeResolver().getType(TypeResolutionEnvironment(Movie("123", "Stranger Things"), emptyMap(), null, null, graphQLSchema, null))
         assertThat(type).isNull()
     }
 
@@ -71,7 +101,7 @@ class DgsFederationResolverTest {
         """.trimIndent()
 
         val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
-        val customTypeResolver = object: DefaultDgsFederationResolver() {
+        val customTypeResolver = object: DefaultDgsFederationResolver(dgsSchemaProvider) {
             override fun typeMapping(): Map<Class<*>, String> {
                 return mapOf(Pair(Movie::class.java, "DgsMovie"))
             }
@@ -79,6 +109,92 @@ class DgsFederationResolverTest {
 
         val type = customTypeResolver.typeResolver().getType(TypeResolutionEnvironment(Movie("123", "Stranger Things"), emptyMap(), null, null, graphQLSchema, null))
         assertThat(type.name).isEqualTo("DgsMovie")
+    }
+
+    @Test
+    fun missingDgsEntityFetcher() {
+        val arguments = mapOf<String,Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie")))))
+        val dataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
+        assertThrows<MissingDgsEntityFetcherException> { DefaultDgsFederationResolver(dgsSchemaProvider).entitiesFetcher().get(dataFetchingEnvironment) }
+    }
+
+    @Test
+    fun missingTypeNameForEntitiesQuery() {
+        val arguments = mapOf<String,Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("something", "Else")))))
+        val dataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
+        assertThrows<RuntimeException> { DefaultDgsFederationResolver(dgsSchemaProvider).entitiesFetcher().get(dataFetchingEnvironment) }
+    }
+
+    @Test
+    fun dgsEntityFetcher() {
+        val movieEntityFetcher = object {
+            @DgsEntityFetcher(name = "Movie")
+            fun movieEntityFetcher(values: Map<String, Any>): Movie {
+                return Movie(values["movieId"].toString())
+            }
+        }
+
+        testEntityFetcher(movieEntityFetcher)
+
+    }
+
+    @Test
+    fun dgsEntityFetcherWithDataFetchingEnv() {
+        val movieEntityFetcher = object {
+            @DgsEntityFetcher(name = "Movie")
+            fun movieEntityFetcher(values: Map<String, Any>, dfe: DataFetchingEnvironment?): Movie {
+                if(dfe == null) {
+                    throw RuntimeException()
+                }
+                return Movie(values["movieId"].toString())
+            }
+        }
+
+        testEntityFetcher(movieEntityFetcher)
+
+    }
+
+    @Test
+    fun dgsEntityFetcherWithDgsDataFetchingEnv() {
+        val movieEntityFetcher = object {
+            @DgsEntityFetcher(name = "Movie")
+            fun movieEntityFetcher(values: Map<String, Any>, dfe: DgsDataFetchingEnvironment?): Movie {
+                if(dfe == null) {
+                    throw RuntimeException()
+                }
+                return Movie(values["movieId"].toString())
+            }
+        }
+
+        testEntityFetcher(movieEntityFetcher)
+    }
+
+    @Test
+    fun dgsEntityFetcherMissingArgument() {
+        val movieEntityFetcher = object {
+            @DgsEntityFetcher(name = "Movie")
+            fun movieEntityFetcher(): Movie {
+                throw RuntimeException("Should not be called")
+            }
+        }
+        val arguments = mapOf<String,Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie")))))
+        val dataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
+        assertThrows<RuntimeException> { DefaultDgsFederationResolver(dgsSchemaProvider).entitiesFetcher().get(dataFetchingEnvironment) }
+    }
+
+    private fun testEntityFetcher(movieEntityFetcher: Any) {
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("MovieEntityFetcher", movieEntityFetcher))
+        dgsSchemaProvider.schema("""type Query {}""")
+
+        val arguments = mapOf<String,Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie"), Pair("movieId", "1")))))
+        val dataFetchingEnvironment = DgsDataFetchingEnvironment(DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build())
+
+        val result = (DefaultDgsFederationResolver(dgsSchemaProvider).entitiesFetcher().get(dataFetchingEnvironment) as CompletableFuture<List<*>>).get()
+        assertThat(result).isNotNull
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0] is Movie).isTrue
+        assertThat((result[0] as Movie).movieId).isEqualTo("1")
     }
 
     private fun buildGraphQLSchema(schema: String): GraphQLSchema {
@@ -90,4 +206,4 @@ class DgsFederationResolverTest {
     }
 }
 
-data class Movie(val movieId:String, val title:String)
+data class Movie(val movieId:String = "", val title:String = "")

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -831,7 +831,7 @@ internal class DgsSchemaProviderTest {
         val executionResult = build.execute("{video{title}}")
         assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
-        val video = data["video"] as Map<String, *>
+        val video = data["video"] as Map<*, *>
         assertEquals("ShowA", video["title"])
     }
 }


### PR DESCRIPTION
Fixes: #5 
Also includes improved error handling in finding entity fetchers.

