### PR TITLE
[Fine Grained Approach] Replace path properties with @ConfigurationProperties

### DIFF
--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -358,6 +358,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
             "project": true
@@ -730,6 +731,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
             "project": true

--- a/graphql-dgs-graphiql-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-graphiql-autoconfigure/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework:spring-webmvc")
     implementation("jakarta.servlet:jakarta.servlet-api")
+    implementation(project(":graphql-dgs-spring-webmvc-autoconfigure"))
 
-    testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
 }

--- a/graphql-dgs-graphiql-autoconfigure/dependencies.lock
+++ b/graphql-dgs-graphiql-autoconfigure/dependencies.lock
@@ -26,10 +26,60 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "16.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.5.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "project": true
+        },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
             "locked": "1.4.31"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
@@ -175,19 +225,112 @@
         }
     },
     "runtimeClasspath": {
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "0.6.3"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.11.4"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.11.4"
+        },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
+        },
+        "com.github.javafaker:javafaker": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.0.2"
+        },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "16.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.5.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "project": true
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
             "locked": "1.4.31"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "1.4.31"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.7.30"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
             "locked": "2.3.6.RELEASE"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
@@ -196,7 +339,27 @@
         "org.springframework.security:spring-security-bom": {
             "locked": "5.3.6.RELEASE"
         },
+        "org.springframework.security:spring-security-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
+        },
         "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        },
+        "org.springframework:spring-web": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
             "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-webmvc": {
@@ -224,6 +387,49 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
         },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "16.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.5.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "project": true
+        },
         "io.mockk:mockk": {
             "locked": "1.10.3-jdk8"
         },
@@ -231,6 +437,13 @@
             "locked": "4.0.4"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
             "locked": "1.4.31"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
@@ -259,8 +472,76 @@
         }
     },
     "testRuntimeClasspath": {
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "0.6.3"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.11.4"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.11.4"
+        },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
+        },
+        "com.github.javafaker:javafaker": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.0.2"
+        },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "16.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.5.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "project": true
         },
         "io.mockk:mockk": {
             "locked": "1.10.3-jdk8"
@@ -268,13 +549,38 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
             "locked": "1.4.31"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "1.4.31"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.7.30"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "2.3.6.RELEASE"
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
             "locked": "2.3.6.RELEASE"
         },
         "org.springframework.boot:spring-boot-starter-test": {
@@ -289,7 +595,27 @@
         "org.springframework.security:spring-security-bom": {
             "locked": "5.3.6.RELEASE"
         },
+        "org.springframework.security:spring-security-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.3.6.RELEASE"
+        },
+        "org.springframework:spring-context": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "5.2.12.RELEASE"
+        },
         "org.springframework:spring-framework-bom": {
+            "locked": "5.2.12.RELEASE"
+        },
+        "org.springframework:spring-web": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
             "locked": "5.2.12.RELEASE"
         },
         "org.springframework:spring-webmvc": {

--- a/graphql-dgs-graphiql-autoconfigure/src/main/java/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLConfigurationProperties.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/main/java/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLConfigurationProperties.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.graphiql.autoconfiguration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+/**
+ * Configuration properties for DGS GraphiQL.
+ */
+@ConstructorBinding
+@ConfigurationProperties(prefix = "dgs.graphql.graphiql")
+@Suppress("ConfigurationProperties")
+data class GraphiQLConfigurationProperties(
+    /** Path to the GraphiQL endpoint without trailing slash. */
+    @DefaultValue("/graphiql") val path: String
+)

--- a/graphql-dgs-graphiql-autoconfigure/src/main/java/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLConfigurer.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/main/java/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLConfigurer.kt
@@ -17,7 +17,8 @@
 package com.netflix.graphql.dgs.graphiql.autoconfiguration
 
 import com.netflix.graphql.dgs.graphiql.autoconfiguration.GraphiQLConfigurer.Constants.PATH_TO_GRAPHIQL_INDEX_HTML
-import org.springframework.beans.factory.annotation.Value
+import com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.Resource
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
@@ -33,10 +34,11 @@ import java.nio.charset.StandardCharsets.UTF_8
 import javax.servlet.http.HttpServletRequest
 
 @Configuration
+@EnableConfigurationProperties(value = [ GraphiQLConfigurationProperties::class, DgsWebMvcConfigurationProperties::class ])
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
 open class GraphiQLConfigurer(
-    @Value("\${dgs.graphql.graphiql.path:/graphiql}") private val graphiqlPath: String,
-    @Value("\${dgs.graphql.path:/graphql}") private val graphqlPath: String
+    private val graphiqlConfigProps: GraphiQLConfigurationProperties,
+    private val dgsWebMvcConfigProps: DgsWebMvcConfigurationProperties
 ) : WebMvcConfigurer {
 
     object Constants {
@@ -44,8 +46,8 @@ open class GraphiQLConfigurer(
     }
 
     override fun addViewControllers(registry: ViewControllerRegistry) {
-        registry.addViewController(graphiqlPath).setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
-        registry.addViewController("$graphiqlPath/").setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
+        registry.addViewController(graphiqlConfigProps.path).setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
+        registry.addViewController("${graphiqlConfigProps.path}/").setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
     }
 
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
@@ -55,7 +57,7 @@ open class GraphiQLConfigurer(
             .setCachePeriod(3600)
             .resourceChain(true)
             .addResolver(PathResourceResolver())
-            .addTransformer(TokenReplacingTransformer("<DGS_GRAPHQL_PATH>", graphqlPath))
+            .addTransformer(TokenReplacingTransformer("<DGS_GRAPHQL_PATH>", dgsWebMvcConfigProps.path))
     }
 
     class TokenReplacingTransformer(private val replaceToken: String, private val replaceValue: String) :

--- a/graphql-dgs-graphiql-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-graphiql-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -5,12 +5,6 @@
       "type": "java.lang.Boolean",
       "description": "Enables GraphiQL functionality.",
       "defaultValue": "true"
-    },
-    {
-      "name": "dgs.graphql.graphiql.path",
-      "type": "java.lang.String",
-      "description": "Path to the GraphiQL endpoint without trailing slash.",
-      "defaultValue": "/graphiql"
     }
   ]
 }

--- a/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLConfigurationPropertiesTest.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLConfigurationPropertiesTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.graphiql.autoconfiguration
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+import java.util.*
+
+class GraphiQLConfigurationPropertiesTest {
+
+    @Test
+    fun graphiQLPathDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.path).isEqualTo("/graphiql")
+    }
+
+    @Test
+    fun graphiQLPathCustom() {
+        val properties = bind("dgs.graphql.graphiql.path", "/private/giql")
+        Assertions.assertThat(properties.path).isEqualTo("/private/giql")
+    }
+
+    private fun bind(name: String, value: String): GraphiQLConfigurationProperties {
+        return bind(Collections.singletonMap(name, value))
+    }
+
+    private fun bind(map: Map<String?, String?>): GraphiQLConfigurationProperties {
+        val source: ConfigurationPropertySource = MapConfigurationPropertySource(map)
+        return Binder(source).bindOrCreate("dgs.graphql.graphiql", GraphiQLConfigurationProperties::class.java)
+    }
+}

--- a/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigCustomGraphQLPathTest.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigCustomGraphQLPathTest.kt
@@ -16,13 +16,12 @@
 
 package com.netflix.graphql.dgs.graphiql.autoconfiguration
 
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.context.annotation.Configuration
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -37,10 +36,6 @@ class GraphiQLPathConfigCustomGraphQLPathTest(@Autowired val restTemplate: TestR
             String::class.java
         )
         assertTrue(entity.statusCode.is2xxSuccessful)
-        assertTrue(entity.body.contains("fetch('/zuzu'"))
+        Assertions.assertThat(entity.body).isNotNull.contains("fetch('/zuzu'")
     }
-
-    @SpringBootApplication
-    @Configuration
-    open class MockAutoConfiguration
 }

--- a/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigCustomGraphiQLPathTest.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigCustomGraphiQLPathTest.kt
@@ -16,13 +16,12 @@
 
 package com.netflix.graphql.dgs.graphiql.autoconfiguration
 
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.context.annotation.Configuration
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -37,10 +36,6 @@ class GraphiQLPathConfigCustomGraphiQLPathTest(@Autowired val restTemplate: Test
             String::class.java
         )
         assertTrue(entity.statusCode.is2xxSuccessful)
-        assertTrue(entity.body.contains("fetch('/graphql'"))
+        Assertions.assertThat(entity.body).isNotNull.contains("fetch('/graphql'")
     }
-
-    @SpringBootApplication
-    @Configuration
-    open class MockAutoConfiguration
 }

--- a/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigCustomPathsTest.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigCustomPathsTest.kt
@@ -16,13 +16,12 @@
 
 package com.netflix.graphql.dgs.graphiql.autoconfiguration
 
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.context.annotation.Configuration
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -37,10 +36,6 @@ class GraphiQLPathConfigCustomPathsTest(@Autowired val restTemplate: TestRestTem
             String::class.java
         )
         assertTrue(entity.statusCode.is2xxSuccessful)
-        assertTrue(entity.body.contains("fetch('/zuzu'"))
+        Assertions.assertThat(entity.body).isNotNull.contains("fetch('/zuzu'")
     }
-
-    @SpringBootApplication
-    @Configuration
-    open class MockAutoConfiguration
 }

--- a/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigDefaultPathsTest.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigDefaultPathsTest.kt
@@ -16,13 +16,12 @@
 
 package com.netflix.graphql.dgs.graphiql.autoconfiguration
 
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.context.annotation.Configuration
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
@@ -36,10 +35,6 @@ class GraphiQLPathConfigDefaultPathsTest(@Autowired val restTemplate: TestRestTe
             String::class.java
         )
         assertTrue(entity.statusCode.is2xxSuccessful)
-        assertTrue(entity.body.contains("fetch('/graphql'"))
+        Assertions.assertThat(entity.body).isNotNull.contains("fetch('/graphql'")
     }
-
-    @SpringBootApplication
-    @Configuration
-    open class MockAutoConfiguration
 }

--- a/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigTestApplication.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathConfigTestApplication.kt
@@ -22,8 +22,11 @@ import io.mockk.mockk
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
 
+/**
+ * Used indirectly by the 'GraphiQLPathConfig**' tests for configuration.
+ */
 @SpringBootApplication
-open class GraphiQLPathTestApplication {
+open class GraphiQLPathConfigTestApplication {
     @Bean
     open fun dgsSchemaProvider(): DgsSchemaProvider {
         return mockk()

--- a/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathTestApplication.kt
+++ b/graphql-dgs-graphiql-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/graphiql/autoconfiguration/GraphiQLPathTestApplication.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.graphiql.autoconfiguration
+
+import com.netflix.graphql.dgs.DgsQueryExecutor
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import io.mockk.mockk
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Bean
+
+@SpringBootApplication
+open class GraphiQLPathTestApplication {
+    @Bean
+    open fun dgsSchemaProvider(): DgsSchemaProvider {
+        return mockk()
+    }
+
+    @Bean
+    open fun dgsQueryExecutor(): DgsQueryExecutor {
+        return mockk()
+    }
+}

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -610,6 +610,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
             "project": true

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -331,6 +331,9 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure"
+            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {
@@ -647,6 +650,9 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-graphiql-autoconfigure"
+            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoconfiguration.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoconfiguration.kt
@@ -22,11 +22,13 @@ import com.netflix.graphql.dgs.mvc.DgsRestController
 import com.netflix.graphql.dgs.mvc.DgsRestSchemaJsonController
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ConditionalOnWebApplication
+@EnableConfigurationProperties(DgsWebMvcConfigurationProperties::class)
 open class DgsWebMvcAutoconfiguration {
     @Bean
     open fun dgsRestController(dgsQueryExecutor: DgsQueryExecutor): DgsRestController {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.autoconfigure
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+/**
+ * Configuration properties for DGS web controllers.
+ */
+@ConstructorBinding
+@ConfigurationProperties(prefix = "dgs.graphql")
+@Suppress("ConfigurationProperties")
+data class DgsWebMvcConfigurationProperties(
+    /** Path to the GraphQL endpoint without trailing slash. */
+    @DefaultValue("/graphql") val path: String,
+    @DefaultValue val schemaJson: DgsSchemaJsonConfigurationProperties
+) {
+    /**
+     * Configuration properties for the schema-json endpoint.
+     */
+    data class DgsSchemaJsonConfigurationProperties(
+        /** Path to the schema-json endpoint without trailing slash. */
+        @DefaultValue("/schema.json") val path: String
+    )
+}

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,22 +1,10 @@
 {
   "properties": [
     {
-      "name": "dgs.graphql.path",
-      "type": "java.lang.String",
-      "description": "Path to the GraphQL endpoint without trailing slash.",
-      "defaultValue": "/graphql"
-    },
-    {
       "name": "dgs.graphql.schema-json.enabled",
       "type": "java.lang.Boolean",
       "description": "Enables schema-json endpoint functionality.",
       "defaultValue": "true"
-    },
-    {
-      "name": "dgs.graphql.schema-json.path",
-      "type": "java.lang.String",
-      "description": "Path to the schema-json endpoint without trailing slash.",
-      "defaultValue": "/schema.json"
     }
   ]
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfiguration/DgsWebMvcConfigurationPropertiesTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfiguration/DgsWebMvcConfigurationPropertiesTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.autoconfiguration
+
+import com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+import java.util.*
+
+class DgsWebMvcConfigurationPropertiesTest {
+
+    @Test
+    fun graphQLPathDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.path).isEqualTo("/graphql")
+    }
+
+    @Test
+    fun graphQLPathCustom() {
+        val properties = bind("dgs.graphql.path", "/private/gql")
+        Assertions.assertThat(properties.path).isEqualTo("/private/gql")
+    }
+
+    @Test
+    fun schemaJsonPathDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/schema.json")
+    }
+
+    @Test
+    fun schemaJsonPathCustom() {
+        val properties = bind("dgs.graphql.schema-json.path", "/private/schema.json")
+        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/private/schema.json")
+    }
+
+    @Test
+    fun allCustomPathsSpecified() {
+        val propertyValues: MutableMap<String?, String?> = HashMap()
+        propertyValues["dgs.graphql.path"] = "/private/gql"
+        propertyValues["dgs.graphql.schema-json.path"] = "/private/sj"
+        val properties = bind(propertyValues)
+        Assertions.assertThat(properties.path).isEqualTo("/private/gql")
+        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/private/sj")
+    }
+
+    private fun bind(name: String, value: String): DgsWebMvcConfigurationProperties {
+        return bind(Collections.singletonMap(name, value))
+    }
+
+    private fun bind(map: Map<String?, String?>): DgsWebMvcConfigurationProperties {
+        val source: ConfigurationPropertySource = MapConfigurationPropertySource(map)
+        return Binder(source).bindOrCreate("dgs.graphql", DgsWebMvcConfigurationProperties::class.java)
+    }
+}

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -63,9 +63,11 @@ import org.springframework.web.multipart.MultipartFile
 
 @RestController
 class DgsRestController(private val dgsQueryExecutor: DgsQueryExecutor) {
+
     val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
 
-    @RequestMapping("\${dgs.graphql.path:/graphql}", produces = ["application/json"])
+    // The @ConfigurationProperties bean name is <prefix>-<fqn>
+    @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.path}", produces = ["application/json"])
     fun graphql(
         @RequestBody body: String?,
         @RequestParam fileParams: Map<String, MultipartFile>?,

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
@@ -32,7 +32,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class DgsRestSchemaJsonController(private val schemaProvider: DgsSchemaProvider) {
 
-    @RequestMapping("\${dgs.graphql.schema-json.path:/schema.json}", produces = ["application/json"])
+    // The @ConfigurationProperties bean name is <prefix>-<fqn>
+    @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.schemaJson.path}", produces = ["application/json"])
     fun schema(): String {
         val mapper = jacksonObjectMapper()
 


### PR DESCRIPTION
Fixes gh-128

@paulbakker @berngp 

This is the "Fine Grained" approach as described in [this comment](https://github.com/Netflix/dgs-framework/pull/148#discussion_r593825252). 

I like this much better. One thing you will notice is that I had to make graphiql depend on webmvc module. It was either that or duplicate the same property for `dgs.graphql.path` in the graphiql config props. One of the reasons of moving to config props was to not have to specify the defaults in multiple places. 

While the graphiql module did not previously depend on the webmvc module via dependencies, it does depend on the GraphQL controller being available. For this reason it makes me feel that adding a dep to the wembvc module is not that bad. Really I think that the graphiql module should just be merged w/ the webmvc module. Were there other reasons for having them split up? 


