### PR TITLE
Removes the exclusion of json-smart from graphql-dgs-client

### DIFF
--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -18,9 +18,7 @@ plugins {
 }
 
 dependencies {
-    api("com.jayway.jsonpath:json-path:2.4.+") {
-        exclude(group = "net.minidev", module = "json-smart")
-    }
+    api("com.jayway.jsonpath:json-path:2.4.+")
     api("io.projectreactor:reactor-core:3.4.+")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")


### PR DESCRIPTION
@paulbakker 

Fixes gh-73