### PR TITLE
Applied standard kotlin code style

### DIFF
--- a/.github/workflows/releasedraft.yml
+++ b/.github/workflows/releasedraft.yml
@@ -8,7 +8,7 @@ on:
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   update_release_draft:

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Netflix, Inc.
+# Copyright 2021 Netflix, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 systemProp.nebula.features.coreBomSupport=true
+kotlin.code.style=official

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import reactor.core.publisher.Mono
  * @sample com.netflix.graphql.dgs.client.StandaloneDgsGraphQLClientTest
  * @sample com.netflix.graphql.dgs.client.GatewayGraphQLClientTest
  */
-class DefaultGraphQLClient(private val url: String): GraphQLClient, MonoGraphQLClient {
+class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQLClient {
 
     companion object {
         private val objectMapper: ObjectMapper = try {
@@ -56,6 +56,7 @@ class DefaultGraphQLClient(private val url: String): GraphQLClient, MonoGraphQLC
         private val defaultHeaders = mapOf(
                 "Accept" to listOf("application/json"),
                 "Content-type" to listOf("application/json"))
+
         private data class Request(val query: String, val variables: Map<String, Any>)
     }
 

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package com.netflix.graphql.dgs.client
 
 import reactor.core.publisher.Mono
-import java.lang.RuntimeException
 
 interface GraphQLClient {
     fun executeQuery(query: String, variables: Map<String, Any>, requestExecutor: RequestExecutor): GraphQLResponse

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -50,8 +50,8 @@ data class GraphQLResponse(val json: String) {
     /**
      * Map representation of data
      */
-    val data: Map<String, Any> = parsed.read("data")?: emptyMap()
-    val errors : List<GraphQLError> = parsed.read("errors", object: TypeRef<List<GraphQLError>>() {})?: emptyList()
+    val data: Map<String, Any> = parsed.read("data") ?: emptyMap()
+    val errors: List<GraphQLError> = parsed.read("errors", object : TypeRef<List<GraphQLError>>() {}) ?: emptyList()
 
     private val logger = LoggerFactory.getLogger(GraphQLResponse::class.java)
 
@@ -87,7 +87,7 @@ data class GraphQLResponse(val json: String) {
 
         try {
             return parsed.read(dataPath, clazz)
-        } catch(ex: Exception) {
+        } catch (ex: Exception) {
             logger.error("Error extracting path '${path}' from data: '${data}'")
             throw ex
         }
@@ -102,7 +102,7 @@ data class GraphQLResponse(val json: String) {
 
         try {
             return parsed.read(dataPath, typeRef)
-        } catch(ex: Exception) {
+        } catch (ex: Exception) {
             logger.error("Error extracting path '${path}' from data: '${data}'")
             throw ex
         }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseSubProjectionNode.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseSubProjectionNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
-abstract class BaseSubProjectionNode<T,R>(val parent: T, val root: R): BaseProjectionNode() {
+abstract class BaseSubProjectionNode<T, R>(val parent: T, val root: R) : BaseProjectionNode() {
 
     fun parent(): T {
         return parent

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,6 @@ package com.netflix.graphql.dgs.client.codegen
 import java.util.stream.Collectors
 
 
-
-
-
 class GraphQLQueryRequest(private val query: GraphQLQuery, private val projection: BaseProjectionNode?) {
 
     constructor(query: GraphQLQuery) : this(query, null)
@@ -39,12 +36,12 @@ class GraphQLQueryRequest(private val query: GraphQLQuery, private val projectio
                 if (inputEntry.value != null) {
                     builder.append(inputEntry.key)
                     builder.append(": ")
-                    if(inputEntry.value is String) {
+                    if (inputEntry.value is String) {
                         builder.append("\"")
                         builder.append(inputEntry.value.toString())
                         builder.append("\"")
                     } else if (inputEntry.value is List<*>) {
-                        val listValues =  inputEntry.value as List<*>
+                        val listValues = inputEntry.value as List<*>
                         if (listValues.isNotEmpty() && listValues[0] is String) {
                             builder.append("[")
                             val elements = inputEntry.value as List<String>

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/exceptions/NoDataPresentException.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/exceptions/NoDataPresentException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,4 @@
 
 package com.netflix.graphql.dgs.client.exceptions
 
-import java.lang.RuntimeException
-
-class NoDataPresentException: RuntimeException("No data available in response")
+class NoDataPresentException : RuntimeException("No data available in response")

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ErrorsTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ErrorsTest.kt
@@ -165,9 +165,9 @@ class ErrorsTest {
         """.trimIndent()
 
         server.expect(requestTo(url))
-            .andExpect(method(HttpMethod.POST))
-            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON))
 
         val graphQLResponse = client.executeQuery("""{ hello }""", emptyMap(), requestExecutor)
         assertThat(graphQLResponse.errors[0].extensions).isNull()

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.jayway.jsonpath.TypeRef
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
@@ -24,9 +23,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.test.web.client.MockRestServiceServer
-import org.springframework.test.web.client.match.MockRestRequestMatchers.content
-import org.springframework.test.web.client.match.MockRestRequestMatchers.method
-import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.match.MockRestRequestMatchers.*
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 import org.springframework.web.client.RestTemplate
 import java.time.OffsetDateTime

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ReactiveWebClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ReactiveWebClientTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,18 +28,18 @@ class ReactiveWebClientTest {
 
     private val requestExecutor = MonoRequestExecutor { url, headers, body ->
         WebClient.builder()
-            .exchangeFunction {
-                Mono.just(ClientResponse.create(HttpStatus.OK)
-                    .header("content-type", "application/json")
-                    .body("""{ "data": { "hello": "Hi!"}}""")
-                    .build())
-            }.build()
-            .post()
-            .uri(url)
-            .headers { consumer -> headers.forEach { consumer.addAll(it.key, it.value) } }
-            .bodyValue(body)
-            .exchange()
-            .flatMap { cr -> cr.bodyToMono(String::class.java).map { json -> HttpResponse(cr.rawStatusCode(), json) } }
+                .exchangeFunction {
+                    Mono.just(ClientResponse.create(HttpStatus.OK)
+                            .header("content-type", "application/json")
+                            .body("""{ "data": { "hello": "Hi!"}}""")
+                            .build())
+                }.build()
+                .post()
+                .uri(url)
+                .headers { consumer -> headers.forEach { consumer.addAll(it.key, it.value) } }
+                .bodyValue(body)
+                .exchange()
+                .flatMap { cr -> cr.bodyToMono(String::class.java).map { json -> HttpResponse(cr.rawStatusCode(), json) } }
     }
 
     @Test

--- a/graphql-dgs-mocking/src/main/kotlin/com/netflix/graphql/mocking/DgsSchemaTransformer.kt
+++ b/graphql-dgs-mocking/src/main/kotlin/com/netflix/graphql/mocking/DgsSchemaTransformer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package com.netflix.graphql.mocking
 
 import graphql.schema.*
-import java.util.HashMap
+import java.util.*
 
 class DgsSchemaTransformer {
 

--- a/graphql-dgs-mocking/src/main/kotlin/com/netflix/graphql/mocking/MockGraphQLVisitor.kt
+++ b/graphql-dgs-mocking/src/main/kotlin/com/netflix/graphql/mocking/MockGraphQLVisitor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,31 +25,31 @@ import org.slf4j.LoggerFactory
 
 class MockGraphQLVisitor(private val mockConfig: Map<String, Any?>, private val mockFetchers: MutableMap<FieldCoordinates, DataFetcher<*>>) : GraphQLTypeVisitorStub() {
     private val logger: Logger = LoggerFactory.getLogger(this.javaClass)
-    private val providedRoots : MutableList<String?> = mutableListOf()
+    private val providedRoots: MutableList<String?> = mutableListOf()
 
     override fun visitGraphQLFieldDefinition(node: GraphQLFieldDefinition?, context: TraverserContext<GraphQLSchemaElement>?): TraversalControl {
         val pathForNode = getPathForNode(context?.parentNodes, node)
 
-        if(mockConfig.keys.any { pathForNode?.startsWith(it) == true } && !providedRoots.any { pathForNode?.startsWith(it!!) == true && pathForNode.count { c -> c == '.' }  != it?.count { c -> c == '.'} } ) {
-            val type = if(node?.type is GraphQLNonNull) (node.type as GraphQLNonNull).wrappedType else node?.type
+        if (mockConfig.keys.any { pathForNode?.startsWith(it) == true } && !providedRoots.any { pathForNode?.startsWith(it!!) == true && pathForNode.count { c -> c == '.' } != it?.count { c -> c == '.' } }) {
+            val type = if (node?.type is GraphQLNonNull) (node.type as GraphQLNonNull).wrappedType else node?.type
 
-            val dataFetcher : DataFetcher<*> = if(mockConfig[pathForNode] != null) {
+            val dataFetcher: DataFetcher<*> = if (mockConfig[pathForNode] != null) {
                 logger.info("Returning provided mock data for {}", pathForNode)
                 providedRoots.add(pathForNode)
                 getProvidedMockData(pathForNode)
             } else {
                 logger.info("Generating mock data for {}", pathForNode)
-                when(type) {
+                when (type) {
                     is GraphQLScalarType -> {
                         DataFetcher { generateDataForScalar(type.name) }
                     }
                     is GraphQLList -> {
-                        val wrappedType = when(type.wrappedType) {
+                        val wrappedType = when (type.wrappedType) {
                             is GraphQLNamedType -> (type.wrappedType as GraphQLNamedType).name
                             else -> return super.visitGraphQLFieldDefinition(node, context)
                         }
 
-                        val mockedValues = (0..Faker().number().numberBetween(0,10))
+                        val mockedValues = (0..Faker().number().numberBetween(0, 10))
                                 .map { generateDataForScalar(wrappedType) }
                                 .toList()
                         DataFetcher { mockedValues }
@@ -66,13 +66,12 @@ class MockGraphQLVisitor(private val mockConfig: Map<String, Any?>, private val 
     }
 
 
-
     private fun generateDataForScalar(type: String): Any {
-        return when(type) {
+        return when (type) {
             "String" -> Faker().book().title()
             "Boolean" -> Faker().bool().bool()
             "Int" -> Faker().number().randomDigit()
-            "Float" ->  Faker().number().randomDouble(2, 0, 100000)
+            "Float" -> Faker().number().randomDouble(2, 0, 100000)
             "ID" -> Faker().number().digit()
             else -> Object()
         }
@@ -80,13 +79,13 @@ class MockGraphQLVisitor(private val mockConfig: Map<String, Any?>, private val 
 
     private fun getProvidedMockData(pathForNode: String?): DataFetcher<*> {
 
-        return when(val provided = mockConfig[pathForNode]) {
+        return when (val provided = mockConfig[pathForNode]) {
             is DataFetcher<*> -> provided
             else -> DataFetcher { provided }
         }
     }
 
-    private val getPathForNode = {parents: List<GraphQLSchemaElement>?, node: GraphQLFieldDefinition? -> parents?.filterIsInstance<GraphQLFieldDefinition>()?.map {it.name}?.fold(node?.name) { n, result -> "$result.$n" }}
+    private val getPathForNode = { parents: List<GraphQLSchemaElement>?, node: GraphQLFieldDefinition? -> parents?.filterIsInstance<GraphQLFieldDefinition>()?.map { it.name }?.fold(node?.name) { n, result -> "$result.$n" } }
 
 
 }

--- a/graphql-dgs-mocking/src/test/kotlin/com/netflix/graphql/mocking/MockGraphQLVisitorTest.kt
+++ b/graphql-dgs-mocking/src/test/kotlin/com/netflix/graphql/mocking/MockGraphQLVisitorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,10 @@ import com.netflix.graphql.mocking.testobjects.MyObject
 import com.netflix.graphql.mocking.testobjects.SomeObject
 import graphql.ExecutionInput
 import graphql.GraphQL
-import graphql.schema.*
+import graphql.schema.DataFetcher
+import graphql.schema.FieldCoordinates
+import graphql.schema.GraphQLCodeRegistry
+import graphql.schema.GraphQLSchema
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.SchemaGenerator
 import graphql.schema.idl.SchemaParser
@@ -174,8 +177,8 @@ internal class MockGraphQLVisitorTest {
 
         val someObject = data["someObject"] as Map<*, *>
 
-        when(val value = someObject["someKey"]!!) {
-            is List<*> -> value.forEach { Assertions.assertTrue(it is String)}
+        when (val value = someObject["someKey"]!!) {
+            is List<*> -> value.forEach { Assertions.assertTrue(it is String) }
             else -> Assertions.fail("Returned mock is not a List")
         }
     }
@@ -202,7 +205,7 @@ internal class MockGraphQLVisitorTest {
         val data = execute(schema, "query { someObject {someKey { name} } }", mockConfig)
 
         val someObject = data["someObject"] as Map<*, *>
-        val someKey = someObject["someKey"] as Map<*,*>
+        val someKey = someObject["someKey"] as Map<*, *>
         Assertions.assertNotNull(someKey)
         Assertions.assertTrue(someKey["name"] is String)
     }
@@ -230,7 +233,7 @@ internal class MockGraphQLVisitorTest {
 
         val someObject = data["someObject"] as Map<*, *>
         val myObjectArr = someObject["someKey"] as List<*>
-        Assertions.assertTrue(((myObjectArr[0] as Map<*,*>)["name"] as String).isNotBlank())
+        Assertions.assertTrue(((myObjectArr[0] as Map<*, *>)["name"] as String).isNotBlank())
 
     }
 
@@ -279,7 +282,7 @@ internal class MockGraphQLVisitorTest {
         val someKeyList = someObject["someKey"] as List<*>
         Assertions.assertNotNull(someKeyList)
         Assertions.assertEquals(1, someKeyList.size)
-        Assertions.assertEquals("mymockedvalue", (someKeyList[0] as Map<*,*>)["name"])
+        Assertions.assertEquals("mymockedvalue", (someKeyList[0] as Map<*, *>)["name"])
     }
 
     @Test
@@ -324,7 +327,7 @@ internal class MockGraphQLVisitorTest {
         Assertions.assertEquals(listOf("listNameMock"), names)
     }
 
-  private fun execute(schema: GraphQLSchema, query: String, mockConfig: Map<String, Any?>): Map<String, *> {
+    private fun execute(schema: GraphQLSchema, query: String, mockConfig: Map<String, Any?>): Map<String, *> {
         val transform = DgsSchemaTransformer().transformSchema(schema, mockConfig)
 
         val graphQL = GraphQL.newGraphQL(transform)
@@ -337,7 +340,7 @@ internal class MockGraphQLVisitorTest {
         return executionResult.getData()
     }
 
-    private fun createSchema(schema : String): GraphQLSchema {
+    private fun createSchema(schema: String): GraphQLSchema {
         val schemaParser = SchemaParser()
         val typeDefinitionRegistry = schemaParser.parse(schema.trimIndent())
 

--- a/graphql-dgs-mocking/src/test/kotlin/com/netflix/graphql/mocking/testobjects/MyObject.kt
+++ b/graphql-dgs-mocking/src/test/kotlin/com/netflix/graphql/mocking/testobjects/MyObject.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.mocking.testobjects
 
-class MyObject(val name : String = "test")
+class MyObject(val name: String = "test")

--- a/graphql-dgs-mocking/src/test/kotlin/com/netflix/graphql/mocking/testobjects/SomeObject.kt
+++ b/graphql-dgs-mocking/src/test/kotlin/com/netflix/graphql/mocking/testobjects/SomeObject.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.mocking.testobjects
 
-class SomeObject(var someKey : List<MyObject> = listOf())
+class SomeObject(var someKey: List<MyObject> = listOf())

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsData.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsData.java
@@ -31,5 +31,6 @@ import java.lang.annotation.*;
 @Inherited
 public @interface DgsData {
     String parentType();
+
     String field();
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
@@ -33,8 +33,11 @@ import java.lang.annotation.Target;
 @Component
 public @interface DgsDataLoader {
     String name();
+
     boolean caching() default true;
+
     boolean batching() default true;
+
     int maxBatchSize() default 0;
 }
 

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/InputArgument.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/InputArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,5 +25,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface InputArgument {
     String value();
+
     Class<?> collectionType() default Object.class;
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DataLoaderInstrumentationExtensionProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DataLoaderInstrumentationExtensionProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import org.dataloader.MappedBatchLoader
 import org.dataloader.MappedBatchLoaderWithContext
 
 interface DataLoaderInstrumentationExtensionProvider {
-    fun provide(original: BatchLoader<*, *>, name: String) : BatchLoader<*, *>
-    fun provide(original: BatchLoaderWithContext<*, *>, name: String) : BatchLoaderWithContext<*, *>
-    fun provide(original: MappedBatchLoader<*, *>, name: String) : MappedBatchLoader<*, *>
-    fun provide(original: MappedBatchLoaderWithContext<*, *>, name: String) : MappedBatchLoaderWithContext<*, *>
+    fun provide(original: BatchLoader<*, *>, name: String): BatchLoader<*, *>
+    fun provide(original: BatchLoaderWithContext<*, *>, name: String): BatchLoaderWithContext<*, *>
+    fun provide(original: MappedBatchLoader<*, *>, name: String): MappedBatchLoader<*, *>
+    fun provide(original: MappedBatchLoaderWithContext<*, *>, name: String): MappedBatchLoaderWithContext<*, *>
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.dataloader.DataLoader
 import org.dataloader.DataLoaderRegistry
 import java.util.*
 
-class DgsDataFetchingEnvironment(private val dfe :DataFetchingEnvironment) : DataFetchingEnvironment {
+class DgsDataFetchingEnvironment(private val dfe: DataFetchingEnvironment) : DataFetchingEnvironment {
 
     fun <K, V> getDataLoader(loaderClass: Class<*>): DataLoader<K, V> {
         val annotation = loaderClass.getAnnotation(DgsDataLoader::class.java)
@@ -77,7 +77,7 @@ class DgsDataFetchingEnvironment(private val dfe :DataFetchingEnvironment) : Dat
     }
 
     override fun <T : Any?> getRoot(): T {
-       return dfe.getRoot()
+        return dfe.getRoot()
     }
 
     override fun getFieldDefinition(): GraphQLFieldDefinition {
@@ -91,7 +91,7 @@ class DgsDataFetchingEnvironment(private val dfe :DataFetchingEnvironment) : Dat
     }
 
     override fun getMergedField(): MergedField {
-       return dfe.mergedField
+        return dfe.mergedField
     }
 
     override fun getField(): Field {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsFederationResolver.kt
@@ -26,5 +26,5 @@ import graphql.schema.TypeResolver
  */
 interface DgsFederationResolver {
     fun entitiesFetcher(): DataFetcher<Any?>
-    fun typeResolver() : TypeResolver
+    fun typeResolver(): TypeResolver
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
@@ -38,10 +38,11 @@ interface DgsQueryExecutor {
 
     fun execute(query: String, variables: Map<String, Any>, extensions: Map<String, Any>?, headers: HttpHeaders): ExecutionResult =
             execute(query = query, variables = variables, extensions = extensions, headers = headers, operationName = null)
+
     fun execute(query: String, variables: Map<String, Any>, extensions: Map<String, Any>?, headers: HttpHeaders, operationName: String? = null): ExecutionResult
 
-    fun <T> executeAndExtractJsonPath(query: String, jsonPath: String):T
-    fun <T> executeAndExtractJsonPath(query: String, jsonPath: String, variables: Map<String, Any>):T
+    fun <T> executeAndExtractJsonPath(query: String, jsonPath: String): T
+    fun <T> executeAndExtractJsonPath(query: String, jsonPath: String, variables: Map<String, Any>): T
 
     fun executeAndGetDocumentContext(query: String): DocumentContext
     fun executeAndGetDocumentContext(query: String, variables: Map<String, Any>): DocumentContext

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
@@ -30,9 +30,9 @@ open class DgsContext(val customContext: Any?) {
 
     companion object {
         @JvmStatic
-        fun <T> getCustomContext(dgsContext: Any) : T {
+        fun <T> getCustomContext(dgsContext: Any): T {
             @Suppress("UNCHECKED_CAST")
-            return when(dgsContext) {
+            return when (dgsContext) {
                 is DgsContext -> dgsContext.customContext as T
                 else -> throw RuntimeException("The context object passed to getCustomContext is not a DgsContext. It is a ${dgsContext::class.java.name} instead.")
             }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,17 +38,19 @@ class DefaultDataFetcherExceptionHandler : DataFetcherExceptionHandler {
         val springSecurityAvailable = try {
             Class.forName("org.springframework.security.access.AccessDeniedException")
             true
-        } catch (ex: ClassNotFoundException) { false }
+        } catch (ex: ClassNotFoundException) {
+            false
+        }
 
-        val graphqlError = if(springSecurityAvailable && exception is org.springframework.security.access.AccessDeniedException) {
+        val graphqlError = if (springSecurityAvailable && exception is org.springframework.security.access.AccessDeniedException) {
             TypedGraphQLError.PERMISSION_DENIED.message("%s: %s", exception::class.java.name, exception.message)
                     .path(handlerParameters.path).build()
-        } else if(exception is DgsEntityNotFoundException) {
+        } else if (exception is DgsEntityNotFoundException) {
             TypedGraphQLError.NOT_FOUND.message("%s: %s", exception::class.java.name, exception.message)
                     .path(handlerParameters.path).build()
-        } else if(exception is DgsBadRequestException) {
+        } else if (exception is DgsBadRequestException) {
             TypedGraphQLError.BAD_REQUEST.message("%s: %s", exception::class.java.name, exception.message)
-                .path(handlerParameters.path).build()
+                    .path(handlerParameters.path).build()
         } else {
             TypedGraphQLError.INTERNAL.message("%s: %s", exception::class.java.name, exception.message)
                     .path(handlerParameters.path).build()

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsBadRequestException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsBadRequestException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class DgsBadRequestException(override val message: String = "Malformed or incorrect request"): RuntimeException(message)
+class DgsBadRequestException(override val message: String = "Malformed or incorrect request") : RuntimeException(message)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsEntityNotFoundException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsEntityNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class DgsEntityNotFoundException(override val message: String = "Requested entity not found"): RuntimeException(message)
+class DgsEntityNotFoundException(override val message: String = "Requested entity not found") : RuntimeException(message)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsInvalidInputArgumentException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsInvalidInputArgumentException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-import java.lang.Exception
-
-class DgsInvalidInputArgumentException(override val message: String, override val cause: Exception? = null):RuntimeException(message, cause)
+class DgsInvalidInputArgumentException(override val message: String, override val cause: Exception? = null) : RuntimeException(message, cause)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsQueryExecutionDataExtractionException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsQueryExecutionDataExtractionException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.netflix.graphql.dgs.exceptions
 
 import com.jayway.jsonpath.TypeRef
 import com.jayway.jsonpath.spi.mapper.MappingException
-import java.lang.RuntimeException
 
 data class DgsQueryExecutionDataExtractionException(val ex: Exception, val jsonResult: String, val jsonPath: String, val targetClass: String) : RuntimeException(String.format("Error deserializing data from '%s' with JsonPath '%s' and target class %s", jsonResult, jsonPath, targetClass), ex) {
     constructor(ex: MappingException, jsonResult: String, jsonPath: String, targetClass: TypeRef<*>) : this(ex, jsonResult, jsonPath, targetClass.type.typeName)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidDataLoaderTypeException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidDataLoaderTypeException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class InvalidDataLoaderTypeException(clazz: Class<*>): RuntimeException("@DgsDataLoader found that doesn't implement BatchLoader: ${clazz.name}.")
+class InvalidDataLoaderTypeException(clazz: Class<*>) : RuntimeException("@DgsDataLoader found that doesn't implement BatchLoader: ${clazz.name}.")

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidDgsConfigurationException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidDgsConfigurationException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,5 @@
  */
 
 package com.netflix.graphql.dgs.exceptions
-
-import java.lang.RuntimeException
 
 class InvalidDgsConfigurationException(message: String) : RuntimeException(message)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidDgsEntityFetcher.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidDgsEntityFetcher.kt
@@ -16,5 +16,5 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class InvalidDgsEntityFetcher(message: String): RuntimeException(message) {
+class InvalidDgsEntityFetcher(message: String) : RuntimeException(message) {
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidTypeResolverException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/InvalidTypeResolverException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-import java.lang.RuntimeException
-
-class InvalidTypeResolverException(msg: String): RuntimeException(msg)
+class InvalidTypeResolverException(msg: String) : RuntimeException(msg)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/MissingDgsEntityFetcherException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/MissingDgsEntityFetcherException.kt
@@ -16,5 +16,5 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class MissingDgsEntityFetcherException(type: String): RuntimeException("Missing @DgsEntityFetcher for type $type") {
+class MissingDgsEntityFetcherException(type: String) : RuntimeException("Missing @DgsEntityFetcher for type $type") {
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/MultipleDataLoadersDefinedException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/MultipleDataLoadersDefinedException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class MultipleDataLoadersDefinedException(clazz: Class<*>): RuntimeException("Multiple data loaders found, unable to disambiguate for ${clazz.name}.")
+class MultipleDataLoadersDefinedException(clazz: Class<*>) : RuntimeException("Multiple data loaders found, unable to disambiguate for ${clazz.name}.")

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/NoDataLoaderFoundException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/NoDataLoaderFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class NoDataLoaderFoundException(clazz: Class<*>): RuntimeException("No data loader found. Missing @DgsDataLoader for ${clazz.name}.")
+class NoDataLoaderFoundException(clazz: Class<*>) : RuntimeException("No data loader found. Missing @DgsDataLoader for ${clazz.name}.")

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/NoDgsFederationResolverFoundException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/NoDgsFederationResolverFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,5 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-import java.lang.RuntimeException
-
-class NoDgsFederationResolverFoundException: RuntimeException("@key directive was used in schema, but could not find DgsComponent implementing DgsFederationResolver.")
+class NoDgsFederationResolverFoundException : RuntimeException("@key directive was used in schema, but could not find DgsComponent implementing DgsFederationResolver.")
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/NoSchemaFoundException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/NoSchemaFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-import java.lang.RuntimeException
-
-class NoSchemaFoundException: RuntimeException("No schema files found. Define schemas in src/main/resources/schema/*.graphqls")
+class NoSchemaFoundException : RuntimeException("No schema files found. Define schemas in src/main/resources/schema/*.graphqls")

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/QueryException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/QueryException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,5 @@
 package com.netflix.graphql.dgs.exceptions
 
 import graphql.GraphQLError
-import java.lang.RuntimeException
 
-class QueryException(val errors: List<GraphQLError>): RuntimeException(errors.joinToString(separator = ", ") { it.message })
+class QueryException(val errors: List<GraphQLError>) : RuntimeException(errors.joinToString(separator = ", ") { it.message })

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/UnsupportedSecuredDataLoaderException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/UnsupportedSecuredDataLoaderException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class UnsupportedSecuredDataLoaderException(clazz: Class<*>): RuntimeException("Field level @DgsDataLoader is not supported on classes that use @Secured. Move your @DgsDataLoader to its own class. The offending field is in: ${clazz.name}")
+class UnsupportedSecuredDataLoaderException(clazz: Class<*>) : RuntimeException("Field level @DgsDataLoader is not supported on classes that use @Secured. Move your @DgsDataLoader to its own class. The offending field is in: ${clazz.name}")

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -35,14 +35,14 @@ import java.util.stream.Stream
 
 @DgsComponent
 open class DefaultDgsFederationResolver() :
-    DgsFederationResolver {
+        DgsFederationResolver {
 
     /**
      * This constructor is used by DgsSchemaProvider when no custom DgsFederationResolver is provided.
      * This is the most common use case.
      * The default constructor is used to extend the DefaultDgsFederationResolver. In that case injection is used to provide the schemaProvider.
      */
-    constructor(providedDgsSchemaProvider: DgsSchemaProvider): this() {
+    constructor(providedDgsSchemaProvider: DgsSchemaProvider) : this() {
         dgsSchemaProvider = providedDgsSchemaProvider
     }
 
@@ -64,39 +64,39 @@ open class DefaultDgsFederationResolver() :
 
     private fun dgsEntityFetchers(env: DataFetchingEnvironment): CompletableFuture<List<Any?>> {
         val resultList = env.getArgument<List<Map<String, Any>>>(_Entity.argumentName)
-            .stream()
-            .map { values ->
-                val typename = values["__typename"] ?: throw RuntimeException("__typename missing from arguments in federated query")
-                val fetcher = dgsSchemaProvider.entityFetchers[typename]
-                    ?: throw MissingDgsEntityFetcherException(typename.toString())
+                .stream()
+                .map { values ->
+                    val typename = values["__typename"] ?: throw RuntimeException("__typename missing from arguments in federated query")
+                    val fetcher = dgsSchemaProvider.entityFetchers[typename]
+                            ?: throw MissingDgsEntityFetcherException(typename.toString())
 
-                if(!fetcher.second.parameterTypes.any { it.isAssignableFrom(Map::class.java)}) {
-                    throw InvalidDgsEntityFetcher("@DgsEntityFetcher ${fetcher.first::class.java.name}.${fetcher.second.name} is invalid. A DgsEntityFetcher must accept an argument of type Map<String, Object>")
-                }
-
-                val result =
-                    if (fetcher.second.parameterTypes.any { it.isAssignableFrom(DgsDataFetchingEnvironment::class.java)}) {
-                        fetcher.second.invoke(fetcher.first, values, DgsDataFetchingEnvironment(env))
-                    } else {
-                        fetcher.second.invoke(fetcher.first, values)
+                    if (!fetcher.second.parameterTypes.any { it.isAssignableFrom(Map::class.java) }) {
+                        throw InvalidDgsEntityFetcher("@DgsEntityFetcher ${fetcher.first::class.java.name}.${fetcher.second.name} is invalid. A DgsEntityFetcher must accept an argument of type Map<String, Object>")
                     }
 
-                if(result == null) {
-                    throw MissingDgsEntityFetcherException(typename.toString())
-                }
+                    val result =
+                            if (fetcher.second.parameterTypes.any { it.isAssignableFrom(DgsDataFetchingEnvironment::class.java) }) {
+                                fetcher.second.invoke(fetcher.first, values, DgsDataFetchingEnvironment(env))
+                            } else {
+                                fetcher.second.invoke(fetcher.first, values)
+                            }
 
-                if (result is CompletableFuture<*>) {
-                    result
-                } else {
-                    CompletableFuture.completedFuture(result)
-                }
-            }.collect(Collectors.toList())
+                    if (result == null) {
+                        throw MissingDgsEntityFetcherException(typename.toString())
+                    }
+
+                    if (result is CompletableFuture<*>) {
+                        result
+                    } else {
+                        CompletableFuture.completedFuture(result)
+                    }
+                }.collect(Collectors.toList())
 
         return CompletableFuture.allOf(*resultList.toTypedArray()).thenApply {
             resultList.stream()
-                .map { cf -> cf.join() }
-                .flatMap { r -> if (r is Collection<*>) r.stream() else Stream.of(r) }
-                .collect(Collectors.toList())
+                    .map { cf -> cf.join() }
+                    .flatMap { r -> if (r is Collection<*>) r.stream() else Stream.of(r) }
+                    .collect(Collectors.toList())
         }
     }
 
@@ -109,12 +109,12 @@ open class DefaultDgsFederationResolver() :
             val src: Any = env.getObject()
 
             val typeName =
-                if (typeMapping().containsKey(src::class.java)) typeMapping()[src::class.java] else src::class.java.simpleName
+                    if (typeMapping().containsKey(src::class.java)) typeMapping()[src::class.java] else src::class.java.simpleName
             val type = env.schema.getObjectType(typeName)
             if (type == null) {
                 logger.warn(
-                    "No type definition found for {}. You probably need to provide either a type mapping, or override DefaultDgsFederationResolver.typeResolver(). Alternatively make sure the type name in the schema and your Java model match",
-                    src::class.java.name
+                        "No type definition found for {}. You probably need to provide either a type mapping, or override DefaultDgsFederationResolver.typeResolver(). Alternatively make sure the type name in the schema and your Java model match",
+                        src::class.java.name
                 )
             }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ open class DefaultDgsGraphQLContextBuilder(private val dgsCustomContextBuilder: 
     var headers: HttpHeaders? = null
 
     override fun build(): DgsContext {
-        return TimeTracer.logTime({buildDgsContext()}, logger, "Created DGS context in {}ms")
+        return TimeTracer.logTime({ buildDgsContext() }, logger, "Created DGS context in {}ms")
     }
 
     private fun buildDgsContext(): DgsContext {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -38,7 +38,7 @@ import graphql.schema.GraphQLSchema
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
-import java.util.Optional
+import java.util.*
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -52,7 +52,7 @@ class DefaultDgsQueryExecutor(defaultSchema: GraphQLSchema,
                               private val queryExecutionStrategy: ExecutionStrategy,
                               private val mutationExecutionStrategy: ExecutionStrategy,
                               private val idProvider: Optional<ExecutionIdProvider>,
-                              private val reloadIndicator: ReloadSchemaIndicator = ReloadSchemaIndicator{ false }
+                              private val reloadIndicator: ReloadSchemaIndicator = ReloadSchemaIndicator { false }
 ) : DgsQueryExecutor {
 
     private val parseContext: ParseContext =
@@ -80,17 +80,17 @@ class DefaultDgsQueryExecutor(defaultSchema: GraphQLSchema,
 
     override fun execute(query: String, variables: Map<String, Any>, operationName: String?): ExecutionResult {
         val graphQLSchema: GraphQLSchema =
-                if(reloadIndicator.reloadSchema())
-                    schema.updateAndGet{ schemaProvider.schema() }
+                if (reloadIndicator.reloadSchema())
+                    schema.updateAndGet { schemaProvider.schema() }
                 else
                     schema.get()
 
         val graphQLBuilder =
-            GraphQL.newGraphQL(graphQLSchema)
-                .instrumentation(chainedInstrumentation)
-                .queryExecutionStrategy(queryExecutionStrategy)
-                .mutationExecutionStrategy(mutationExecutionStrategy)
-                .subscriptionExecutionStrategy(SubscriptionExecutionStrategy())
+                GraphQL.newGraphQL(graphQLSchema)
+                        .instrumentation(chainedInstrumentation)
+                        .queryExecutionStrategy(queryExecutionStrategy)
+                        .mutationExecutionStrategy(mutationExecutionStrategy)
+                        .subscriptionExecutionStrategy(SubscriptionExecutionStrategy())
         if (idProvider.isPresent) {
             graphQLBuilder.executionIdProvider(idProvider.get())
         }
@@ -115,9 +115,9 @@ class DefaultDgsQueryExecutor(defaultSchema: GraphQLSchema,
         }
 
         //Check for NonNullableFieldWasNull errors, and log them explicitly because they don't run through the exception handlers.
-        if(executionResult.errors.size > 0) {
+        if (executionResult.errors.size > 0) {
             val nullValueError = executionResult.errors.find { it is NonNullableFieldWasNullError }
-            if(nullValueError != null) {
+            if (nullValueError != null) {
                 logger.error(nullValueError.message)
             }
         }
@@ -133,7 +133,7 @@ class DefaultDgsQueryExecutor(defaultSchema: GraphQLSchema,
         return JsonPath.read(getJsonResult(query, variables), jsonPath)
     }
 
-    override fun <T> executeAndExtractJsonPathAsObject(query: String, jsonPath: String, clazz: Class<T> ): T {
+    override fun <T> executeAndExtractJsonPathAsObject(query: String, jsonPath: String, clazz: Class<T>): T {
         val jsonResult = getJsonResult(query, emptyMap())
         return try {
             parseContext.parse(jsonResult).read(jsonPath, clazz)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,10 +36,10 @@ import javax.annotation.PostConstruct
 class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) {
     val logger: Logger = LoggerFactory.getLogger(DgsDataLoaderProvider::class.java)
 
-    private val batchLoaders = mutableListOf<Pair<BatchLoader<*,*>, DgsDataLoader>>()
-    private val batchLoadersWithContext = mutableListOf<Pair<BatchLoaderWithContext<*,*>, DgsDataLoader>>()
-    private val mappedBatchLoaders = mutableListOf<Pair<MappedBatchLoader<*,*>, DgsDataLoader>>()
-    private val mappedBatchLoadersWithContext = mutableListOf<Pair<MappedBatchLoaderWithContext<*,*>, DgsDataLoader>>()
+    private val batchLoaders = mutableListOf<Pair<BatchLoader<*, *>, DgsDataLoader>>()
+    private val batchLoadersWithContext = mutableListOf<Pair<BatchLoaderWithContext<*, *>, DgsDataLoader>>()
+    private val mappedBatchLoaders = mutableListOf<Pair<MappedBatchLoader<*, *>, DgsDataLoader>>()
+    private val mappedBatchLoadersWithContext = mutableListOf<Pair<MappedBatchLoaderWithContext<*, *>, DgsDataLoader>>()
 
     fun buildRegistry(): DataLoaderRegistry {
         return buildRegistryWithContextSupplier({ null })
@@ -50,9 +50,9 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
 
         val dataLoaderRegistry = DataLoaderRegistry()
         batchLoaders.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second)) }
-        mappedBatchLoaders.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second))}
+        mappedBatchLoaders.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second)) }
         batchLoadersWithContext.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second, contextSupplier)) }
-        mappedBatchLoadersWithContext.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second, contextSupplier))}
+        mappedBatchLoadersWithContext.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second, contextSupplier)) }
 
         val endTime = System.currentTimeMillis()
         val totalTime = endTime - startTime
@@ -77,11 +77,11 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
 
                 val annotation = field.getAnnotation(DgsDataLoader::class.java)
                 field.isAccessible = true
-                when(val get = field.get(dgsComponent)) {
+                when (val get = field.get(dgsComponent)) {
                     is BatchLoader<*, *> -> batchLoaders.add(Pair(get, annotation))
-                    is BatchLoaderWithContext<*,*> -> batchLoadersWithContext.add(Pair(get, annotation))
+                    is BatchLoaderWithContext<*, *> -> batchLoadersWithContext.add(Pair(get, annotation))
                     is MappedBatchLoader<*, *> -> mappedBatchLoaders.add(Pair(get, annotation))
-                    is MappedBatchLoaderWithContext<*,*> -> mappedBatchLoadersWithContext.add(Pair(get, annotation))
+                    is MappedBatchLoaderWithContext<*, *> -> mappedBatchLoadersWithContext.add(Pair(get, annotation))
                     else -> throw InvalidDataLoaderTypeException(dgsComponent::class.java)
                 }
             }
@@ -94,10 +94,10 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
             val javaClass = DgsComponentUtils.getClassEnhancedBySpringCGLib(dgsComponent)
             val annotation = javaClass.getAnnotation(DgsDataLoader::class.java)
             when (dgsComponent) {
-                is BatchLoader<*,*> -> batchLoaders.add(Pair(dgsComponent, annotation))
-                is BatchLoaderWithContext<*,*> -> batchLoadersWithContext.add(Pair(dgsComponent, annotation))
-                is MappedBatchLoader<*,*> -> mappedBatchLoaders.add(Pair(dgsComponent, annotation))
-                is MappedBatchLoaderWithContext<*,*> -> mappedBatchLoadersWithContext.add(Pair(dgsComponent, annotation))
+                is BatchLoader<*, *> -> batchLoaders.add(Pair(dgsComponent, annotation))
+                is BatchLoaderWithContext<*, *> -> batchLoadersWithContext.add(Pair(dgsComponent, annotation))
+                is MappedBatchLoader<*, *> -> mappedBatchLoaders.add(Pair(dgsComponent, annotation))
+                is MappedBatchLoaderWithContext<*, *> -> mappedBatchLoadersWithContext.add(Pair(dgsComponent, annotation))
                 else -> throw InvalidDataLoaderTypeException(dgsComponent::class.java)
             }
         }
@@ -107,14 +107,14 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         val options = DataLoaderOptions.newOptions()
                 .setBatchingEnabled(dgsDataLoader.batching)
                 .setCachingEnabled(dgsDataLoader.caching)
-        if(dgsDataLoader.maxBatchSize > 0) {
+        if (dgsDataLoader.maxBatchSize > 0) {
             options.setMaxBatchSize(dgsDataLoader.maxBatchSize)
         }
 
         val extendedBatchLoader = try {
             val extensionProvider = applicationContext.getBean(DataLoaderInstrumentationExtensionProvider::class.java)
             extensionProvider.provide(batchLoader, dgsDataLoader.name)
-        } catch(ex: NoSuchBeanDefinitionException) {
+        } catch (ex: NoSuchBeanDefinitionException) {
             batchLoader
         }
 
@@ -125,14 +125,14 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         val options = DataLoaderOptions.newOptions()
                 .setBatchingEnabled(dgsDataLoader.batching)
                 .setCachingEnabled(dgsDataLoader.caching)
-        if(dgsDataLoader.maxBatchSize > 0) {
+        if (dgsDataLoader.maxBatchSize > 0) {
             options.setMaxBatchSize(dgsDataLoader.maxBatchSize)
         }
 
         val extendedBatchLoader = try {
             val extensionProvider = applicationContext.getBean(DataLoaderInstrumentationExtensionProvider::class.java)
             extensionProvider.provide(batchLoader, dgsDataLoader.name)
-        } catch(ex: NoSuchBeanDefinitionException) {
+        } catch (ex: NoSuchBeanDefinitionException) {
             batchLoader
         }
 
@@ -145,14 +145,14 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
                 .setBatchLoaderContextProvider(supplier::get)
                 .setCachingEnabled(dgsDataLoader.caching)
 
-        if(dgsDataLoader.maxBatchSize > 0) {
+        if (dgsDataLoader.maxBatchSize > 0) {
             options.setMaxBatchSize(dgsDataLoader.maxBatchSize)
         }
 
         val extendedBatchLoader = try {
             val extensionProvider = applicationContext.getBean(DataLoaderInstrumentationExtensionProvider::class.java)
             extensionProvider.provide(batchLoader, dgsDataLoader.name)
-        } catch(ex: NoSuchBeanDefinitionException) {
+        } catch (ex: NoSuchBeanDefinitionException) {
             batchLoader
         }
 
@@ -165,14 +165,14 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
                 .setBatchLoaderContextProvider(supplier::get)
                 .setCachingEnabled(dgsDataLoader.caching)
 
-        if(dgsDataLoader.maxBatchSize > 0) {
+        if (dgsDataLoader.maxBatchSize > 0) {
             options.setMaxBatchSize(dgsDataLoader.maxBatchSize)
         }
 
         val extendedBatchLoader = try {
             val extensionProvider = applicationContext.getBean(DataLoaderInstrumentationExtensionProvider::class.java)
             extensionProvider.provide(batchLoader, dgsDataLoader.name)
-        } catch(ex: NoSuchBeanDefinitionException) {
+        } catch (ex: NoSuchBeanDefinitionException) {
             batchLoader
         }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -67,12 +67,12 @@ class DgsSchemaProvider(private val applicationContext: ApplicationContext,
     fun schema(schema: String? = null): GraphQLSchema {
         val startTime = System.currentTimeMillis()
         val dgsComponents = applicationContext.getBeansWithAnnotation(DgsComponent::class.java)
-        val hasDynamicTypeRegistry = dgsComponents.values.any { it.javaClass.methods.any { m -> m.isAnnotationPresent(DgsTypeDefinitionRegistry::class.java) }}
+        val hasDynamicTypeRegistry = dgsComponents.values.any { it.javaClass.methods.any { m -> m.isAnnotationPresent(DgsTypeDefinitionRegistry::class.java) } }
 
         var mergedRegistry = if (schema == null) {
-            findSchemaFiles(hasDynamicTypeRegistry=hasDynamicTypeRegistry).map {
+            findSchemaFiles(hasDynamicTypeRegistry = hasDynamicTypeRegistry).map {
                 InputStreamReader(it.inputStream, StandardCharsets.UTF_8).use { reader -> SchemaParser().parse(reader) }
-            }.fold(TypeDefinitionRegistry()) {a, b -> a.merge(b) }
+            }.fold(TypeDefinitionRegistry()) { a, b -> a.merge(b) }
         } else {
             SchemaParser().parse(schema)
         }
@@ -90,7 +90,7 @@ class DgsSchemaProvider(private val applicationContext: ApplicationContext,
         val codeRegistryBuilder = GraphQLCodeRegistry.newCodeRegistry()
         val runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring()
 
-        dgsComponents.values.mapNotNull { dgsComponent -> invokeDgsTypeDefinitionRegistry(dgsComponent) }.fold(mergedRegistry) { a, b -> a.merge(b)}
+        dgsComponents.values.mapNotNull { dgsComponent -> invokeDgsTypeDefinitionRegistry(dgsComponent) }.fold(mergedRegistry) { a, b -> a.merge(b) }
         findScalars(applicationContext, runtimeWiringBuilder)
         findDataFetchers(dgsComponents, codeRegistryBuilder, mergedRegistry)
         findTypeResolvers(dgsComponents, runtimeWiringBuilder, mergedRegistry)
@@ -122,7 +122,7 @@ class DgsSchemaProvider(private val applicationContext: ApplicationContext,
             }
 
             method.invoke(dgsComponent) as TypeDefinitionRegistry
-        }.reduceOrNull {a, b -> a.merge(b)}
+        }.reduceOrNull { a, b -> a.merge(b) }
     }
 
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/MultipartVariableMapper.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/MultipartVariableMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ object MultipartVariableMapper {
         }
 
         override fun recurse(location: MutableMap<String, Any>, target: String): Any {
-            return location[target]?: error("")
+            return location[target] ?: error("")
         }
     }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/logging/LogEvent.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/logging/LogEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,4 +39,4 @@ data class LogEvent(
         var clientId: String = "",
         var mapleLegacyCaller: String = "",
         var mapleLegacyCallerAuthzAllowed: String = ""
-        )
+)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/scalars/UploadScalar.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/scalars/UploadScalar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile
 
 @DgsComponent
 class UploadScalar {
-    val upload:GraphQLScalarType = GraphQLScalarType.newScalar().name("Upload")
+    val upload: GraphQLScalarType = GraphQLScalarType.newScalar().name("Upload")
             .description("A custom scalar that represents files")
             .coercing(MultipartFileCoercing).build()
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CustomScalarsTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CustomScalarsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class CustomScalarsTest {
 
     @Test
     fun testLocalDateTimeScalar() {
-        val fetcher = object: Any() {
+        val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "now")
             fun now(): LocalDateTime {
                 return LocalDateTime.now()

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DataFetcherWithDirectivesTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DataFetcherWithDirectivesTest.kt
@@ -31,12 +31,13 @@ import java.util.*
 class DataFetcherWithDirectivesTest {
     @MockK
     lateinit var applicationContextMock: ApplicationContext
+
     @Test
     fun addFetchersWithConvertedArguments() {
 
-        val queryFetcher = object: Any() {
-            @DgsData(parentType="Query", field="hello")
-            fun hellOFetcher(dataFetchingEnvironment: DgsDataFetchingEnvironment):String {
+        val queryFetcher = object : Any() {
+            @DgsData(parentType = "Query", field = "hello")
+            fun hellOFetcher(dataFetchingEnvironment: DgsDataFetchingEnvironment): String {
                 val directive = dataFetchingEnvironment.fieldDefinition.directives[0]
                 return "hello ${directive.arguments[0].value}"
             }
@@ -47,7 +48,7 @@ class DataFetcherWithDirectivesTest {
 
         val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
         val schema = provider.schema(
-            """
+                """
             directive @someDirective(name: String) on FIELD_DEFINITION
             type Query {
                 hello: String @someDirective(name: "some name")
@@ -58,7 +59,7 @@ class DataFetcherWithDirectivesTest {
 
         val build = GraphQL.newGraphQL(schema).build()
         val executionResult = build.execute("{ hello }")
-        val data: Map<String,String> = executionResult.getData()
+        val data: Map<String, String> = executionResult.getData()
         assertThat(data["hello"]).isEqualTo("hello some name")
     }
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,8 +107,8 @@ class DgsDataFetchingEnvironmentTest {
     @Test
     fun getDataLoader() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcher))
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns mapOf(Pair("helloLoader", ExampleBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloLoader", ExampleBatchLoader()))
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
@@ -132,8 +132,8 @@ class DgsDataFetchingEnvironmentTest {
     @Test
     fun getDataLoaderWithBasicDFE() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherWithBasicDFE))
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns mapOf(Pair("helloLoader", ExampleBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloLoader", ExampleBatchLoader()))
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
@@ -156,9 +156,9 @@ class DgsDataFetchingEnvironmentTest {
 
     @Test
     fun getDataLoaderFromField() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherWithField), Pair("helloLoader", ExampleBatchLoaderFromField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
@@ -181,9 +181,9 @@ class DgsDataFetchingEnvironmentTest {
 
     @Test
     fun getMultipleDataLoadersFromField() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherWithMultipleField), Pair("helloLoader", ExampleMultipleBatchLoadersAsField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
@@ -205,8 +205,8 @@ class DgsDataFetchingEnvironmentTest {
     @Test
     fun getMappedDataLoader() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherMapped))
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns mapOf(Pair("helloLoader", ExampleMappedBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloLoader", ExampleMappedBatchLoader()))
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
@@ -229,9 +229,9 @@ class DgsDataFetchingEnvironmentTest {
 
     @Test
     fun getMappedDataLoaderFromField() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherWithFieldMapped), Pair("helloLoader", ExampleMappedBatchLoaderFromField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
@@ -270,10 +270,10 @@ class DgsDataFetchingEnvironmentTest {
         verify { dfeMock.containsArgument("name") }
 
         dgsDfe.getArgument<String>("name")
-        verify { dfeMock.getArgument<String>("name")}
+        verify { dfeMock.getArgument<String>("name") }
 
         dgsDfe.getArgumentOrDefault("name", "")
-        verify { dfeMock.getArgumentOrDefault("name", "")}
+        verify { dfeMock.getArgumentOrDefault("name", "") }
 
         dgsDfe.getContext<String>()
         verify { dfeMock.getContext<String>() }
@@ -322,7 +322,7 @@ class DgsDataFetchingEnvironmentTest {
         verify { dfeMock.queryDirectives }
 
         dgsDfe.getDataLoader<String, String>("loaderA")
-        verify { dfeMock.getDataLoader<String, String>("loaderA")}
+        verify { dfeMock.getDataLoader<String, String>("loaderA") }
 
         dgsDfe.dataLoaderRegistry
         verify { dfeMock.dataLoaderRegistry }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,30 +35,30 @@ class DgsDataLoaderProviderTest {
 
     @Test
     fun findDataLoaders() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java)} returns emptyMap()
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns mapOf(Pair("helloFetcher", ExampleBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloFetcher", ExampleBatchLoader()))
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
         val dataLoaderRegistry = provider.buildRegistry()
         Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
-        val dataLoader = dataLoaderRegistry .getDataLoader<Any, Any>("exampleLoader")
+        val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoader")
         Assertions.assertNotNull(dataLoader)
     }
 
     @Test
     fun dataLoaderInvalidType() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns mapOf(Pair("helloFetcher", object {}))
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloFetcher", object {}))
         val provider = DgsDataLoaderProvider(applicationContextMock)
         assertThrows<InvalidDataLoaderTypeException> { provider.findDataLoaders() }
     }
 
     @Test
     fun findDataLoadersFromFields() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns emptyMap()
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java)} returns mapOf(Pair("helloFetcher", ExampleBatchLoaderFromField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", ExampleBatchLoaderFromField()))
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -73,23 +73,23 @@ class DgsDataLoaderProviderTest {
 
     @Test
     fun findMappedDataLoaders() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java)} returns emptyMap()
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns mapOf(Pair("helloFetcher", ExampleMappedBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloFetcher", ExampleMappedBatchLoader()))
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
         val dataLoaderRegistry = provider.buildRegistry()
         Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
-        val dataLoader = dataLoaderRegistry .getDataLoader<Any, Any>("exampleMappedLoader")
+        val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoader")
         Assertions.assertNotNull(dataLoader)
     }
 
     @Test
     fun findMappedDataLoadersFromFields() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)} returns emptyMap()
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java)} returns mapOf(Pair("helloFetcher", ExampleMappedBatchLoaderFromField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java)} throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", ExampleMappedBatchLoaderFromField()))
+        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsFederationResolverTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsFederationResolverTest.kt
@@ -45,15 +45,15 @@ class DgsFederationResolverTest {
     @MockK
     lateinit var applicationContextMock: ApplicationContext
 
-    lateinit var dgsSchemaProvider:DgsSchemaProvider
+    lateinit var dgsSchemaProvider: DgsSchemaProvider
 
     @BeforeEach
     fun setup() {
         dgsSchemaProvider = DgsSchemaProvider(
                 applicationContextMock,
-        Optional.empty(),
-        Optional.empty(),
-        Optional.empty()
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()
         )
     }
 
@@ -107,7 +107,7 @@ class DgsFederationResolverTest {
         """.trimIndent()
 
         val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
-        val customTypeResolver = object: DefaultDgsFederationResolver(dgsSchemaProvider) {
+        val customTypeResolver = object : DefaultDgsFederationResolver(dgsSchemaProvider) {
             override fun typeMapping(): Map<Class<*>, String> {
                 return mapOf(Pair(Movie::class.java, "DgsMovie"))
             }
@@ -119,14 +119,14 @@ class DgsFederationResolverTest {
 
     @Test
     fun missingDgsEntityFetcher() {
-        val arguments = mapOf<String,Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie")))))
+        val arguments = mapOf<String, Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie")))))
         val dataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
         assertThrows<MissingDgsEntityFetcherException> { DefaultDgsFederationResolver(dgsSchemaProvider).entitiesFetcher().get(dataFetchingEnvironment) }
     }
 
     @Test
     fun missingTypeNameForEntitiesQuery() {
-        val arguments = mapOf<String,Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("something", "Else")))))
+        val arguments = mapOf<String, Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("something", "Else")))))
         val dataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
         assertThrows<RuntimeException> { DefaultDgsFederationResolver(dgsSchemaProvider).entitiesFetcher().get(dataFetchingEnvironment) }
     }
@@ -149,7 +149,7 @@ class DgsFederationResolverTest {
         val movieEntityFetcher = object {
             @DgsEntityFetcher(name = "Movie")
             fun movieEntityFetcher(values: Map<String, Any>, dfe: DataFetchingEnvironment?): Movie {
-                if(dfe == null) {
+                if (dfe == null) {
                     throw RuntimeException()
                 }
                 return Movie(values["movieId"].toString())
@@ -165,7 +165,7 @@ class DgsFederationResolverTest {
         val movieEntityFetcher = object {
             @DgsEntityFetcher(name = "Movie")
             fun movieEntityFetcher(values: Map<String, Any>, dfe: DgsDataFetchingEnvironment?): Movie {
-                if(dfe == null) {
+                if (dfe == null) {
                     throw RuntimeException()
                 }
                 return Movie(values["movieId"].toString())
@@ -183,7 +183,7 @@ class DgsFederationResolverTest {
                 throw RuntimeException("Should not be called")
             }
         }
-        val arguments = mapOf<String,Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie")))))
+        val arguments = mapOf<String, Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie")))))
         val dataFetchingEnvironment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
         assertThrows<RuntimeException> { DefaultDgsFederationResolver(dgsSchemaProvider).entitiesFetcher().get(dataFetchingEnvironment) }
     }
@@ -193,7 +193,7 @@ class DgsFederationResolverTest {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("MovieEntityFetcher", movieEntityFetcher))
         dgsSchemaProvider.schema("""type Query {}""")
 
-        val arguments = mapOf<String,Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie"), Pair("movieId", "1")))))
+        val arguments = mapOf<String, Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie"), Pair("movieId", "1")))))
         val dataFetchingEnvironment = DgsDataFetchingEnvironment(DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build())
 
         val result = (DefaultDgsFederationResolver(dgsSchemaProvider).entitiesFetcher().get(dataFetchingEnvironment) as CompletableFuture<List<*>>).get()
@@ -212,4 +212,4 @@ class DgsFederationResolverTest {
     }
 }
 
-data class Movie(val movieId:String = "", val title:String = "")
+data class Movie(val movieId: String = "", val title: String = "")

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -75,10 +75,10 @@ internal class DgsSchemaProviderTest {
     @Test
     fun findSchemaFiles() {
         val findSchemaFiles = DgsSchemaProvider(
-            applicationContextMock,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty()
+                applicationContextMock,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()
         ).findSchemaFiles()
         assertThat(findSchemaFiles.size).isGreaterThan(1)
         assertEquals("schema1.graphqls", findSchemaFiles[0].filename)
@@ -88,10 +88,10 @@ internal class DgsSchemaProviderTest {
     fun findSchemaFilesEmptyDir() {
         assertThrows<NoSchemaFoundException> {
             DgsSchemaProvider(
-                applicationContextMock,
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty()
+                    applicationContextMock,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()
             ).findSchemaFiles("notexists")
         }
     }
@@ -99,10 +99,10 @@ internal class DgsSchemaProviderTest {
     @Test
     fun allowNoSchemasWhenTypeRegistryProvided() {
         val findSchemaFiles = DgsSchemaProvider(
-            applicationContextMock,
-            Optional.empty(),
-            Optional.of(TypeDefinitionRegistry()),
-            Optional.empty()
+                applicationContextMock,
+                Optional.empty(),
+                Optional.of(TypeDefinitionRegistry()),
+                Optional.empty()
         ).findSchemaFiles("noexists")
         assertEquals(0, findSchemaFiles.size)
     }
@@ -117,10 +117,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -142,10 +142,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -182,10 +182,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -217,10 +217,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -256,10 +256,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -295,10 +295,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -338,10 +338,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -385,10 +385,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -419,8 +419,8 @@ internal class DgsSchemaProviderTest {
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
             fun someFetcher(
-                @InputArgument("capitalize") capitalize: Boolean,
-                @InputArgument("person") person: Person
+                    @InputArgument("capitalize") capitalize: Boolean,
+                    @InputArgument("person") person: Person
             ): String {
                 return if (capitalize) {
                     "hello, ${person.name}".capitalize()
@@ -431,10 +431,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -465,9 +465,9 @@ internal class DgsSchemaProviderTest {
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
             fun someFetcher(
-                dfe: DataFetchingEnvironment,
-                @InputArgument("capitalize") capitalize: Boolean,
-                @InputArgument("person") person: Person
+                    dfe: DataFetchingEnvironment,
+                    @InputArgument("capitalize") capitalize: Boolean,
+                    @InputArgument("person") person: Person
             ): String {
                 val otherArg: String = dfe.getArgument("otherArg")
 
@@ -481,10 +481,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -515,9 +515,9 @@ internal class DgsSchemaProviderTest {
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
             fun someFetcher(
-                @InputArgument("capitalize") capitalize: Boolean,
-                @InputArgument("person") person: Person,
-                dfe: DataFetchingEnvironment
+                    @InputArgument("capitalize") capitalize: Boolean,
+                    @InputArgument("person") person: Person,
+                    dfe: DataFetchingEnvironment
             ): String {
                 val otherArg: String = dfe.getArgument("otherArg")
 
@@ -531,10 +531,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -568,11 +568,11 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            ),
-            Pair("Upload", UploadScalar()),
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                ),
+                Pair("Upload", UploadScalar()),
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -580,12 +580,12 @@ internal class DgsSchemaProviderTest {
 
 
         val file: MultipartFile =
-            MockMultipartFile("hello.txt", "hello.txt", MediaType.TEXT_PLAIN_VALUE, "Hello World".toByteArray())
+                MockMultipartFile("hello.txt", "hello.txt", MediaType.TEXT_PLAIN_VALUE, "Hello World".toByteArray())
 
         val build = GraphQL.newGraphQL(provider.schema(schema)).build()
         val executionResult = build.execute(
-            ExecutionInput.newExecutionInput().query("mutation(\$input: Upload!)  { upload(file: \$input) }")
-                .variables(mapOf(Pair("input", file)))
+                ExecutionInput.newExecutionInput().query("mutation(\$input: Upload!)  { upload(file: \$input) }")
+                        .variables(mapOf(Pair("input", file)))
         )
         assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -610,10 +610,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -647,10 +647,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf(Pair("DateTime", LocalDateTimeScalar()))
 
@@ -682,10 +682,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf(Pair("DateTime", LocalDateTimeScalar()))
 
@@ -755,10 +755,10 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        fetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -793,8 +793,8 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair("defaultResolver", resolverDefault),
-            Pair("videoFetcher", defaultVideoFetcher)
+                Pair("defaultResolver", resolverDefault),
+                Pair("videoFetcher", defaultVideoFetcher)
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -837,8 +837,8 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair("defaultResolver", resolverDefault),
-            Pair("overrideResolver", resolverOverride), Pair("videoFetcher", defaultVideoFetcher)
+                Pair("defaultResolver", resolverDefault),
+                Pair("overrideResolver", resolverOverride), Pair("videoFetcher", defaultVideoFetcher)
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -850,10 +850,10 @@ internal class DgsSchemaProviderTest {
     @Test
     fun addFetchersWithoutDataFetchingEnvironment() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                defaultHelloFetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        defaultHelloFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -870,8 +870,8 @@ internal class DgsSchemaProviderTest {
         val codeRegistry = object : Any() {
             @DgsCodeRegistry
             fun registry(
-                codeRegistryBuilder: GraphQLCodeRegistry.Builder,
-                registry: TypeDefinitionRegistry?
+                    codeRegistryBuilder: GraphQLCodeRegistry.Builder,
+                    registry: TypeDefinitionRegistry?
             ): GraphQLCodeRegistry.Builder? {
                 val df = DataFetcher { "Runtime added field" }
                 val coordinates = FieldCoordinates.coordinates("Query", "myField")
@@ -881,29 +881,29 @@ internal class DgsSchemaProviderTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                defaultHelloFetcher
-            ), Pair("codeRegistry", codeRegistry)
+                Pair(
+                        "helloFetcher",
+                        defaultHelloFetcher
+                ), Pair("codeRegistry", codeRegistry)
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val typeDefinitionFactory = TypeDefinitionRegistry()
         val objectTypeExtensionDefinition = ObjectTypeExtensionDefinition.newObjectTypeExtensionDefinition()
-            .name("Query")
-            .fieldDefinition(
-                FieldDefinition.newFieldDefinition()
-                    .name("myField")
-                    .type(TypeName("String")).build()
-            )
-            .build()
+                .name("Query")
+                .fieldDefinition(
+                        FieldDefinition.newFieldDefinition()
+                                .name("myField")
+                                .type(TypeName("String")).build()
+                )
+                .build()
 
         typeDefinitionFactory.add(objectTypeExtensionDefinition)
         val provider = DgsSchemaProvider(
-            applicationContextMock,
-            Optional.empty(),
-            Optional.of(typeDefinitionFactory),
-            Optional.empty()
+                applicationContextMock,
+                Optional.empty(),
+                Optional.of(typeDefinitionFactory),
+                Optional.empty()
         )
         val schema = provider.schema()
         val build = GraphQL.newGraphQL(schema).build()
@@ -941,7 +941,7 @@ internal class DgsSchemaProviderTest {
         """.trimIndent()
 
         val dgsSchemaProvider =
-            DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+                DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf()
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         assertThat(dgsSchemaProvider.schema(schema)).isNotNull
@@ -951,10 +951,10 @@ internal class DgsSchemaProviderTest {
     @Test
     fun enableInstrumentationForDataFetchers() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                defaultHelloFetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        defaultHelloFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -976,10 +976,10 @@ internal class DgsSchemaProviderTest {
             }
         }
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                noTracingDataFetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        noTracingDataFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -998,10 +998,10 @@ internal class DgsSchemaProviderTest {
             }
         }
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                noTracingDataFetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        noTracingDataFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -1021,10 +1021,10 @@ internal class DgsSchemaProviderTest {
             }
         }
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                noTracingDataFetcher
-            )
+                Pair(
+                        "helloFetcher",
+                        noTracingDataFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -1058,16 +1058,16 @@ internal class DgsSchemaProviderTest {
             }
         }
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "videoFetcher",
-                defaultVideoFetcher
-            )
+                Pair(
+                        "videoFetcher",
+                        defaultVideoFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "titleFetcher",
-                titleFetcher
-            )
+                Pair(
+                        "titleFetcher",
+                        titleFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -1105,16 +1105,16 @@ internal class DgsSchemaProviderTest {
             }
         }
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "videoFetcher",
-                defaultVideoFetcher
-            )
+                Pair(
+                        "videoFetcher",
+                        defaultVideoFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "titleFetcher",
-                titleFetcher
-            )
+                Pair(
+                        "titleFetcher",
+                        titleFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
@@ -1151,16 +1151,16 @@ internal class DgsSchemaProviderTest {
             }
         }
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "videoFetcher",
-                defaultVideoFetcher
-            )
+                Pair(
+                        "videoFetcher",
+                        defaultVideoFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "titleFetcher",
-                titleFetcher
-            )
+                Pair(
+                        "titleFetcher",
+                        titleFetcher
+                )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsTypeRegistryDefinitionTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsTypeRegistryDefinitionTest.kt
@@ -48,9 +48,9 @@ class DgsTypeRegistryDefinitionTest {
                 val newRegistry = TypeDefinitionRegistry()
 
                 val query =
-                    ObjectTypeExtensionDefinition.newObjectTypeExtensionDefinition().name("Query").fieldDefinition(
-                        FieldDefinition.newFieldDefinition().name("dynamicField").type(TypeName("String")).build()
-                    ).build()
+                        ObjectTypeExtensionDefinition.newObjectTypeExtensionDefinition().name("Query").fieldDefinition(
+                                FieldDefinition.newFieldDefinition().name("dynamicField").type(TypeName("String")).build()
+                        ).build()
 
                 newRegistry.add(query);
 
@@ -58,9 +58,9 @@ class DgsTypeRegistryDefinitionTest {
             }
         }
 
-        val queryFetcher = object: Any() {
-            @DgsData(parentType="Query", field="dynamicField")
-            fun dynamicField():String {
+        val queryFetcher = object : Any() {
+            @DgsData(parentType = "Query", field = "dynamicField")
+            fun dynamicField(): String {
                 return "hello from dgs"
             }
         }
@@ -72,7 +72,7 @@ class DgsTypeRegistryDefinitionTest {
         val schema = provider.schema()
         val graphql = GraphQL.newGraphQL(schema).build()
         val result = graphql.execute(
-            """
+                """
             {
                 dynamicField
             }
@@ -91,9 +91,9 @@ class DgsTypeRegistryDefinitionTest {
                 val newRegistry = TypeDefinitionRegistry()
 
                 val query =
-                    ObjectTypeExtensionDefinition.newObjectTypeExtensionDefinition().name("Query").fieldDefinition(
-                        FieldDefinition.newFieldDefinition().name("dynamicField").type(TypeName("String")).build()
-                    ).build()
+                        ObjectTypeExtensionDefinition.newObjectTypeExtensionDefinition().name("Query").fieldDefinition(
+                                FieldDefinition.newFieldDefinition().name("dynamicField").type(TypeName("String")).build()
+                        ).build()
 
                 newRegistry.add(query);
 
@@ -107,9 +107,9 @@ class DgsTypeRegistryDefinitionTest {
                 val newRegistry = TypeDefinitionRegistry()
 
                 val query =
-                    ObjectTypeExtensionDefinition.newObjectTypeExtensionDefinition().name("Query").fieldDefinition(
-                        FieldDefinition.newFieldDefinition().name("number").type(TypeName("Int")).build()
-                    ).build()
+                        ObjectTypeExtensionDefinition.newObjectTypeExtensionDefinition().name("Query").fieldDefinition(
+                                FieldDefinition.newFieldDefinition().name("number").type(TypeName("Int")).build()
+                        ).build()
 
                 newRegistry.add(query);
 
@@ -117,16 +117,16 @@ class DgsTypeRegistryDefinitionTest {
             }
         }
 
-        val queryFetcher = object: Any() {
-            @DgsData(parentType="Query", field="dynamicField")
-            fun dynamicField():String {
+        val queryFetcher = object : Any() {
+            @DgsData(parentType = "Query", field = "dynamicField")
+            fun dynamicField(): String {
                 return "hello from dgs"
             }
         }
 
-        val numberFetcher = object: Any() {
-            @DgsData(parentType="Query", field="number")
-            fun dynamicField():Int {
+        val numberFetcher = object : Any() {
+            @DgsData(parentType = "Query", field = "number")
+            fun dynamicField(): Int {
                 return 1
             }
         }
@@ -138,7 +138,7 @@ class DgsTypeRegistryDefinitionTest {
         val schema = provider.schema()
         val graphql = GraphQL.newGraphQL(schema).build()
         val result = graphql.execute(
-            """
+                """
             {
                 dynamicField
                 number

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoader.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import org.dataloader.BatchLoader
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
-@DgsDataLoader(name="exampleLoader")
-class ExampleBatchLoader: BatchLoader<String, String> {
+@DgsDataLoader(name = "exampleLoader")
+class ExampleBatchLoader : BatchLoader<String, String> {
     override fun load(keys: MutableList<String>?): CompletionStage<MutableList<String>> {
         return CompletableFuture.supplyAsync { mutableListOf("a", "b", "c") }
     }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoader.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,11 @@ import org.dataloader.MappedBatchLoader
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
-@DgsDataLoader(name="exampleMappedLoader")
+@DgsDataLoader(name = "exampleMappedLoader")
 class ExampleMappedBatchLoader : MappedBatchLoader<String, String> {
     override fun load(keys: MutableSet<String>?): CompletionStage<MutableMap<String, String>> {
-        return CompletableFuture.supplyAsync  {
-          val result = mutableMapOf<String,String>()
+        return CompletableFuture.supplyAsync {
+            val result = mutableMapOf<String, String>()
             keys?.forEach { result[it] = it.toUpperCase() }
             result
         }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/InterfaceDataFetchersTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/InterfaceDataFetchersTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,12 @@ class InterfaceDataFetchersTest {
         var title: String
     }
 
-    class ScaryMovie: Movie {
+    class ScaryMovie : Movie {
         override var title: String = ""
         var gory = true
     }
 
-    class ActionMovie: Movie {
+    class ActionMovie : Movie {
         override var title: String = ""
         var nrOfExplosions = 0
     }
@@ -52,8 +52,8 @@ class InterfaceDataFetchersTest {
     @Test
     fun testDataFetchersOnInterface() {
 
-        val movieTypeResolver = object: Any() {
-            @DgsTypeResolver(name="Movie")
+        val movieTypeResolver = object : Any() {
+            @DgsTypeResolver(name = "Movie")
             fun movieTypes(movie: Movie): String {
                 return when (movie) {
                     is ScaryMovie -> "ScaryMovie"
@@ -64,16 +64,16 @@ class InterfaceDataFetchersTest {
 
         }
 
-        val fetcher = object: Any() {
-            @DgsData(parentType="Movie", field="director")
-            fun directorFetcher(dfe: DataFetchingEnvironment):String {
+        val fetcher = object : Any() {
+            @DgsData(parentType = "Movie", field = "director")
+            fun directorFetcher(dfe: DataFetchingEnvironment): String {
                 return "The Director"
             }
         }
 
-        val queryFetcher = object: Any() {
-            @DgsData(parentType="Query", field="movies")
-            fun moviesFetcher(dfe: DataFetchingEnvironment):List<Movie> {
+        val queryFetcher = object : Any() {
+            @DgsData(parentType = "Query", field = "movies")
+            fun moviesFetcher(dfe: DataFetchingEnvironment): List<Movie> {
                 return listOf(ScaryMovie(), ActionMovie())
             }
         }
@@ -107,7 +107,7 @@ class InterfaceDataFetchersTest {
 
         val build = GraphQL.newGraphQL(schema).build()
         val executionResult = build.execute("{movies {director}}")
-         assertEquals(0, executionResult.errors.size)
+        assertEquals(0, executionResult.errors.size)
         assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, List<Map<String, *>>>>()
         assertEquals("The Director", data["movies"]!![0]["director"])

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/LocalDateTimeScalar.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/LocalDateTimeScalar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,8 @@ import graphql.schema.CoercingSerializeException
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-@DgsScalar(name="DateTime")
-class LocalDateTimeScalar: Coercing<LocalDateTime, String> {
+@DgsScalar(name = "DateTime")
+class LocalDateTimeScalar : Coercing<LocalDateTime, String> {
     override fun parseValue(input: Any?): LocalDateTime {
         return LocalDateTime.parse(input.toString(), DateTimeFormatter.ISO_DATE_TIME)
     }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/TypeResolverTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/TypeResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,19 +41,19 @@ class TypeResolverTest {
         var title: String
     }
 
-    class ScaryMovie: Movie {
+    class ScaryMovie : Movie {
         override var title: String = ""
         var gory = true
     }
 
-    class ActionMovie: Movie {
+    class ActionMovie : Movie {
         override var title: String = ""
         var nrOfExplosions = 0
     }
 
-    val queryFetcher = object: Any() {
-        @DgsData(parentType="Query", field="movies")
-        fun moviesFetcher():List<Movie> {
+    val queryFetcher = object : Any() {
+        @DgsData(parentType = "Query", field = "movies")
+        fun moviesFetcher(): List<Movie> {
             return listOf(ScaryMovie(), ActionMovie())
         }
     }
@@ -146,14 +146,14 @@ class TypeResolverTest {
                         }
                     }
                 }""".trimIndent())
-            }
+        }
 
     }
 
     @Test
     fun testCustomTypeResolver() {
-        val movieTypeResolver = object: Any() {
-            @DgsTypeResolver(name="Movie")
+        val movieTypeResolver = object : Any() {
+            @DgsTypeResolver(name = "Movie")
             fun movieTypes(movie: Movie): String {
                 return when (movie) {
                     is ScaryMovie -> "ScaryMovie"

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/UnionDataFetcherTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/UnionDataFetcherTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ class UnionDataFetcherTest {
 
     data class SeriesSearchResult(val name: String, val episodes: Int)
 
-    val searchResultTypeResolver = object: Any() {
-        @DgsTypeResolver(name="SearchResult")
+    val searchResultTypeResolver = object : Any() {
+        @DgsTypeResolver(name = "SearchResult")
         fun searchResultTypes(result: Any): String {
             return when (result) {
                 is MovieSearchResult -> "MovieSearchResult"
@@ -48,17 +48,17 @@ class UnionDataFetcherTest {
         }
     }
 
-    val queryFetcher = object: Any() {
-        @DgsData(parentType="Query", field="search")
-        fun searchFetcher():List<Any> {
+    val queryFetcher = object : Any() {
+        @DgsData(parentType = "Query", field = "search")
+        fun searchFetcher(): List<Any> {
             return listOf(MovieSearchResult("Extraction", 90), SeriesSearchResult("The Witcher", 15))
         }
     }
 
-    val imdbFetcher = object: Any() {
-        @DgsData(parentType="SearchResult", field="imdbRating")
-        fun imdbRating():Int {
-            return Random.nextInt(1,5)
+    val imdbFetcher = object : Any() {
+        @DgsData(parentType = "SearchResult", field = "imdbRating")
+        fun imdbRating(): Int {
+            return Random.nextInt(1, 5)
         }
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandlerTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandlerTest.kt
@@ -40,7 +40,7 @@ internal class DefaultDataFetcherExceptionHandlerTest {
 
     @Test
     fun securityError() {
-        every { dataFetcherExceptionHandlerParameters.exception}.returns(AccessDeniedException("Denied"))
+        every { dataFetcherExceptionHandlerParameters.exception }.returns(AccessDeniedException("Denied"))
 
         val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
         assertThat(result.errors.size).isEqualTo(1)
@@ -54,7 +54,7 @@ internal class DefaultDataFetcherExceptionHandlerTest {
 
     @Test
     fun normalError() {
-        every { dataFetcherExceptionHandlerParameters.exception}.returns(RuntimeException("Something broke"))
+        every { dataFetcherExceptionHandlerParameters.exception }.returns(RuntimeException("Something broke"))
 
         val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
         assertThat(result.errors.size).isEqualTo(1)
@@ -68,7 +68,7 @@ internal class DefaultDataFetcherExceptionHandlerTest {
 
     @Test
     fun normalErrorWithSpecialCharacterString() {
-        every { dataFetcherExceptionHandlerParameters.exception}.returns(RuntimeException("/bgt_budgetingProject/specificPass: not a PassId: bdgt%3Apass%2F3"))
+        every { dataFetcherExceptionHandlerParameters.exception }.returns(RuntimeException("/bgt_budgetingProject/specificPass: not a PassId: bdgt%3Apass%2F3"))
 
         val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
         assertThat(result.errors.size).isEqualTo(1)

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,11 @@ import graphql.execution.instrumentation.ChainedInstrumentation
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.dataloader.DataLoaderRegistry
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.context.ApplicationContext
 import java.util.*

--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/ErrorDetail.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/ErrorDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,11 +26,11 @@ import static com.netflix.graphql.types.errors.ErrorType.*;
  * This allows the ErrorType enumeration to be small and mostly static so that application branching logic
  * can depend on it. The ErrorDetail provides a more specific cause for the error. This enumeration will
  * be much larger and likely change/grow over time.
- *
+ * <p>
  * For example, a service may be unavailable, resulting in ErrorType UNAVAILABLE. The ErrorDetail may be
  * more specific, such as THROTTLED_CPU. The ErrorType should be sufficient to control client behavior,
  * while the ErrorDetail is more useful for debugging and real-time operations.
- *
+ * <p>
  * The example below is not to be considered canonical. This enumeration may be defined by the server,
  * and should be included with the server schema.
  */

--- a/graphql-error-types/src/main/resources/META-INF/schema/errortype.graphqls
+++ b/graphql-error-types/src/main/resources/META-INF/schema/errortype.graphqls
@@ -105,12 +105,12 @@ enum ErrorType {
     Service implementers can use the following guidelines to decide
     between `FAILED_PRECONDITION` and `UNAVAILABLE`:
 
-      - Use `UNAVAILABLE` if the client can retry just the failing call.
-      - Use `FAILED_PRECONDITION` if the client should not retry until
-         the system state has been explicitly fixed.  E.g., if an "rmdir"
+    - Use `UNAVAILABLE` if the client can retry just the failing call.
+    - Use `FAILED_PRECONDITION` if the client should not retry until
+    the system state has been explicitly fixed.  E.g., if an "rmdir"
          fails because the directory is non-empty, `FAILED_PRECONDITION`
-         should be returned since the client should not retry unless
-         the files are deleted from the directory.
+    should be returned since the client should not retry unless
+    the files are deleted from the directory.
 
     HTTP Mapping: 400 Bad Request or 500 Internal Server Error
     """


### PR DESCRIPTION
This PR from hell reformats each and every file in the project.

We've been struggling with keeping code formatting consistent in pull requests, and the "Kotlin Code Style" is now available. The idea is to just get it over with and apply this style, so it won't be in our way as much in the future.

This will obviously not be ideal for anyone with an open PR. I think the easiest way to work around it is rebase on this commit, force your changes to overwrite the ones form this commit, and reformat again.

@bono007 @berngp @marceloverdijk would you be ok with this?

Btw, don't bother actually reviewing this, the reformatting was completely automatic. This PR is only there to get eyes on the upcoming annoying change.