### PR TITLE
Added support for ExecutionIdProvider

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -32,6 +32,7 @@ import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.ExecutionStrategy
+import graphql.execution.ExecutionIdProvider
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.schema.GraphQLCodeRegistry
@@ -66,6 +67,7 @@ open class DgsAutoConfiguration {
                               environment: Environment,
                               @Qualifier("query") providedQueryExecutionStrategy: Optional<ExecutionStrategy>,
                               @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
+                              idProvider: Optional<ExecutionIdProvider>,
                               reloadSchemaIndicator: ReloadSchemaIndicator
     ): DgsQueryExecutor {
 
@@ -80,6 +82,7 @@ open class DgsAutoConfiguration {
                 chainedInstrumentation,
                 queryExecutionStrategy,
                 mutationExecutionStrategy,
+                idProvider,
                 reloadSchemaIndicator
         )
     }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
@@ -114,7 +114,7 @@ internal class DefaultDgsQueryExecutorTest {
         """.trimIndent())
 
 
-        dgsQueryExecutor = DefaultDgsQueryExecutor(schema, provider, dgsDataLoaderProvider, DefaultDgsGraphQLContextBuilder(Optional.empty()), ChainedInstrumentation(), AsyncExecutionStrategy(), AsyncSerialExecutionStrategy())
+        dgsQueryExecutor = DefaultDgsQueryExecutor(schema, provider, dgsDataLoaderProvider, DefaultDgsGraphQLContextBuilder(Optional.empty()), ChainedInstrumentation(), AsyncExecutionStrategy(), AsyncSerialExecutionStrategy(), Optional.empty())
     }
 
     @Test


### PR DESCRIPTION
This provides support for providing a custom `graphql-java` `ExecutionIdProvider` bean to be used in the `GraphqL` instance.

We generate id's for every HTTP request and re-use this id in the GraphQL execution for tracing purposes.


On a related note, I noticed a new `GraphQL` instance seems to be created for every GraphQL request [here](https://github.com/Netflix/dgs-framework/blob/1f2d40fe6d51fced9ed4e6d8043808b0f8cf16bb/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt#L85-L91).
Probably it is done this way to support [reloading the schema](https://github.com/Netflix/dgs-framework/blob/1f2d40fe6d51fced9ed4e6d8043808b0f8cf16bb/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt#L79-L83) but I think that could be optimized by caching the `GraphQL` instance. Interested in another PR for that?