### PR TITLE
Added new interface DgsCustomContextBuilderWithRequest

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -20,6 +20,7 @@ import com.netflix.graphql.dgs.DgsContextBuilder
 import com.netflix.graphql.dgs.DgsFederationResolver
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilder
+import com.netflix.graphql.dgs.context.DgsCustomContextBuilderWithRequest
 import com.netflix.graphql.dgs.exceptions.DefaultDataFetcherExceptionHandler
 import com.netflix.graphql.dgs.internal.DefaultDgsGraphQLContextBuilder
 import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
@@ -28,11 +29,7 @@ import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.dgs.scalars.UploadScalar
 import com.netflix.graphql.mocking.MockProvider
-import graphql.execution.AsyncExecutionStrategy
-import graphql.execution.AsyncSerialExecutionStrategy
-import graphql.execution.DataFetcherExceptionHandler
-import graphql.execution.ExecutionIdProvider
-import graphql.execution.ExecutionStrategy
+import graphql.execution.*
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.schema.GraphQLCodeRegistry
@@ -146,8 +143,11 @@ open class DgsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    open fun graphQLContextBuilder(dgsCustomContextBuilder: Optional<DgsCustomContextBuilder<*>>): DgsContextBuilder {
-        return DefaultDgsGraphQLContextBuilder(dgsCustomContextBuilder)
+    open fun graphQLContextBuilder(
+        dgsCustomContextBuilder: Optional<DgsCustomContextBuilder<*>>,
+        dgsCustomContextBuilderWithRequest: Optional<DgsCustomContextBuilderWithRequest<*>>
+    ): DgsContextBuilder {
+        return DefaultDgsGraphQLContextBuilder(dgsCustomContextBuilder, dgsCustomContextBuilderWithRequest)
     }
 
     @Bean

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsCustomContextBuilderWithRequest.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsCustomContextBuilderWithRequest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.context
+
+import org.springframework.http.HttpHeaders
+import org.springframework.web.context.request.WebRequest
+
+/**
+ * When a bean implementing this interface is found, the framework will call the [build] method for every request.
+ * The result of the [build] method is placed on the [DgsContext] and can be retrieved with [DgsContext.customContext]
+ * or with one of the static methods on [DgsContext] given a DataFetchingEnvironment or batchLoaderEnvironment.
+ */
+interface DgsCustomContextBuilderWithRequest<T> {
+    fun build(extensions: Map<String, Any>?, headers: HttpHeaders?, webRequest: WebRequest?): T
+}


### PR DESCRIPTION
Added new interface DgsCustomContextBuilderWithRequest, which is an alternative to the DgsCustomContextBuilder. An implementation of the new interface will get precedence over the old one, and gets access to the web request.

This is a fix for #95 