### PR TITLE
Excludes json-smart transitive dependency from json-path

### DIFF
--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -18,7 +18,9 @@ plugins {
 }
 
 dependencies {
-    api("com.jayway.jsonpath:json-path:2.4.+")
+    api("com.jayway.jsonpath:json-path:2.4.+") {
+        exclude(group = "net.minidev", module = "json-smart")
+    }
     api("io.projectreactor:reactor-core:3.4.+")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.jayway.jsonpath.Configuration
-import com.jayway.jsonpath.DocumentContext
-import com.jayway.jsonpath.JsonPath
-import com.jayway.jsonpath.Option
-import com.jayway.jsonpath.TypeRef
+import com.jayway.jsonpath.*
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider
 import org.slf4j.LoggerFactory
@@ -40,9 +36,9 @@ data class GraphQLResponse(val json: String) {
         private val mapper: ObjectMapper = jacksonObjectMapper()
                 .registerModule(JavaTimeModule())
                 .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
-        private val jsonPathConfig: Configuration = Configuration.defaultConfiguration()
+        private val jsonPathConfig: Configuration = Configuration.builder()
                 .jsonProvider(JacksonJsonProvider(mapper))
-                .mappingProvider(JacksonMappingProvider(mapper))
+                .mappingProvider(JacksonMappingProvider(mapper)).build()
                 .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL)
     }
 

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -23,7 +23,10 @@ dependencies {
     api(project(":graphql-dgs-mocking"))
 
     api("com.graphql-java:graphql-java:${Versions.GRAPHQL_JAVA}")
-    api("com.jayway.jsonpath:json-path:2.+")
+    api("com.jayway.jsonpath:json-path:2.+") {
+        exclude(group = "net.minidev", module = "json-smart")
+    }
+
     implementation("org.springframework:spring-web")
     implementation("org.springframework.boot:spring-boot")
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import com.netflix.graphql.dgs.DgsContextBuilder
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.exceptions.DgsQueryExecutionDataExtractionException
 import com.netflix.graphql.dgs.exceptions.QueryException
+import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor.ReloadSchemaIndicator
 import graphql.*
 import graphql.execution.ExecutionStrategy
 import graphql.execution.NonNullableFieldWasNullError
@@ -52,12 +53,12 @@ class DefaultDgsQueryExecutor(defaultSchema: GraphQLSchema,
 ) : DgsQueryExecutor {
 
     private val parseContext: ParseContext =
-            JsonPath.using(Configuration.defaultConfiguration()
+            JsonPath.using(Configuration.builder()
                     .jsonProvider(JacksonJsonProvider(jacksonObjectMapper()))
                     .mappingProvider(
                             JacksonMappingProvider(jacksonObjectMapper()
                                     .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
-                                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)))
+                                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES))).build()
                     .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL))
 
     val logger: Logger = LoggerFactory.getLogger(DefaultDgsQueryExecutor::class.java)


### PR DESCRIPTION
Excludes the transitive dependency on `net.minidev:json-smart` from `json-path` as DGS configures in Jackson as the default JSON provider ([graphql-dgs-client](https://github.com/Netflix/dgs-framework/blob/master/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt#L43) and [graphql-dgs](https://github.com/Netflix/dgs-framework/blob/master/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt#L56)) and `json-smart` is not needed.


Before these changes:
```java
IT-USA-B00159:graphql-dgs cbono$ ../gradlew dependencyInsight --configuration compileClasspath --dependency json-smart 

> Task :graphql-dgs:dependencyInsight
net.minidev:json-smart:2.3 (by constraint)
   variant "compile" [
      org.gradle.status                  = release (not requested)
      org.gradle.usage                   = java-api
      org.gradle.libraryelements         = jar (compatible with: classes)
      org.gradle.category                = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling     = external
         org.jetbrains.kotlin.platform.type = jvm
         org.gradle.jvm.version             = 8
   ]

net.minidev:json-smart:2.3
+--- com.jayway.jsonpath:json-path:2.5.0
|    +--- compileClasspath (requested com.jayway.jsonpath:json-path:2.+)
|    \--- org.springframework.boot:spring-boot-dependencies:2.3.8.RELEASE (requested com.jayway.jsonpath:json-path:2.4.0)
|         \--- compileClasspath
\--- org.springframework.boot:spring-boot-dependencies:2.3.8.RELEASE (*)
```

After these changes:
```java
IT-USA-B00159:graphql-dgs cbono$ ../gradlew dependencyInsight --configuration compileClasspath --dependency json-smart 
```java
> Task :graphql-dgs:dependencyInsight
No dependencies matching given input were found in configuration ':graphql-dgs:compileClasspath'
```

Same result in `graphql-dgs-client` module.


Fixes gh-58