### PR TITLE
Enable Spring Boot's Configuration Processors.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -15,7 +15,7 @@
  */
 
 object Versions {
-    const val KOTLIN_VERSON = "1.4.10"
+    const val KOTLIN_VERSION = "1.4.10"
     const val SPRING_VERSION = "5.2.12.RELEASE"
     const val SPRING_BOOT_VERSION = "2.3.8.RELEASE"
     const val SPRING_SECURITY_VERSION = "5.3.6.RELEASE"

--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-    kotlin("jvm")
-}
 
 dependencies {
     api("com.jayway.jsonpath:json-path:2.4.+")
     api("io.projectreactor:reactor-core:3.4.+")
     api("com.fasterxml.jackson.core:jackson-annotations")
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework:spring-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     testImplementation("org.springframework.boot:spring-boot-starter-web")

--- a/graphql-dgs-example-java/build.gradle.kts
+++ b/graphql-dgs-example-java/build.gradle.kts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
-
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation(project(":graphql-dgs-spring-boot-starter"))

--- a/graphql-dgs-graphiql-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-graphiql-autoconfigure/build.gradle.kts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
 dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework:spring-webmvc")

--- a/graphql-dgs-mocking/build.gradle.kts
+++ b/graphql-dgs-mocking/build.gradle.kts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
 dependencies {
     api("com.graphql-java:graphql-java:${Versions.GRAPHQL_JAVA}")
     implementation("com.github.javafaker:javafaker:1.+")

--- a/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
-
 dependencies {
     api(project(":graphql-dgs"))
     api(project(":graphql-dgs-spring-webmvc"))

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,5 @@
+{
+  "groups": [],
+  "properties": [],
+  "hints": []
+}

--- a/graphql-dgs-spring-webmvc-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-webmvc-autoconfigure/build.gradle.kts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
-
 dependencies {
     api(project(":graphql-dgs"))
     api(project(":graphql-dgs-spring-webmvc"))

--- a/graphql-dgs-spring-webmvc/build.gradle.kts
+++ b/graphql-dgs-spring-webmvc/build.gradle.kts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
-
 dependencies {
     api(project(":graphql-error-types"))
     api(project(":graphql-dgs"))

--- a/graphql-dgs-subscriptions-sse-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/build.gradle.kts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
 dependencies {
     implementation(project(":graphql-dgs"))
     implementation(project(":graphql-dgs-subscriptions-sse"))

--- a/graphql-dgs-subscriptions-sse/build.gradle.kts
+++ b/graphql-dgs-subscriptions-sse/build.gradle.kts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
-
 dependencies {
     implementation(project(":graphql-dgs"))
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/build.gradle.kts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
 dependencies {
     implementation(project(":graphql-dgs"))
     implementation(project(":graphql-dgs-subscriptions-websockets"))

--- a/graphql-dgs-subscriptions-websockets/build.gradle.kts
+++ b/graphql-dgs-subscriptions-websockets/build.gradle.kts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
-
 dependencies {
     implementation(project(":graphql-dgs"))
 

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    kotlin("jvm")
-}
-
 dependencies {
     api(project(":graphql-error-types"))
     api(project(":graphql-dgs-mocking"))


### PR DESCRIPTION
This commit enables Spring Boot's Configuration Processors via the [kapt] Gradle plugin.
This enables us to delivery, as part of our artifacts, both the `spring-autoconfigure-metadata.properties`
and the `additional-spring-configuration-metadata.json` files.

As define in the [Autoconfigure Module],
> Spring Boot uses an annotation processor to collect the conditions on auto-configurations in
> a metadata file (META-INF/spring-autoconfigure-metadata.properties). If that file is present,
> it is used to eagerly filter auto-configurations that do not match, which will improve startup time.

[kapt]: https://kotlinlang.org/docs/kapt.html
[Autoconfigure Module]: https://docs.spring.io/spring-boot/docs/2.3.x/reference/htmlsingle/#boot-features-custom-starter-module-autoconfigure