### PR TITLE
Add validation to DgsWebMvcConfigurationProperties (manual approach)

### DIFF
--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.webmvc.autoconfigure
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.bind.DefaultValue
+import javax.annotation.PostConstruct
 
 /**
  * Configuration properties for DGS web controllers.
@@ -46,4 +47,17 @@ data class DgsWebMvcConfigurationProperties(
         /** Path to the schema-json endpoint without trailing slash. */
         @DefaultValue("/schema.json") val path: String
     )
+
+    @PostConstruct
+    fun validatePaths() {
+        validatePath(this.path, "dgs.graphql.path")
+        validatePath(this.graphiql.path, "dgs.graphql.graphiql.path")
+        validatePath(this.schemaJson.path, "dgs.graphql.schema-json.path")
+    }
+
+    private fun validatePath(path: String, pathProperty: String) {
+        if (!path.startsWith("/") || path.endsWith("/")) {
+            throw IllegalArgumentException("$pathProperty must start with '/' and not end with '/' but was '$path'")
+        }
+    }
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesTest.kt
@@ -16,7 +16,7 @@
 
 package com.netflix.graphql.dgs.webmvc.autoconfigure
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.context.properties.bind.Binder
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource
@@ -28,37 +28,37 @@ class DgsWebMvcConfigurationPropertiesTest {
     @Test
     fun graphQLPathDefault() {
         val properties = bind(Collections.emptyMap())
-        Assertions.assertThat(properties.path).isEqualTo("/graphql")
+        assertThat(properties.path).isEqualTo("/graphql")
     }
 
     @Test
     fun graphQLPathCustom() {
         val properties = bind("dgs.graphql.path", "/private/gql")
-        Assertions.assertThat(properties.path).isEqualTo("/private/gql")
+        assertThat(properties.path).isEqualTo("/private/gql")
     }
 
     @Test
     fun graphiQLPathDefault() {
         val properties = bind(Collections.emptyMap())
-        Assertions.assertThat(properties.graphiql.path).isEqualTo("/graphiql")
+        assertThat(properties.graphiql.path).isEqualTo("/graphiql")
     }
 
     @Test
     fun graphiQLPathCustom() {
         val properties = bind("dgs.graphql.graphiql.path", "/private/giql")
-        Assertions.assertThat(properties.graphiql.path).isEqualTo("/private/giql")
+        assertThat(properties.graphiql.path).isEqualTo("/private/giql")
     }
 
     @Test
     fun schemaJsonPathDefault() {
         val properties = bind(Collections.emptyMap())
-        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/schema.json")
+        assertThat(properties.schemaJson.path).isEqualTo("/schema.json")
     }
 
     @Test
     fun schemaJsonPathCustom() {
         val properties = bind("dgs.graphql.schema-json.path", "/private/schema.json")
-        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/private/schema.json")
+        assertThat(properties.schemaJson.path).isEqualTo("/private/schema.json")
     }
 
     @Test
@@ -68,9 +68,9 @@ class DgsWebMvcConfigurationPropertiesTest {
         propertyValues["dgs.graphql.graphiql.path"] = "/private/giql"
         propertyValues["dgs.graphql.schema-json.path"] = "/private/sj"
         val properties = bind(propertyValues)
-        Assertions.assertThat(properties.path).isEqualTo("/private/gql")
-        Assertions.assertThat(properties.graphiql.path).isEqualTo("/private/giql")
-        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/private/sj")
+        assertThat(properties.path).isEqualTo("/private/gql")
+        assertThat(properties.graphiql.path).isEqualTo("/private/giql")
+        assertThat(properties.schemaJson.path).isEqualTo("/private/sj")
     }
 
     private fun bind(name: String, value: String): DgsWebMvcConfigurationProperties {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesValidationTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesValidationTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.autoconfigure
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+
+class DgsWebMvcConfigurationPropertiesValidationTest {
+
+    private val context = ApplicationContextRunner().withConfiguration(
+        AutoConfigurations.of(
+            MockConfigPropsAutoConfiguration::class.java
+        )
+    )!!
+
+    @Test
+    fun graphqlControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("dgs.graphql.path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun graphqlControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("dgs.graphql.path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun graphqlControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun graphiqlControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("dgs.graphql.graphiql.path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun graphiqlControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("dgs.graphql.graphiql.path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun graphiqlControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("dgs.graphql.schema-json.path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("dgs.graphql.schema-json.path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun defaultsAreValid() {
+        context
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(DgsWebMvcConfigurationProperties::class)
+    open class MockConfigPropsAutoConfiguration
+}


### PR DESCRIPTION
This adds validation to the `DgsWebMvcConfigurationProperties` config props. 

ℹ️ this uses a manual set of checks implemented inside a `@PostConstruct` method on the config props. 
**pros/cons**
* (+) simple, no new deps required
* (-) not extensible, will have to implement each new validation we add to the config props

ℹ️ an alternate approach using JSR-303 annotations is #179

#### Startup failure looks like this:

![image](https://user-images.githubusercontent.com/28907971/111921648-ab950e80-8a63-11eb-94b0-62a8afcb4904.png)



@paulbakker @berngp - which approach are you in favor of? 