### PR TITLE
Provide the means to customize when the DefaultDgsQueryExecutor reloads the schema.

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -23,6 +23,7 @@ import com.netflix.graphql.dgs.context.DgsCustomContextBuilder
 import com.netflix.graphql.dgs.exceptions.DefaultDataFetcherExceptionHandler
 import com.netflix.graphql.dgs.internal.DefaultDgsGraphQLContextBuilder
 import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
+import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor.ReloadSchemaIndicator
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.dgs.scalars.UploadScalar
@@ -55,25 +56,32 @@ import java.util.*
 open class DgsAutoConfiguration {
 
     @Bean
-    open fun dgsQueryExecutor(applicationContext: ApplicationContext, schema: GraphQLSchema, schemaProvider: DgsSchemaProvider, dgsDataLoaderProvider: DgsDataLoaderProvider, dgsContextBuilder: DgsContextBuilder, dataFetcherExceptionHandler: DataFetcherExceptionHandler, chainedInstrumentation: ChainedInstrumentation, environment: Environment, @Qualifier("query") providedQueryExecutionStrategy: Optional<ExecutionStrategy>, @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>): DgsQueryExecutor {
-        val hotReloadSetting = environment.getProperty("dgs.reload")
-        val isLaptopProfile = environment.activeProfiles.contains("laptop")
+    open fun dgsQueryExecutor(applicationContext: ApplicationContext,
+                              schema: GraphQLSchema,
+                              schemaProvider: DgsSchemaProvider,
+                              dgsDataLoaderProvider: DgsDataLoaderProvider,
+                              dgsContextBuilder: DgsContextBuilder,
+                              dataFetcherExceptionHandler: DataFetcherExceptionHandler,
+                              chainedInstrumentation: ChainedInstrumentation,
+                              environment: Environment,
+                              @Qualifier("query") providedQueryExecutionStrategy: Optional<ExecutionStrategy>,
+                              @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
+                              reloadSchemaIndicator: ReloadSchemaIndicator
+    ): DgsQueryExecutor {
 
-        val enableReload = when (hotReloadSetting) {
-            "true" -> {
-                true
-            }
-            "false" -> {
-                false
-            }
-            else -> {
-                isLaptopProfile
-            }
-        }
 
         val queryExecutionStrategy = providedQueryExecutionStrategy.orElse(AsyncExecutionStrategy(dataFetcherExceptionHandler))
         val mutationExecutionStrategy = providedMutationExecutionStrategy.orElse(AsyncSerialExecutionStrategy(dataFetcherExceptionHandler))
-        return DefaultDgsQueryExecutor(schema, schemaProvider, dgsDataLoaderProvider, dgsContextBuilder, chainedInstrumentation, enableReload, queryExecutionStrategy, mutationExecutionStrategy)
+        return DefaultDgsQueryExecutor(
+                schema,
+                schemaProvider,
+                dgsDataLoaderProvider,
+                dgsContextBuilder,
+                chainedInstrumentation,
+                queryExecutionStrategy,
+                mutationExecutionStrategy,
+                reloadSchemaIndicator
+        )
     }
 
     @Bean
@@ -87,9 +95,47 @@ open class DgsAutoConfiguration {
         return ChainedInstrumentation(listOfInstrumentations)
     }
 
+    /**
+     * Used by the [DefaultDgsQueryExecutor], it controls if, and when, such executor should reload the schema.
+     * This implementation will return either the boolean value of the `dgs.reload` flag
+     * or `true` if the `laptop` profile is an active Spring Boot profiles.
+     * <p>
+     * You can provide a bean of type [ReloadSchemaIndicator] if you want to control when the
+     * [DefaultDgsQueryExecutor] should reload the schema.
+     *
+     * @implSpec the implementation of such bean should be thread-safe.
+     */
     @Bean
     @ConditionalOnMissingBean
-    open fun dgsSchemaProvider(applicationContext: ApplicationContext, federationResolver: Optional<DgsFederationResolver>, dataFetcherExceptionHandler: DataFetcherExceptionHandler, existingTypeDefinitionFactory: Optional<TypeDefinitionRegistry>, existingCodeRegistry: Optional<GraphQLCodeRegistry>, mockProviders: Optional<Set<MockProvider>>): DgsSchemaProvider {
+    open fun defaultReloadSchemaIndicator(environment: Environment): ReloadSchemaIndicator {
+        val isLaptopProfile = environment.activeProfiles.contains("laptop")
+        val hotReloadSetting = environment.getProperty("dgs.reload")
+
+        return ReloadSchemaIndicator {
+            when (hotReloadSetting) {
+                "true" -> {
+                    true
+                }
+                "false" -> {
+                    false
+                }
+                else -> {
+                    isLaptopProfile
+                }
+            }
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    open fun dgsSchemaProvider(
+            applicationContext: ApplicationContext,
+            federationResolver: Optional<DgsFederationResolver>,
+            dataFetcherExceptionHandler: DataFetcherExceptionHandler,
+            existingTypeDefinitionFactory: Optional<TypeDefinitionRegistry>,
+            existingCodeRegistry: Optional<GraphQLCodeRegistry>,
+            mockProviders: Optional<Set<MockProvider>>
+    ): DgsSchemaProvider {
         return DgsSchemaProvider(applicationContext, federationResolver, existingTypeDefinitionFactory, mockProviders)
     }
 
@@ -101,13 +147,13 @@ open class DgsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun schema(dgsSchemaProvider: DgsSchemaProvider) : GraphQLSchema {
+    open fun schema(dgsSchemaProvider: DgsSchemaProvider): GraphQLSchema {
         return dgsSchemaProvider.schema()
     }
 
     @Bean
     @ConditionalOnMissingBean
-    open fun graphQLContextBuilder(dgsCustomContextBuilder: Optional<DgsCustomContextBuilder<*>>) : DgsContextBuilder {
+    open fun graphQLContextBuilder(dgsCustomContextBuilder: Optional<DgsCustomContextBuilder<*>>): DgsContextBuilder {
         return DefaultDgsGraphQLContextBuilder(dgsCustomContextBuilder)
     }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -51,7 +51,10 @@ import java.util.concurrent.CompletionStage
 /**
  * Main framework class that scans for components and configures a runtime executable schema.
  */
-class DgsSchemaProvider(private val applicationContext: ApplicationContext, private val federationResolver: Optional<DgsFederationResolver>, private val existingTypeDefinitionRegistry: Optional<TypeDefinitionRegistry>, private val mockProviders: Optional<Set<MockProvider>>) {
+class DgsSchemaProvider(private val applicationContext: ApplicationContext,
+                        private val federationResolver: Optional<DgsFederationResolver>,
+                        private val existingTypeDefinitionRegistry: Optional<TypeDefinitionRegistry>,
+                        private val mockProviders: Optional<Set<MockProvider>>) {
 
     val dataFetcherInstrumentationEnabled = mutableMapOf<String, Boolean>()
     val entityFetchers = mutableMapOf<String, Pair<Any, Method>>()
@@ -232,25 +235,23 @@ class DgsSchemaProvider(private val applicationContext: ApplicationContext, priv
                         val collectionType = annotation.collectionType.java
                         val parameterValue: Any? = environment.getArgument(parameterName)
 
-                        val convertValue : Any? = if (parameterValue is List<*> && collectionType != Object::class.java) {
+                        val convertValue: Any? = if (parameterValue is List<*> && collectionType != Object::class.java) {
                             try {
                                 parameterValue.map { item -> jacksonObjectMapper().convertValue(item, collectionType) }.toList()
                             } catch (ex: Exception) {
                                 throw DgsInvalidInputArgumentException("Specified type '${collectionType}' is invalid for $parameterName.", ex)
                             }
-                        } else if(parameterValue is MultipartFile) {
+                        } else if (parameterValue is MultipartFile) {
                             parameterValue
-                        }
-                        else if(environment.fieldDefinition.arguments.find { it.name == parameterName }?.type is GraphQLScalarType) {
+                        } else if (environment.fieldDefinition.arguments.find { it.name == parameterName }?.type is GraphQLScalarType) {
                             parameterValue
-                        }
-                        else {
+                        } else {
                             jacksonObjectMapper().convertValue(parameterValue, parameter.type)
                         }
 
                         val paramType = parameter.type
 
-                        if(convertValue != null && !paramType.isPrimitive && !paramType.isAssignableFrom(convertValue.javaClass)) {
+                        if (convertValue != null && !paramType.isPrimitive && !paramType.isAssignableFrom(convertValue.javaClass)) {
                             throw DgsInvalidInputArgumentException("Specified type '${parameter.type}' is invalid. Found ${parameterValue?.javaClass?.name} instead.")
                         }
 
@@ -391,6 +392,5 @@ class DgsSchemaProvider(private val applicationContext: ApplicationContext, priv
 
         return schemas + testSchemas + metaInfSchemas
     }
-
 
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
@@ -89,7 +89,13 @@ internal class DefaultDgsQueryExecutorTest {
         every { dgsDataLoaderProvider.buildRegistryWithContextSupplier(any<Supplier<Any>>()) } returns DataLoaderRegistry()
 
 
-        val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+        val provider = DgsSchemaProvider(
+                applicationContextMock,
+                federationResolver = Optional.empty(),
+                existingTypeDefinitionRegistry = Optional.empty(),
+                mockProviders = Optional.empty()
+        )
+
         val schema = provider.schema("""
             type Query {
                 hello: String
@@ -108,7 +114,7 @@ internal class DefaultDgsQueryExecutorTest {
         """.trimIndent())
 
 
-        dgsQueryExecutor = DefaultDgsQueryExecutor(schema, provider, dgsDataLoaderProvider, DefaultDgsGraphQLContextBuilder(Optional.empty()), ChainedInstrumentation(), false, AsyncExecutionStrategy(), AsyncSerialExecutionStrategy())
+        dgsQueryExecutor = DefaultDgsQueryExecutor(schema, provider, dgsDataLoaderProvider, DefaultDgsGraphQLContextBuilder(Optional.empty()), ChainedInstrumentation(), AsyncExecutionStrategy(), AsyncSerialExecutionStrategy())
     }
 
     @Test
@@ -221,7 +227,7 @@ internal class DefaultDgsQueryExecutorTest {
             {
                 movies { title } 
             }
-        """.trimIndent(), "data.movies[0]", object: TypeRef<List<String>>() {})
+        """.trimIndent(), "data.movies[0]", object : TypeRef<List<String>>() {})
         }
 
         assertThat(assertThrows.message).isEqualTo("Error deserializing data from '{\"data\":{\"movies\":[{\"title\":\"Extraction\"},{\"title\":\"Da 5 Bloods\"}]}}' with JsonPath 'data.movies[0]' and target class java.util.List<? extends java.lang.String>")
@@ -239,7 +245,7 @@ internal class DefaultDgsQueryExecutorTest {
             }
         """.trimIndent())
 
-        val movieList = context.read("data.movies", object: TypeRef<List<Movie>>(){})
+        val movieList = context.read("data.movies", object : TypeRef<List<Movie>>() {})
         assertThat(movieList.size).isEqualTo(2)
         val movie = context.read("data.movies[0]", Movie::class.java)
         assertThat(movie).isNotNull


### PR DESCRIPTION
This commit provides the means to customize when the `DefaultDgsQueryExecutor` will reload its schema.
This is done via the `DefaultDgsQueryExecutor.ReloadSchemaIndicator` functional interface.
We are also providing an implementation of such interface that respects the current reload behavior.