### PR TITLE
Use CompletionStage interface

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.actuate.metrics.AutoTimer
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 
 class DgsGraphQLMetricsInstrumentation(
     private val registrySupplier: DgsMeterRegistrySupplier,
@@ -100,7 +101,7 @@ class DgsGraphQLMetricsInstrumentation(
             val sampler = Timer.start(registry)
             try {
                 val result = dataFetcher.get(environment)
-                if (result is CompletableFuture<*>) {
+                if (result is CompletionStage<*>) {
                     result.whenComplete { _, error -> recordDataFetcherMetrics(registry, sampler, parameters, error, baseTags) }
                 } else {
                     recordDataFetcherMetrics(registry, sampler, parameters, null, baseTags)
@@ -136,7 +137,7 @@ class DgsGraphQLMetricsInstrumentation(
         }
 
         fun stopTimer(timer: Timer.Builder) {
-            this.timerSample.map { it.stop(timer.register(this.registry)) }
+            this.timerSample.ifPresent { it.stop(timer.register(this.registry)) }
         }
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -30,6 +30,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 
 @DgsComponent
 open class DefaultDgsFederationResolver() :
@@ -81,8 +82,8 @@ open class DefaultDgsFederationResolver() :
                     throw MissingDgsEntityFetcherException(typename.toString())
                 }
 
-                if (result is CompletableFuture<*>) {
-                    result
+                if (result is CompletionStage<*>) {
+                    result.toCompletableFuture()
                 } else {
                     CompletableFuture.completedFuture(result)
                 }


### PR DESCRIPTION
When checking return types of data loaders and entity fetchers, use the
CompletionStage interface instead of the CompletableFuture
implementation.