### PR TITLE
Add a custom exception for bad requests - DgsBadRequestException 

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
@@ -46,8 +46,10 @@ class DefaultDataFetcherExceptionHandler : DataFetcherExceptionHandler {
         } else if(exception is DgsEntityNotFoundException) {
             TypedGraphQLError.NOT_FOUND.message("%s: %s", exception::class.java.name, exception.message)
                     .path(handlerParameters.path).build()
-        }
-        else {
+        } else if(exception is DgsBadRequestException) {
+            TypedGraphQLError.BAD_REQUEST.message("%s: %s", exception::class.java.name, exception.message)
+                .path(handlerParameters.path).build()
+        } else {
             TypedGraphQLError.INTERNAL.message("%s: %s", exception::class.java.name, exception.message)
                     .path(handlerParameters.path).build()
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsBadRequestException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsBadRequestException.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.exceptions
+
+class DgsBadRequestException(override val message: String = "Malformed or incorrect request"): RuntimeException(message)

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandlerTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandlerTest.kt
@@ -95,4 +95,18 @@ internal class DefaultDataFetcherExceptionHandlerTest {
         // We return null here because we don't want graphql-java to write classification field
         assertThat(result.errors[0].errorType).isNull()
     }
+
+    @Test
+    fun badRequestException() {
+        every { dataFetcherExceptionHandlerParameters.exception }.returns(DgsBadRequestException("Malformed movie request"))
+
+        val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
+        assertThat(result.errors.size).isEqualTo(1)
+
+        val extensions = result.errors[0].extensions
+        assertThat(extensions["errorType"]).isEqualTo("BAD_REQUEST")
+
+        // We return null here because we don't want graphql-java to write classification field
+        assertThat(result.errors[0].errorType).isNull()
+    }
 }


### PR DESCRIPTION
This exception sets the graphql error to BAD_REQUEST.