### PR TITLE
Support multiple beans of type DataLoaderInstrumentationExtensionProvider

### DIFF
--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
@@ -28,15 +28,16 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.dataloader.DataLoader
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.support.StaticListableBeanFactory
 import org.springframework.context.ApplicationContext
 import java.util.*
 import java.util.concurrent.CompletableFuture
 
 @ExtendWith(MockKExtension::class)
-class DgsDataFetchingEnvironmentTest {
+internal class DgsDataFetchingEnvironmentTest {
     @MockK
     lateinit var applicationContextMock: ApplicationContext
 
@@ -104,12 +105,19 @@ class DgsDataFetchingEnvironmentTest {
         }
     }
 
+    @BeforeEach
+    fun setDataLoaderInstrumentationExtensionProvider() {
+        val listableBeanFactory = StaticListableBeanFactory()
+        every { applicationContextMock.getBeanProvider(DataLoaderInstrumentationExtensionProvider::class.java) } returns
+            listableBeanFactory.getBeanProvider(DataLoaderInstrumentationExtensionProvider::class.java)
+
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+    }
+
     @Test
     fun getDataLoader() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcher))
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloLoader", ExampleBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -133,8 +141,6 @@ class DgsDataFetchingEnvironmentTest {
     fun getDataLoaderWithBasicDFE() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherWithBasicDFE))
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloLoader", ExampleBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -158,8 +164,6 @@ class DgsDataFetchingEnvironmentTest {
     fun getDataLoaderFromField() {
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherWithField), Pair("helloLoader", ExampleBatchLoaderFromField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -183,8 +187,6 @@ class DgsDataFetchingEnvironmentTest {
     fun getMultipleDataLoadersFromField() {
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherWithMultipleField), Pair("helloLoader", ExampleMultipleBatchLoadersAsField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -206,8 +208,6 @@ class DgsDataFetchingEnvironmentTest {
     fun getMappedDataLoader() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherMapped))
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloLoader", ExampleMappedBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -231,8 +231,6 @@ class DgsDataFetchingEnvironmentTest {
     fun getMappedDataLoaderFromField() {
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", helloFetcherWithFieldMapped), Pair("helloLoader", ExampleMappedBatchLoaderFromField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -22,10 +22,11 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.support.StaticListableBeanFactory
 import org.springframework.context.ApplicationContext
 
 @ExtendWith(MockKExtension::class)
@@ -33,11 +34,17 @@ class DgsDataLoaderProviderTest {
     @MockK
     lateinit var applicationContextMock: ApplicationContext
 
+    @BeforeEach
+    fun setDataLoaderInstrumentationExtensionProvider() {
+        val listableBeanFactory = StaticListableBeanFactory()
+        every { applicationContextMock.getBeanProvider(DataLoaderInstrumentationExtensionProvider::class.java) } returns
+            listableBeanFactory.getBeanProvider(DataLoaderInstrumentationExtensionProvider::class.java)
+    }
+
     @Test
     fun findDataLoaders() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloFetcher", ExampleBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -58,7 +65,6 @@ class DgsDataLoaderProviderTest {
     fun findDataLoadersFromFields() {
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", ExampleBatchLoaderFromField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -75,7 +81,6 @@ class DgsDataLoaderProviderTest {
     fun findMappedDataLoaders() {
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(Pair("helloFetcher", ExampleMappedBatchLoader()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()
@@ -89,7 +94,6 @@ class DgsDataLoaderProviderTest {
     fun findMappedDataLoadersFromFields() {
         every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("helloFetcher", ExampleMappedBatchLoaderFromField()))
-        every { applicationContextMock.getBean(DataLoaderInstrumentationExtensionProvider::class.java) } throws NoSuchBeanDefinitionException(DataLoaderInstrumentationExtensionProvider::class.java)
 
         val provider = DgsDataLoaderProvider(applicationContextMock)
         provider.findDataLoaders()

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithContext.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithContext.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.BatchLoaderEnvironment
+import org.dataloader.BatchLoaderWithContext
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader(name = "exampleLoaderWithContext")
+class ExampleBatchLoaderWithContext : BatchLoaderWithContext<String, String> {
+    override fun load(keys: List<String>?, env: BatchLoaderEnvironment): CompletionStage<List<String>> {
+        return CompletableFuture.supplyAsync { keys?.map { it.toUpperCase() } }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithContext.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithContext.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.BatchLoaderEnvironment
+import org.dataloader.MappedBatchLoaderWithContext
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader(name = "exampleMappedLoaderWithContext")
+class ExampleMappedBatchLoaderWithContext : MappedBatchLoaderWithContext<String, String> {
+    override fun load(keys: MutableSet<String>?, env: BatchLoaderEnvironment): CompletionStage<MutableMap<String, String>> {
+        return CompletableFuture.supplyAsync {
+            val result = mutableMapOf<String, String>()
+            keys?.forEach { result[it] = it.toUpperCase() }
+            result
+        }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/MultiDataLoaderInstrumentationProvidersProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/MultiDataLoaderInstrumentationProvidersProviderTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import com.netflix.graphql.dgs.DataLoaderInstrumentationExtensionProvider
+import com.netflix.graphql.dgs.ExampleBatchLoader
+import com.netflix.graphql.dgs.ExampleBatchLoaderWithContext
+import com.netflix.graphql.dgs.ExampleMappedBatchLoader
+import com.netflix.graphql.dgs.ExampleMappedBatchLoaderWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.dataloader.BatchLoader
+import org.dataloader.BatchLoaderWithContext
+import org.dataloader.MappedBatchLoader
+import org.dataloader.MappedBatchLoaderWithContext
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+
+@SpringBootTest(classes = [MultiDataLoaderInstrumentationProvidersProviderTest.TestLocalConfiguration::class])
+internal class MultiDataLoaderInstrumentationProvidersProviderTest {
+
+    @Autowired
+    lateinit var testAcc: MultiValueMap<String, String>
+
+    @Autowired
+    lateinit var dgsDataLoaderProvider: DgsDataLoaderProvider
+
+    private val expectedAppliedOrder = listOf("head", "mid", "tail")
+
+    @Test
+    fun `Support multiple ordered DataLoaderInstrumentationExtensionProviders`() {
+        val buildRegistry = dgsDataLoaderProvider.buildRegistry()
+
+        assertThat(buildRegistry.dataLoaders).hasSize(4)
+
+        assertThat(testAcc["exampleLoader"]).containsExactlyElementsOf(expectedAppliedOrder)
+        assertThat(testAcc["exampleLoaderWithContext"]).containsExactlyElementsOf(expectedAppliedOrder)
+        assertThat(testAcc["exampleMappedLoader"]).containsExactlyElementsOf(expectedAppliedOrder)
+        assertThat(testAcc["exampleMappedLoaderWithContext"]).containsExactlyElementsOf(expectedAppliedOrder)
+    }
+
+    @Order(100)
+    class HeadDataLoaderInstrumentationExtensionProvider(acc: MultiValueMap<String, String>) :
+        BaseDataLoaderInstrumentationExtensionProvider(acc, "head")
+
+    @Order(200)
+    class MidDataLoaderInstrumentationExtensionProvider(acc: MultiValueMap<String, String>) :
+        BaseDataLoaderInstrumentationExtensionProvider(acc, "mid")
+
+    @Order(300)
+    class TailDataLoaderInstrumentationExtensionProvider(acc: MultiValueMap<String, String>) :
+        BaseDataLoaderInstrumentationExtensionProvider(acc, "tail")
+
+    @Configuration
+    open class TestLocalConfiguration {
+
+        @Bean
+        open fun testAcc(): MultiValueMap<String, String> {
+            return LinkedMultiValueMap()
+        }
+
+        @Bean
+        open fun exampleBatchLoader(): ExampleBatchLoader {
+            return ExampleBatchLoader()
+        }
+
+        @Bean
+        open fun exampleBatchLoaderWithContext(): ExampleBatchLoaderWithContext {
+            return ExampleBatchLoaderWithContext()
+        }
+
+        @Bean
+        open fun exampleMappedBatchLoader(): ExampleMappedBatchLoader {
+            return ExampleMappedBatchLoader()
+        }
+
+        @Bean
+        open fun exampleMappedBatchLoaderWithContext(): ExampleMappedBatchLoaderWithContext {
+            return ExampleMappedBatchLoaderWithContext()
+        }
+
+        @Bean
+        open fun headDataLoaderInstrumentationExtensionProvider(
+            acc: MultiValueMap<String, String>
+        ): DataLoaderInstrumentationExtensionProvider {
+            return HeadDataLoaderInstrumentationExtensionProvider(acc)
+        }
+
+        @Bean
+        open fun midDataLoaderInstrumentationExtensionProvider(
+            acc: MultiValueMap<String, String>
+        ): DataLoaderInstrumentationExtensionProvider {
+            return MidDataLoaderInstrumentationExtensionProvider(acc)
+        }
+
+        @Bean
+        open fun tailDataLoaderInstrumentationExtensionProvider(
+            acc: MultiValueMap<String, String>
+        ): DataLoaderInstrumentationExtensionProvider {
+            return TailDataLoaderInstrumentationExtensionProvider(acc)
+        }
+
+        @Bean
+        open fun dgsDataLoaderProvider(applicationContext: ApplicationContext): DgsDataLoaderProvider {
+            return DgsDataLoaderProvider(applicationContext)
+        }
+    }
+
+    abstract class BaseDataLoaderInstrumentationExtensionProvider(
+        private val acc: MultiValueMap<String, String>,
+        private val value: String
+    ) : DataLoaderInstrumentationExtensionProvider {
+        override fun provide(original: BatchLoader<*, *>, name: String): BatchLoader<*, *> {
+            acc.add(name, value)
+            return original
+        }
+
+        override fun provide(original: BatchLoaderWithContext<*, *>, name: String): BatchLoaderWithContext<*, *> {
+            acc.add(name, value)
+            return original
+        }
+
+        override fun provide(original: MappedBatchLoader<*, *>, name: String): MappedBatchLoader<*, *> {
+            acc.add(name, value)
+            return original
+        }
+
+        override fun provide(
+            original: MappedBatchLoaderWithContext<*, *>,
+            name: String
+        ): MappedBatchLoaderWithContext<*, *> {
+            acc.add(name, value)
+            return original
+        }
+    }
+}


### PR DESCRIPTION
We are adding support for multiple `DataLoaderInstrumentationExtensionProvider` such that developers can define them to cover specific concerns. We are also fetching the beans of such type with an `orderedStream` such that we can control the order of application.