### PR TITLE
Update to Jackson 2.12.2

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -22,5 +22,5 @@ object Versions {
     const val SPRING_CLOUD_VERSION = "Hoxton.SR9"
     const val GRAPHQL_JAVA = "16.2"
     const val GRAPHQL_JAVA_FEDERATION = "0.6.3"
-    const val JACKSON_BOM = "2.11.4"
+    const val JACKSON_BOM = "2.12.2"
 }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -21,7 +21,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -44,7 +44,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -67,7 +67,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -98,7 +98,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -121,7 +121,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -146,7 +146,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -166,7 +166,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -189,7 +189,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -209,7 +209,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -232,7 +232,7 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,16 +27,16 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.4.0"
@@ -84,7 +84,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -107,7 +107,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -138,7 +138,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -161,7 +161,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -186,7 +186,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -206,16 +206,16 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.4.0"
@@ -247,7 +247,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -267,16 +267,16 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.4.0"
@@ -323,16 +323,16 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.4.0"

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -30,10 +30,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -160,7 +160,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -183,7 +183,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -214,7 +214,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -237,7 +237,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -262,7 +262,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -291,14 +291,14 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -307,10 +307,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -511,7 +511,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -534,10 +534,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -663,14 +663,14 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -679,10 +679,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "locked": "1.0.2"
@@ -75,7 +75,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -98,7 +98,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -129,7 +129,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -152,7 +152,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -177,7 +177,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -197,7 +197,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "locked": "1.0.2"
@@ -229,7 +229,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -249,7 +249,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "locked": "1.0.2"
@@ -287,7 +287,7 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "locked": "1.0.2"

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -30,10 +30,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -165,7 +165,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -188,7 +188,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -219,7 +219,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -242,7 +242,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -267,7 +267,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -296,16 +296,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -398,7 +398,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -421,10 +421,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -555,14 +555,14 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -570,10 +570,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -111,7 +111,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -134,7 +134,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -165,7 +165,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -188,7 +188,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -213,7 +213,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -242,17 +242,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -357,7 +357,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -377,7 +377,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -460,17 +460,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -30,10 +30,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -145,7 +145,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -168,7 +168,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -199,7 +199,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -222,7 +222,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -247,7 +247,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -276,14 +276,14 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -291,10 +291,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -449,7 +449,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -472,10 +472,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -586,14 +586,14 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -601,10 +601,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -117,7 +117,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -140,7 +140,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -171,7 +171,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -194,7 +194,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -219,7 +219,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -248,17 +248,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -369,7 +369,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -389,7 +389,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -489,17 +489,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,10 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -109,7 +109,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -132,7 +132,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -163,7 +163,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -186,7 +186,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -211,7 +211,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -240,16 +240,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -339,7 +339,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -359,10 +359,10 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -440,16 +440,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -113,7 +113,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -136,7 +136,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -167,7 +167,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -190,7 +190,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -215,7 +215,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -244,17 +244,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -358,7 +358,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -378,7 +378,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -463,17 +463,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,10 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -109,7 +109,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -132,7 +132,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -163,7 +163,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -186,7 +186,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -211,7 +211,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -240,16 +240,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -339,7 +339,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -359,10 +359,10 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -443,16 +443,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -110,7 +110,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -133,7 +133,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -164,7 +164,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -187,7 +187,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -212,7 +212,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -241,17 +241,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -358,7 +358,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -378,7 +378,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -460,17 +460,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,10 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -112,7 +112,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -135,7 +135,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -166,7 +166,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -189,7 +189,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -214,7 +214,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -243,16 +243,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -345,7 +345,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -365,10 +365,10 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -452,16 +452,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -30,13 +30,13 @@
             "locked": "0.6.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -104,7 +104,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -127,7 +127,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -158,7 +158,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -181,7 +181,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -206,7 +206,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -229,13 +229,13 @@
             "locked": "0.6.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -299,7 +299,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -322,13 +322,13 @@
             "locked": "0.6.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -392,13 +392,13 @@
             "locked": "0.6.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
@@ -69,7 +69,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -92,7 +92,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -123,7 +123,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -146,7 +146,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -171,7 +171,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -191,7 +191,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
@@ -217,7 +217,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
@@ -237,7 +237,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
@@ -269,7 +269,7 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.11.4"
+            "locked": "2.12.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "16.2"


### PR DESCRIPTION
See https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12

Of note, jackson-module-kotlin is compiled /compatible with Kotlin 1.4.
