### PR TITLE
Updating the WebClient example to express a proper usage pattern.

### DIFF
--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ReactiveWebClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ReactiveWebClientTest.kt
@@ -39,7 +39,7 @@ class ReactiveWebClientTest {
             .headers { consumer -> headers.forEach { consumer.addAll(it.key, it.value) } }
             .bodyValue(body)
             .exchange()
-            .map { HttpResponse(it.rawStatusCode(), it.bodyToMono(String::class.java).block()) }
+            .flatMap { cr -> cr.bodyToMono(String::class.java).map { json -> HttpResponse(cr.rawStatusCode(), json) } }
     }
 
     @Test


### PR DESCRIPTION
This commit updates the WebClient usage such that we avoid calling
`block` within a _reactive thread_. This will prevent users from
observing the following error.

```
block()/blockFirst()/blockLast() are blocking, which is not supported in thread reactor-http-client-epoll-12
```

_note:  Since Reactor 3.2 blocking within a reactive pipeline throws an error_