### PR TITLE
The gql.field tag should express the internal field and not the alias.

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentationUtils.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentationUtils.kt
@@ -37,7 +37,7 @@ internal object DgsGraphQLMetricsInstrumentationUtils {
             type as GraphQLObjectType
         }
 
-        return "${parentType.name}.${parameters.executionStepInfo.path.segmentName}"
+        return "${parentType.name}.${parameters.executionStepInfo.field.singleField.name}"
     }
 
     fun shouldIgnoreTag(tag: String): Boolean {

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -91,11 +91,13 @@ class MicrometerServletSmokeTest {
     @Test
     fun `Metrics for a successful request`() {
         mvc.perform(
+            // Note that the query below uses an aliased field, aliasing `ping` to `not_ping`.
+            // We will also assert that the tag reflected by the metric is not affected by the alias.
             MockMvcRequestBuilders
                 .post("/graphql")
-                .content("""{ "query": "{ping}" }""")
+                .content("""{ "query": "{not_ping: ping}" }""")
         ).andExpect(status().isOk)
-            .andExpect(content().json("""{"data":{"ping":"pong"}}""", false))
+            .andExpect(content().json("""{"data":{"not_ping":"pong"}}""", false))
 
         val meters = fetchMeters()
 


### PR DESCRIPTION
This commit resolves the name of the `gql.field` using the actual _field name_ instead of the name provided by the _client_, which can include a field alias.

Fixes #167 .
