### PR TITLE
Introduced schema-base-dir property for loading graphql(s) schema files

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -53,8 +54,11 @@ import java.util.*
  * This does NOT have logging, tracing, metrics and security integration.
  */
 @Configuration
+@EnableConfigurationProperties(DgsConfigurationProperties::class)
 @ImportAutoConfiguration(classes = [JacksonAutoConfiguration::class])
-open class DgsAutoConfiguration {
+open class DgsAutoConfiguration(
+    private val configProps: DgsConfigurationProperties
+) {
 
     @Bean
     open fun dgsQueryExecutor(
@@ -141,7 +145,7 @@ open class DgsAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     open fun schema(dgsSchemaProvider: DgsSchemaProvider): GraphQLSchema {
-        return dgsSchemaProvider.schema()
+        return dgsSchemaProvider.schema(basedir = configProps.schemaBaseDir)
     }
 
     @Bean

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -28,11 +28,7 @@ import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.dgs.scalars.UploadScalar
 import com.netflix.graphql.mocking.MockProvider
-import graphql.execution.AsyncExecutionStrategy
-import graphql.execution.AsyncSerialExecutionStrategy
-import graphql.execution.DataFetcherExceptionHandler
-import graphql.execution.ExecutionIdProvider
-import graphql.execution.ExecutionStrategy
+import graphql.execution.*
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.schema.GraphQLCodeRegistry
@@ -133,8 +129,13 @@ open class DgsAutoConfiguration(
         existingCodeRegistry: Optional<GraphQLCodeRegistry>,
         mockProviders: Optional<Set<MockProvider>>
     ): DgsSchemaProvider {
-        return DgsSchemaProvider(applicationContext, federationResolver, existingTypeDefinitionFactory, mockProviders,
-            configProps.schemaBaseDir)
+        return DgsSchemaProvider(
+            applicationContext,
+            federationResolver,
+            existingTypeDefinitionFactory,
+            mockProviders,
+            configProps.schemaBaseDir
+        )
     }
 
     @Bean

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -133,7 +133,8 @@ open class DgsAutoConfiguration(
         existingCodeRegistry: Optional<GraphQLCodeRegistry>,
         mockProviders: Optional<Set<MockProvider>>
     ): DgsSchemaProvider {
-        return DgsSchemaProvider(applicationContext, federationResolver, existingTypeDefinitionFactory, mockProviders)
+        return DgsSchemaProvider(applicationContext, federationResolver, existingTypeDefinitionFactory, mockProviders,
+            configProps.schemaBaseDir)
     }
 
     @Bean
@@ -145,7 +146,7 @@ open class DgsAutoConfiguration(
     @Bean
     @ConditionalOnMissingBean
     open fun schema(dgsSchemaProvider: DgsSchemaProvider): GraphQLSchema {
-        return dgsSchemaProvider.schema(basedir = configProps.schemaBaseDir)
+        return dgsSchemaProvider.schema()
     }
 
     @Bean

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+/**
+ * Configuration properties for DGS framework.
+ */
+@ConstructorBinding
+@ConfigurationProperties(prefix = "dgs.graphql")
+@Suppress("ConfigurationProperties")
+data class DgsConfigurationProperties(
+    /** Base dir for the GraphQL schema files without trailing slash. */
+    @DefaultValue("schema") val schemaBaseDir: String
+)

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationPropertiesTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationPropertiesTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+import java.util.*
+
+class DgsConfigurationPropertiesTest {
+
+    @Test
+    fun schemaBaseDirDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.schemaBaseDir).isEqualTo("schema")
+    }
+
+    @Test
+    fun schemaBaseDirCustom() {
+        val properties = bind("dgs.graphql.schema-base-dir", "graphql")
+        Assertions.assertThat(properties.schemaBaseDir).isEqualTo("graphql")
+    }
+
+    private fun bind(name: String, value: String): DgsConfigurationProperties {
+        return bind(Collections.singletonMap(name, value))
+    }
+
+    private fun bind(map: Map<String?, String?>): DgsConfigurationProperties {
+        val source: ConfigurationPropertySource = MapConfigurationPropertySource(map)
+        return Binder(source).bindOrCreate("dgs.graphql", DgsConfigurationProperties::class.java)
+    }
+}

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
@@ -17,7 +17,6 @@
 package com.netflix.graphql.dgs.mvc
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
@@ -30,14 +29,13 @@ import org.springframework.web.bind.annotation.RestController
  * Provides an HTTP endpoint to retrieve the available schema.
  */
 @RestController
-class DgsRestSchemaJsonController(private val schemaProvider: DgsSchemaProvider) {
+class DgsRestSchemaJsonController(private val graphQLSchema: GraphQLSchema) {
 
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
     @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.schemaJson.path}", produces = ["application/json"])
     fun schema(): String {
         val mapper = jacksonObjectMapper()
 
-        val graphQLSchema: GraphQLSchema = schemaProvider.schema()
         val graphQL = GraphQL.newGraphQL(graphQLSchema).build()
 
         val executionInput: ExecutionInput = ExecutionInput.newExecutionInput().query(IntrospectionQuery.INTROSPECTION_QUERY)

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.mvc
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
@@ -29,13 +30,14 @@ import org.springframework.web.bind.annotation.RestController
  * Provides an HTTP endpoint to retrieve the available schema.
  */
 @RestController
-class DgsRestSchemaJsonController(private val graphQLSchema: GraphQLSchema) {
+class DgsRestSchemaJsonController(private val schemaProvider: DgsSchemaProvider) {
 
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
     @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.schemaJson.path}", produces = ["application/json"])
     fun schema(): String {
         val mapper = jacksonObjectMapper()
 
+        val graphQLSchema: GraphQLSchema = schemaProvider.schema()
         val graphQL = GraphQL.newGraphQL(graphQLSchema).build()
 
         val executionInput: ExecutionInput = ExecutionInput.newExecutionInput().query(IntrospectionQuery.INTROSPECTION_QUERY)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -69,13 +69,13 @@ class DgsSchemaProvider(
 
     private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
 
-    fun schema(schema: String? = null): GraphQLSchema {
+    fun schema(schema: String? = null, basedir: String = "schema"): GraphQLSchema {
         val startTime = System.currentTimeMillis()
         val dgsComponents = applicationContext.getBeansWithAnnotation(DgsComponent::class.java)
         val hasDynamicTypeRegistry = dgsComponents.values.any { it.javaClass.methods.any { m -> m.isAnnotationPresent(DgsTypeDefinitionRegistry::class.java) } }
 
         var mergedRegistry = if (schema == null) {
-            findSchemaFiles(hasDynamicTypeRegistry = hasDynamicTypeRegistry).map {
+            findSchemaFiles(basedir = basedir, hasDynamicTypeRegistry = hasDynamicTypeRegistry).map {
                 InputStreamReader(it.inputStream, StandardCharsets.UTF_8).use { reader -> SchemaParser().parse(reader) }
             }.fold(TypeDefinitionRegistry()) { a, b -> a.merge(b) }
         } else {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -59,7 +59,8 @@ class DgsSchemaProvider(
     private val applicationContext: ApplicationContext,
     private val federationResolver: Optional<DgsFederationResolver>,
     private val existingTypeDefinitionRegistry: Optional<TypeDefinitionRegistry>,
-    private val mockProviders: Optional<Set<MockProvider>>
+    private val mockProviders: Optional<Set<MockProvider>>,
+    private val basedir: String = "schema"
 ) {
 
     val dataFetcherInstrumentationEnabled = mutableMapOf<String, Boolean>()
@@ -69,7 +70,7 @@ class DgsSchemaProvider(
 
     private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
 
-    fun schema(schema: String? = null, basedir: String = "schema"): GraphQLSchema {
+    fun schema(schema: String? = null): GraphQLSchema {
         val startTime = System.currentTimeMillis()
         val dgsComponents = applicationContext.getBeansWithAnnotation(DgsComponent::class.java)
         val hasDynamicTypeRegistry = dgsComponents.values.any { it.javaClass.methods.any { m -> m.isAnnotationPresent(DgsTypeDefinitionRegistry::class.java) } }


### PR DESCRIPTION
PR for #141 

~~Note I also changed `DgsRestSchemaJsonController.kt` to re-use the schema as it was now creating another `GraphQLSchema` instance.~~
