### PR TITLE
Moving failure analyzer out of the core module 

### DIFF
--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -408,12 +408,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
@@ -455,6 +449,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -777,12 +777,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
@@ -827,6 +821,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs-graphiql-autoconfigure/dependencies.lock
+++ b/graphql-dgs-graphiql-autoconfigure/dependencies.lock
@@ -229,7 +229,7 @@
             "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -264,7 +264,7 @@
             "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -291,12 +291,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -314,6 +308,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -503,12 +503,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -529,6 +523,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/SchemaFailureAnalyzer.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/SchemaFailureAnalyzer.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig
+

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/diagnostics/SchemaFailureAnalyzer.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/diagnostics/SchemaFailureAnalyzer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.internal
+package com.netflix.graphql.dgs.diagnostics
 
 import graphql.schema.idl.errors.SchemaProblem
 import org.springframework.boot.diagnostics.AbstractFailureAnalyzer

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration
+org.springframework.boot.diagnostics.FailureAnalyzer=com.netflix.graphql.dgs.diagnostics.SchemaFailureAnalyzer

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -366,12 +366,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure"
@@ -407,6 +401,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -679,12 +679,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure"
@@ -723,6 +717,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -294,12 +294,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -317,6 +311,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -408,7 +408,7 @@
             "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -512,12 +512,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -528,7 +522,7 @@
             "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.3.8.RELEASE"
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
             "locked": "Hoxton.SR9"
@@ -541,6 +535,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -277,12 +277,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -297,6 +291,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -471,12 +471,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -494,6 +488,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -286,12 +286,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
         },
@@ -309,6 +303,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -499,12 +499,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
         },
@@ -525,6 +519,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -274,12 +274,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -294,6 +288,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -474,12 +474,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -497,6 +491,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -283,12 +283,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
@@ -309,6 +303,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -496,12 +496,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
@@ -525,6 +519,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -277,12 +277,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
         },
@@ -300,6 +294,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -483,12 +483,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
         },
@@ -509,6 +503,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     api("com.jayway.jsonpath:json-path:2.+")
 
     implementation("org.springframework:spring-web")
-    implementation("org.springframework.boot:spring-boot")
+    implementation("org.springframework:spring-context")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -58,9 +58,6 @@
             ],
             "locked": "1.4.10"
         },
-        "org.springframework.boot:spring-boot": {
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -72,6 +69,9 @@
         },
         "org.springframework.security:spring-security-core": {
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -246,9 +246,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -260,6 +257,9 @@
         },
         "org.springframework.security:spring-security-core": {
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -327,9 +327,6 @@
             ],
             "locked": "1.4.10"
         },
-        "org.springframework.boot:spring-boot": {
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -344,6 +341,9 @@
         },
         "org.springframework.security:spring-security-core": {
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"
@@ -406,9 +406,6 @@
             ],
             "locked": "1.7.30"
         },
-        "org.springframework.boot:spring-boot": {
-            "locked": "2.3.6.RELEASE"
-        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -423,6 +420,9 @@
         },
         "org.springframework.security:spring-security-core": {
             "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.12.RELEASE"

--- a/graphql-dgs/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.diagnostics.FailureAnalyzer=com.netflix.graphql.dgs.internal.SchemaFailureAnalyzer


### PR DESCRIPTION
By doing so we can drop the Spring Boot dependency from the core module, which really shouldn't be there.