### PR TITLE
[Coarse Grained Approach] Replace path properties with @ConfigurationProperties

### DIFF
--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -314,6 +314,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -418,6 +419,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -686,6 +693,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
@@ -793,6 +801,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [

--- a/graphql-dgs-graphiql-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-graphiql-autoconfigure/build.gradle.kts
@@ -21,5 +21,4 @@ dependencies {
     implementation(project(":graphql-dgs"))
 
     testImplementation("org.springframework.boot:spring-boot-starter-web")
-    testImplementation("org.springframework.boot:spring-boot-starter-web")
 }

--- a/graphql-dgs-graphiql-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-graphiql-autoconfigure/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework:spring-webmvc")
     implementation("jakarta.servlet:jakarta.servlet-api")
+    implementation(project(":graphql-dgs"))
 
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-web")

--- a/graphql-dgs-graphiql-autoconfigure/dependencies.lock
+++ b/graphql-dgs-graphiql-autoconfigure/dependencies.lock
@@ -26,10 +26,44 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "16.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.5.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
             "locked": "1.4.31"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
@@ -175,14 +209,84 @@
         }
     },
     "runtimeClasspath": {
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "0.6.3"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.11.4"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.11.4"
+        },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
+        },
+        "com.github.javafaker:javafaker": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.0.2"
+        },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "16.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.5.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
             "locked": "1.4.31"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
@@ -196,7 +300,25 @@
         "org.springframework.security:spring-security-bom": {
             "locked": "5.3.6.RELEASE"
         },
+        "org.springframework.security:spring-security-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
+        },
         "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        },
+        "org.springframework:spring-web": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
             "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-webmvc": {
@@ -224,6 +346,35 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "16.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.5.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
         "io.mockk:mockk": {
             "locked": "1.10.3-jdk8"
         },
@@ -231,6 +382,11 @@
             "locked": "4.0.4"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
             "locked": "1.4.31"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
@@ -259,8 +415,61 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "0.6.3"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.11.4"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.11.4"
+        },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
+        },
+        "com.github.javafaker:javafaker": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.0.2"
+        },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "16.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.5.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
         },
         "io.mockk:mockk": {
             "locked": "1.10.3-jdk8"
@@ -269,7 +478,24 @@
             "locked": "4.0.4"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
             "locked": "1.4.31"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
@@ -289,7 +515,25 @@
         "org.springframework.security:spring-security-bom": {
             "locked": "5.3.6.RELEASE"
         },
+        "org.springframework.security:spring-security-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
+        },
         "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        },
+        "org.springframework:spring-web": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
             "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-webmvc": {

--- a/graphql-dgs-graphiql-autoconfigure/src/main/java/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLConfigurer.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/main/java/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLConfigurer.kt
@@ -16,8 +16,9 @@
 
 package com.netflix.graphql.dgs.graphiql.autoconfiguration
 
+import com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties
 import com.netflix.graphql.dgs.graphiql.autoconfiguration.GraphiQLConfigurer.Constants.PATH_TO_GRAPHIQL_INDEX_HTML
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.Resource
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
@@ -33,10 +34,10 @@ import java.nio.charset.StandardCharsets.UTF_8
 import javax.servlet.http.HttpServletRequest
 
 @Configuration
+@EnableConfigurationProperties(DgsGraphQLConfigurationProperties::class)
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
 open class GraphiQLConfigurer(
-    @Value("\${dgs.graphql.graphiql.path:/graphiql}") private val graphiqlPath: String,
-    @Value("\${dgs.graphql.path:/graphql}") private val graphqlPath: String
+    private val dgsConfigProps: DgsGraphQLConfigurationProperties
 ) : WebMvcConfigurer {
 
     object Constants {
@@ -44,8 +45,8 @@ open class GraphiQLConfigurer(
     }
 
     override fun addViewControllers(registry: ViewControllerRegistry) {
-        registry.addViewController(graphiqlPath).setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
-        registry.addViewController("$graphiqlPath/").setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
+        registry.addViewController(dgsConfigProps.graphiql.path).setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
+        registry.addViewController("${dgsConfigProps.graphiql.path}/").setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
     }
 
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
@@ -55,7 +56,7 @@ open class GraphiQLConfigurer(
             .setCachePeriod(3600)
             .resourceChain(true)
             .addResolver(PathResourceResolver())
-            .addTransformer(TokenReplacingTransformer("<DGS_GRAPHQL_PATH>", graphqlPath))
+            .addTransformer(TokenReplacingTransformer("<DGS_GRAPHQL_PATH>", dgsConfigProps.path))
     }
 
     class TokenReplacingTransformer(private val replaceToken: String, private val replaceValue: String) :

--- a/graphql-dgs-graphiql-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-graphiql-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -5,12 +5,6 @@
       "type": "java.lang.Boolean",
       "description": "Enables GraphiQL functionality.",
       "defaultValue": "true"
-    },
-    {
-      "name": "dgs.graphql.graphiql.path",
-      "type": "java.lang.String",
-      "description": "Path to the GraphiQL endpoint without trailing slash.",
-      "defaultValue": "/graphiql"
     }
   ]
 }

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -341,6 +341,12 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -568,6 +574,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
@@ -668,6 +675,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "2.3.6.RELEASE"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -296,6 +296,12 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -507,6 +513,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -302,6 +302,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
@@ -376,6 +377,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -618,6 +625,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
@@ -695,6 +703,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -299,6 +299,12 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -532,6 +538,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoconfiguration.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoconfiguration.kt
@@ -16,17 +16,20 @@
 
 package com.netflix.graphql.dgs.webmvc.autoconfigure
 
+import com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.dgs.mvc.DgsRestController
 import com.netflix.graphql.dgs.mvc.DgsRestSchemaJsonController
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ConditionalOnWebApplication
+@EnableConfigurationProperties(DgsGraphQLConfigurationProperties::class)
 open class DgsWebMvcAutoconfiguration {
     @Bean
     open fun dgsRestController(dgsQueryExecutor: DgsQueryExecutor): DgsRestController {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,22 +1,10 @@
 {
   "properties": [
     {
-      "name": "dgs.graphql.path",
-      "type": "java.lang.String",
-      "description": "Path to the GraphQL endpoint without trailing slash.",
-      "defaultValue": "/graphql"
-    },
-    {
       "name": "dgs.graphql.schema-json.enabled",
       "type": "java.lang.Boolean",
       "description": "Enables schema-json endpoint functionality.",
       "defaultValue": "true"
-    },
-    {
-      "name": "dgs.graphql.schema-json.path",
-      "type": "java.lang.String",
-      "description": "Path to the schema-json endpoint without trailing slash.",
-      "defaultValue": "/schema.json"
     }
   ]
 }

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -282,6 +282,12 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -475,6 +481,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -63,9 +63,11 @@ import org.springframework.web.multipart.MultipartFile
 
 @RestController
 class DgsRestController(private val dgsQueryExecutor: DgsQueryExecutor) {
+
     val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
 
-    @RequestMapping("\${dgs.graphql.path:/graphql}", produces = ["application/json"])
+    // The @ConfigurationProperties bean name is <prefix>-<fqcn>
+    @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties'.path}", produces = ["application/json"])
     fun graphql(
         @RequestBody body: String?,
         @RequestParam fileParams: Map<String, MultipartFile>?,

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
@@ -32,7 +32,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class DgsRestSchemaJsonController(private val schemaProvider: DgsSchemaProvider) {
 
-    @RequestMapping("\${dgs.graphql.schema-json.path:/schema.json}", produces = ["application/json"])
+    // The @ConfigurationProperties bean name is <prefix>-<fqcn>
+    @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties'.schemaJson.path}", produces = ["application/json"])
     fun schema(): String {
         val mapper = jacksonObjectMapper()
 

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -291,6 +291,12 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
         },
@@ -503,6 +509,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -279,6 +279,12 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -478,6 +484,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -288,6 +288,12 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
@@ -500,6 +506,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -282,6 +282,12 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
         },
@@ -487,6 +493,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     implementation("org.springframework:spring-web")
     implementation("org.springframework:spring-context")
+    implementation("org.springframework.boot:spring-boot")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -58,6 +58,9 @@
             ],
             "locked": "1.4.31"
         },
+        "org.springframework.boot:spring-boot": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -251,6 +254,9 @@
             ],
             "locked": "1.7.30"
         },
+        "org.springframework.boot:spring-boot": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -332,6 +338,9 @@
             ],
             "locked": "1.4.31"
         },
+        "org.springframework.boot:spring-boot": {
+            "locked": "2.3.6.RELEASE"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"
         },
@@ -410,6 +419,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
             "locked": "1.7.30"
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.6.RELEASE"

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationProperties.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationProperties.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.bind.DefaultValue
+import org.springframework.validation.annotation.Validated
+
+/**
+ * Configuration properties for DGS.
+ */
+@ConstructorBinding
+@ConfigurationProperties(prefix = "dgs.graphql")
+@Validated
+@Suppress("ConfigurationProperties")
+data class DgsGraphQLConfigurationProperties(
+    /** Path to the GraphQL endpoint without trailing slash. */
+    @DefaultValue("/graphql") val path: String,
+    @DefaultValue val graphiql: DgsGraphiQLConfigurationProperties,
+    @DefaultValue val schemaJson: DgsSchemaJsonConfigurationProperties
+) {
+    /**
+     * Configuration properties for GraphiQL.
+     */
+    data class DgsGraphiQLConfigurationProperties(
+        /** Path to the GraphiQL endpoint without trailing slash. */
+        @DefaultValue("/graphiql") val path: String
+    )
+
+    /**
+     * Configuration properties for the schema-json endpoint.
+     */
+    data class DgsSchemaJsonConfigurationProperties(
+        /** Path to the schema-json endpoint without trailing slash. */
+        @DefaultValue("/schema.json") val path: String
+    )
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationProperties.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationProperties.kt
@@ -19,14 +19,12 @@ package com.netflix.graphql.dgs
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.bind.DefaultValue
-import org.springframework.validation.annotation.Validated
 
 /**
  * Configuration properties for DGS.
  */
 @ConstructorBinding
 @ConfigurationProperties(prefix = "dgs.graphql")
-@Validated
 @Suppress("ConfigurationProperties")
 data class DgsGraphQLConfigurationProperties(
     /** Path to the GraphQL endpoint without trailing slash. */

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationPropertiesTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsGraphQLConfigurationPropertiesTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+import java.util.*
+
+class DgsGraphQLConfigurationPropertiesTest {
+
+    @Test
+    fun graphQLPathDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.path).isEqualTo("/graphql")
+    }
+
+    @Test
+    fun graphQLPathCustom() {
+        val properties = bind("dgs.graphql.path", "/private/gql")
+        Assertions.assertThat(properties.path).isEqualTo("/private/gql")
+    }
+
+    @Test
+    fun graphiQLPathDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.graphiql.path).isEqualTo("/graphiql")
+    }
+
+    @Test
+    fun graphiQLPathCustom() {
+        val properties = bind("dgs.graphql.graphiql.path", "/private/giql")
+        Assertions.assertThat(properties.graphiql.path).isEqualTo("/private/giql")
+    }
+
+    @Test
+    fun schemaJsonPathDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/schema.json")
+    }
+
+    @Test
+    fun schemaJsonPathCustom() {
+        val properties = bind("dgs.graphql.schema-json.path", "/private/schema.json")
+        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/private/schema.json")
+    }
+
+    @Test
+    fun allCustomPathsSpecified() {
+        val propertyValues: MutableMap<String?, String?> = HashMap()
+        propertyValues["dgs.graphql.path"] = "/private/gql"
+        propertyValues["dgs.graphql.graphiql.path"] = "/private/giql"
+        propertyValues["dgs.graphql.schema-json.path"] = "/private/sj"
+        val properties = bind(propertyValues)
+        Assertions.assertThat(properties.path).isEqualTo("/private/gql")
+        Assertions.assertThat(properties.graphiql.path).isEqualTo("/private/giql")
+        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/private/sj")
+    }
+
+    private fun bind(name: String, value: String): DgsGraphQLConfigurationProperties {
+        return bind(Collections.singletonMap(name, value))
+    }
+
+    private fun bind(map: Map<String?, String?>): DgsGraphQLConfigurationProperties {
+        val source: ConfigurationPropertySource = MapConfigurationPropertySource(map)
+        return Binder(source).bindOrCreate("dgs.graphql", DgsGraphQLConfigurationProperties::class.java)
+    }
+}


### PR DESCRIPTION
Fixes gh-128

Creates config props to handle:
* GraphQL path
* GraphiQL path
* schema-json path

### Verification

I added tests for the config props as well as verified the generated metadata file. 

```/Users/cbono/indeed/dgs-framework/graphql-dgs/build/tmp/kapt3/classes/main/META-INF/spring-configuration-metadata.json```
```
{
  "groups": [
    {
      "name": "dgs.graphql",
      "type": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties",
      "sourceType": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties"
    },
    {
      "name": "dgs.graphql.graphiql",
      "type": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties$DgsGraphiQLConfigurationProperties",
      "sourceType": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties",
      "sourceMethod": "getGraphiql()"
    },
    {
      "name": "dgs.graphql.schema-json",
      "type": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties$DgsSchemaJsonConfigurationProperties",
      "sourceType": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties",
      "sourceMethod": "getSchemaJson()"
    }
  ],
  "properties": [
    {
      "name": "dgs.graphql.graphiql.path",
      "type": "java.lang.String",
      "description": "Path to the GraphiQL endpoint without trailing slash.",
      "sourceType": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties$DgsGraphiQLConfigurationProperties",
      "defaultValue": "\/graphiql"
    },
    {
      "name": "dgs.graphql.path",
      "type": "java.lang.String",
      "description": "Path to the GraphQL endpoint without trailing slash.",
      "sourceType": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties",
      "defaultValue": "\/graphql"
    },
    {
      "name": "dgs.graphql.schema-json.path",
      "type": "java.lang.String",
      "description": "Path to the schema-json endpoint without trailing slash.",
      "sourceType": "com.netflix.graphql.dgs.DgsGraphQLConfigurationProperties$DgsSchemaJsonConfigurationProperties",
      "defaultValue": "\/schema.json"
    }
  ],
  "hints": []
}
```



### TODO
Tomorrow I will add validation to the config props for the paths (valid URI that starts w/ a slash but does not end w/ a slash). 

My current plan is to inline the ` implements Validator` on the config props and do the manual validation there. 

Long term we may want to consider the more solid, heavier approach of [bean validation 2.0](https://beanvalidation.org/2.0/)  via 
```java
org.hibernate.validator:hibernate-validator:6.2.0.Final
jakarta.validation:jakarta.validation-api:2.0.2
```
which would give us rich declarative validation w/ all of [these constraints](https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/). 

ℹ️ note that `hibernate-validator` brings ZERO of the persistence aspect of HB8 into the classpath. 
Nonetheless the validation we need right now does not warrant adding these deps at this time IMO.
