### PR TITLE
Refactored Metric Tests for Data Loaders and Outcome Tag

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.dgs.metrics
 
+import io.micrometer.core.instrument.Tag
+
 object DgsMetrics {
 
     /** Defines the GQL Metrics emitted by the framework. */
@@ -42,8 +44,8 @@ object DgsMetrics {
 
     /** Defines the tags applied to the [GqlMetric] emitted by the framework. */
     enum class GqlTag(val key: String) {
-        /** The sanitized query path that resulted in the error. */
-        ERROR_PATH("gql.path"),
+        /** The sanitized query path. */
+        PATH("gql.path"),
 
         /** The GraphQL error code, such as VALIDATION, INTERNAL, etc. */
         ERROR_CODE("gql.errorCode"),
@@ -62,5 +64,14 @@ object DgsMetrics {
 
         /** Used to capture the result of an action, e.g. `ERROR` or `SUCCESS`.*/
         OUTCOME("outcome")
+    }
+
+    enum class GqlTagValue(val owner: GqlTag, val value: String) {
+        /** Value used to reflect as successful  outcome.*/
+        SUCCESS(GqlTag.OUTCOME, "success"),
+        /** Value used to reflect a general failure.*/
+        FAILURE(GqlTag.OUTCOME, "failure");
+
+        val tag: Tag = Tag.of(owner.key, value)
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -64,7 +64,7 @@ class DgsGraphQLMetricsInstrumentation(
                 .get()
                 .counter(
                     GqlMetric.ERROR.key,
-                    tags.and(GqlTag.ERROR_PATH.key, it.path)
+                    tags.and(GqlTag.PATH.key, it.path)
                         .and(GqlTag.ERROR_CODE.key, it.type)
                         .and(GqlTag.ERROR_DETAIL.key, it.detail)
                 ).increment()

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/SimpleGqlOutcomeTagCustomizer.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/SimpleGqlOutcomeTagCustomizer.kt
@@ -16,7 +16,7 @@
 
 package com.netflix.graphql.dgs.metrics.micrometer.tagging
 
-import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlTag
+import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlTagValue
 import graphql.ExecutionResult
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
@@ -25,20 +25,15 @@ import io.micrometer.core.instrument.Tags
 
 class SimpleGqlOutcomeTagCustomizer : DgsExecutionTagCustomizer, DgsFieldFetchTagCustomizer {
 
-    companion object {
-        val OUTCOME_SUCCESS: Tag = Tag.of(GqlTag.OUTCOME.key, "SUCCESS")
-        val OUTCOME_ERROR: Tag = Tag.of(GqlTag.OUTCOME.key, "ERROR")
-    }
-
     override fun getExecutionTags(
         parameters: InstrumentationExecutionParameters,
         result: ExecutionResult,
         exception: Throwable?
     ): Iterable<Tag> {
         return if (result.errors.isNotEmpty() || exception != null) {
-            Tags.of(OUTCOME_ERROR)
+            Tags.of(GqlTagValue.FAILURE.tag)
         } else {
-            Tags.of(OUTCOME_SUCCESS)
+            Tags.of(GqlTagValue.SUCCESS.tag)
         }
     }
 
@@ -46,10 +41,10 @@ class SimpleGqlOutcomeTagCustomizer : DgsExecutionTagCustomizer, DgsFieldFetchTa
         parameters: InstrumentationFieldFetchParameters,
         error: Throwable?
     ): Iterable<Tag> {
-        return if (error != null) {
-            Tags.of(OUTCOME_ERROR)
+        return if (error == null) {
+            Tags.of(GqlTagValue.SUCCESS.tag)
         } else {
-            Tags.of(OUTCOME_SUCCESS)
+            Tags.of(GqlTagValue.FAILURE.tag)
         }
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/none/package-info.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/none/package-info.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package is intended to not offer any beans, its mainly a place holder
+ * to redirect class scanning. Ref [MicrometerServeltSmokeTest]
+ */
+package com.netflix.graphql.dgs.metrics.micrometer.none


### PR DESCRIPTION
This commit is mainly focused on the way we are testing the metrics exposed by _Data Loaders_.
Prior to this the _Data Loaders_ test was basic and only included one kind.
We are now testing it in a more _realistic_ fashion and including a `MappedBatchLoader` as well.

In addition, we are refactoring the Outcome _tag_ to simplify a bit the access to the actual access to Micrometer's Tag reference.