### PR TITLE
Expose jackson-annotations in api scope

### DIFF
--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 dependencies {
     api("com.jayway.jsonpath:json-path:2.4.+")
     api("io.projectreactor:reactor-core:3.4.+")
+    api("com.fasterxml.jackson.core:jackson-annotations")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework:spring-web")

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -17,6 +17,9 @@
         }
     },
     "compileClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.11.4"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.11.4"
         },
@@ -146,6 +149,9 @@
         }
     },
     "runtimeClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.11.4"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.11.4"
         },
@@ -198,6 +204,9 @@
         }
     },
     "testCompileClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.11.4"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.11.4"
         },
@@ -248,6 +257,9 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.11.4"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.11.4"
         },


### PR DESCRIPTION
## Context

Graphql-java 16.+ now supports interface inheritance. The code generated from such model exposes elements of `jackson-annotations`, see examples below. To help developers leverage both, this component and the code-gen plugin, we are adding the `jackson-annotation` artifact in the api scope so they can compile the code-gen code out of the box in such a scenario.

## Examples

GraphQL Schema:
```
interface Media {
    """ Unique Identifier of this Media."""
    id: ID
    """ Title of the Media. """
    title: String
    """ Epoch that represents when this media was released. """
    releaseYear: Int
}

interface Show implements Media {
    id: ID
    title: String
    releaseYear: Int
}
```

The Java code generated by code-gen, see `import com.fasterxml.jackson.annotation`:

```
import com.fasterxml.jackson.annotation.JsonSubTypes;
import com.fasterxml.jackson.annotation.JsonTypeInfo;
import java.lang.Integer;
import java.lang.String;

@JsonTypeInfo(
    use = JsonTypeInfo.Id.NAME,
    include = JsonTypeInfo.As.PROPERTY,
    property = "__typename"
)
@JsonSubTypes({
    @JsonSubTypes.Type(value = StandaloneShow.class, name = "StandaloneShow"),
    @JsonSubTypes.Type(value = SeriesShow.class, name = "SeriesShow")
})
public interface Media {
  String getId();

  void setId(String id);

  String getTitle();

  void setTitle(String title);

  Integer getReleaseYear();

  void setReleaseYear(Integer releaseYear);
}
```