### PR TITLE
Switching back to SB 2.3.6 and Lock updates.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -17,7 +17,7 @@
 object Versions {
     const val KOTLIN_VERSION = "1.4.10"
     const val SPRING_VERSION = "5.2.12.RELEASE"
-    const val SPRING_BOOT_VERSION = "2.3.8.RELEASE"
+    const val SPRING_BOOT_VERSION = "2.3.6.RELEASE"
     const val SPRING_SECURITY_VERSION = "5.3.6.RELEASE"
     const val SPRING_CLOUD_VERSION = "Hoxton.SR9"
     const val GRAPHQL_JAVA = "16.2"

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -4,7 +4,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -20,8 +20,96 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.10"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinCompilerClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinCompilerPluginClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
+        "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
+    "kotlinKlibCommonizerClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinNativeCompilerPluginClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -38,7 +126,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -54,8 +142,11 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.10"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -72,7 +163,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -88,11 +179,11 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.10"
         },
-        "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -108,11 +199,11 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.4.10"
         },
-        "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -39,7 +45,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -54,6 +60,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -62,7 +84,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -78,11 +100,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -94,6 +119,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -102,7 +132,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -119,7 +149,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -136,7 +166,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -171,7 +201,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -191,7 +221,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -229,16 +259,16 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -282,16 +312,16 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -106,17 +112,19 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -128,6 +136,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -136,7 +160,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -152,11 +176,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -168,6 +195,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -176,7 +208,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -193,7 +225,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -210,7 +242,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -361,10 +393,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -378,7 +412,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -386,29 +420,29 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -454,7 +488,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -544,6 +578,9 @@
             ],
             "project": true
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
@@ -556,20 +593,22 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -701,6 +740,9 @@
             ],
             "project": true
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
@@ -720,10 +762,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -737,7 +781,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -745,32 +789,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-graphiql-autoconfigure/dependencies.lock
+++ b/graphql-dgs-graphiql-autoconfigure/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -24,10 +30,10 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -42,6 +48,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -50,7 +72,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -66,11 +88,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -82,6 +107,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -90,7 +120,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -107,7 +137,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -124,7 +154,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -144,10 +174,10 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -167,7 +197,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -183,17 +213,20 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -212,17 +245,20 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -33,7 +39,7 @@
             "locked": "1.7.30"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -45,6 +51,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -53,7 +75,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -69,11 +91,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -85,6 +110,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -93,7 +123,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -110,7 +140,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -127,7 +157,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -156,7 +186,7 @@
             "locked": "1.7.30"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -173,7 +203,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -195,6 +225,9 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.4.10"
         },
@@ -202,10 +235,10 @@
             "locked": "1.7.30"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -227,6 +260,9 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.4.10"
         },
@@ -234,10 +270,10 @@
             "locked": "1.7.30"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -60,15 +66,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -80,6 +87,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -88,7 +111,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -104,11 +127,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -120,6 +146,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -128,7 +159,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -145,7 +176,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -162,7 +193,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -249,7 +280,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -263,13 +295,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -299,7 +331,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -358,18 +390,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -459,7 +492,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -473,16 +507,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -95,18 +101,120 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kotlinCompilerClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinCompilerPluginClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
+        "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
+    "kotlinKlibCommonizerClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinNativeCompilerPluginClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -123,7 +231,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -247,7 +355,8 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -261,31 +370,31 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -323,7 +432,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -400,6 +509,9 @@
             ],
             "project": true
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
@@ -414,21 +526,22 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -532,6 +645,9 @@
             ],
             "project": true
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
@@ -552,7 +668,8 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -566,34 +683,34 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -60,15 +66,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -83,6 +90,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -91,7 +114,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -107,11 +130,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -123,6 +149,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -131,7 +162,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -148,7 +179,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -165,7 +196,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -252,7 +283,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -266,13 +298,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -302,7 +334,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -361,18 +393,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -465,7 +498,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -479,16 +513,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -58,12 +64,13 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -78,6 +85,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -86,7 +109,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -102,11 +125,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -118,6 +144,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -126,7 +157,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -143,7 +174,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -160,7 +191,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -235,7 +266,8 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -249,10 +281,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -281,7 +313,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -338,15 +370,16 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -427,7 +460,8 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -441,13 +475,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -56,15 +62,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -82,6 +89,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -90,7 +113,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -106,11 +129,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -122,6 +148,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -130,7 +161,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -147,7 +178,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -164,7 +195,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -244,7 +275,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -258,13 +290,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -300,7 +332,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -348,22 +380,26 @@
             ],
             "project": true
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -445,11 +481,15 @@
             ],
             "project": true
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -463,16 +503,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -55,12 +61,13 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -78,6 +85,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -86,7 +109,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -102,11 +125,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -118,6 +144,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -126,7 +157,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -143,7 +174,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -160,7 +191,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -232,7 +263,8 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -246,10 +278,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -281,7 +313,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -338,15 +370,16 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -430,7 +463,8 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -444,13 +478,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -56,15 +62,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -79,6 +86,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -87,7 +110,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -103,11 +126,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -119,6 +145,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -127,7 +158,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -144,7 +175,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -161,7 +192,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -241,7 +272,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -255,16 +287,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -300,7 +332,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -355,18 +387,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -452,7 +485,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -466,19 +500,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -55,15 +61,16 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -81,6 +88,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -89,7 +112,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -105,11 +128,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -121,6 +147,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -129,7 +160,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -146,7 +177,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -163,7 +194,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -235,7 +266,8 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -249,13 +281,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -287,7 +319,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -344,18 +376,19 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -439,7 +472,8 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -453,16 +487,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -47,15 +53,16 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -73,6 +80,22 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -81,7 +104,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -97,11 +120,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -113,6 +139,11 @@
             "locked": "5.2.12.RELEASE"
         }
     },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
@@ -121,7 +152,7 @@
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -138,7 +169,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -155,7 +186,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -204,7 +235,8 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -215,10 +247,10 @@
             "locked": "1.7.30"
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -241,7 +273,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -290,18 +322,19 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -362,7 +395,8 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.10"
         },
@@ -373,13 +407,13 @@
             "locked": "1.7.30"
         },
         "org.springframework.boot:spring-boot": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -3,8 +3,14 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -23,8 +29,112 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.10"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kapt": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kaptTest": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "2.3.6.RELEASE"
+        }
+    },
+    "kotlinCompilerClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinCompilerPluginClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        },
+        "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinKaptWorkerDependencies": {
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.4.10"
+        }
+    },
+    "kotlinKlibCommonizerClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
+            "locked": "1.4.10"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "Hoxton.SR9"
+        },
+        "org.springframework.security:spring-security-bom": {
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        }
+    },
+    "kotlinNativeCompilerPluginClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.11.4"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -41,7 +151,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -60,8 +170,11 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.10"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -78,7 +191,7 @@
             "locked": "2.11.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -97,11 +210,17 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.10"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -120,11 +239,17 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "io.mockk:mockk": {
+            "locked": "1.10.3-jdk8"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.10"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"


### PR DESCRIPTION
This commit moves us back to Spring Boot (SB) 2.3.6 and updates the locks to
reflect the change. There is no specific issues with 2.3.8, this is only
done, for now to avoid conflicts with the internal SB version.