### PR TITLE
WIP: Add validation to DgsWebMvcConfigurationProperties (JSR-303 approach) 

### DIFF
--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -109,6 +109,12 @@
             ],
             "locked": "3.4.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -406,6 +412,12 @@
             ],
             "locked": "4.0.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -616,6 +628,12 @@
             ],
             "locked": "3.4.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -780,6 +798,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "4.0.4"
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -112,6 +112,12 @@
         "net.bytebuddy:byte-buddy": {
             "locked": "1.10.18"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -506,6 +512,12 @@
         "net.bytebuddy:byte-buddy": {
             "locked": "1.10.18"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -666,6 +678,12 @@
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.10.18"
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -93,6 +93,12 @@
             ],
             "locked": "3.4.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -366,6 +372,12 @@
             ],
             "locked": "4.0.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -538,6 +550,12 @@
             ],
             "locked": "3.4.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -678,6 +696,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "4.0.4"
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ],
+            "locked": "6.1.6.Final"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"

--- a/graphql-dgs-spring-webmvc-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-webmvc-autoconfigure/build.gradle.kts
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
+plugins {
+    id("org.jetbrains.kotlin.plugin.allopen") version Versions.KOTLIN_VERSION
+}
+
 dependencies {
     api(project(":graphql-dgs"))
     api(project(":graphql-dgs-spring-webmvc"))
+    api("org.hibernate.validator:hibernate-validator")
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework:spring-webmvc")
     implementation("jakarta.servlet:jakarta.servlet-api")
@@ -24,4 +29,8 @@ dependencies {
     testImplementation("io.mockk:mockk:1.10.3-jdk8")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation(project(":graphql-dgs-spring-boot-oss-autoconfigure"))
+}
+
+configure<org.jetbrains.kotlin.allopen.gradle.AllOpenExtension> {
+    annotations("org.springframework.boot.context.properties.ConfigurationProperties")
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -68,6 +68,9 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -141,6 +144,9 @@
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.11.4"
+        },
+        "org.jetbrains.kotlin:kotlin-allopen": {
+            "locked": "1.4.31"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.4.31"
@@ -305,6 +311,9 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -440,6 +449,9 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
         },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.1.6.Final"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"
         },
@@ -555,6 +567,9 @@
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "6.1.6.Final"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.31"

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
@@ -19,31 +19,51 @@ package com.netflix.graphql.dgs.webmvc.autoconfigure
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.bind.DefaultValue
+import org.springframework.validation.annotation.Validated
+import javax.validation.Constraint
+import javax.validation.Valid
+import javax.validation.constraints.Pattern
+import kotlin.reflect.KClass
 
 /**
  * Configuration properties for DGS web controllers.
  */
 @ConstructorBinding
 @ConfigurationProperties(prefix = "dgs.graphql")
+@Validated
 @Suppress("ConfigurationProperties")
 data class DgsWebMvcConfigurationProperties(
     /** Path to the GraphQL endpoint without trailing slash. */
-    @DefaultValue("/graphql") val path: String,
-    @DefaultValue val graphiql: DgsGraphiQLConfigurationProperties,
-    @DefaultValue val schemaJson: DgsSchemaJsonConfigurationProperties
+    @DefaultValue("/graphql") @field:ValidPath val path: String,
+    @DefaultValue @Valid val graphiql: DgsGraphiQLConfigurationProperties,
+    @DefaultValue @Valid val schemaJson: DgsSchemaJsonConfigurationProperties
 ) {
     /**
      * Configuration properties for the schema-json endpoint.
      */
     data class DgsGraphiQLConfigurationProperties(
         /** Path to the GraphiQL endpoint without trailing slash. */
-        @DefaultValue("/graphiql") val path: String
+        @DefaultValue("/graphiql") @field:ValidPath val path: String
     )
+
     /**
      * Configuration properties for the schema-json endpoint.
      */
     data class DgsSchemaJsonConfigurationProperties(
         /** Path to the schema-json endpoint without trailing slash. */
-        @DefaultValue("/schema.json") val path: String
+        @DefaultValue("/schema.json") @field:ValidPath val path: String
+    )
+
+    /**
+     * Convenience annotation to prevent having to repeat the @Pattern for every path field.
+     */
+    @kotlin.annotation.Target(AnnotationTarget.FIELD)
+    @kotlin.annotation.Retention(AnnotationRetention.RUNTIME)
+    @Constraint(validatedBy = [])
+    @Pattern(regexp = "^/.*[^/]\$", message = "path must start with '/' and not end with '/'")
+    annotation class ValidPath(
+        val message: String = "",
+        val groups: Array<KClass<out Any>> = [],
+        val payload: Array<KClass<out Any>> = []
     )
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesTest.kt
@@ -16,7 +16,7 @@
 
 package com.netflix.graphql.dgs.webmvc.autoconfigure
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.context.properties.bind.Binder
 import org.springframework.boot.context.properties.source.ConfigurationPropertySource
@@ -28,37 +28,37 @@ class DgsWebMvcConfigurationPropertiesTest {
     @Test
     fun graphQLPathDefault() {
         val properties = bind(Collections.emptyMap())
-        Assertions.assertThat(properties.path).isEqualTo("/graphql")
+        assertThat(properties.path).isEqualTo("/graphql")
     }
 
     @Test
     fun graphQLPathCustom() {
         val properties = bind("dgs.graphql.path", "/private/gql")
-        Assertions.assertThat(properties.path).isEqualTo("/private/gql")
+        assertThat(properties.path).isEqualTo("/private/gql")
     }
 
     @Test
     fun graphiQLPathDefault() {
         val properties = bind(Collections.emptyMap())
-        Assertions.assertThat(properties.graphiql.path).isEqualTo("/graphiql")
+        assertThat(properties.graphiql.path).isEqualTo("/graphiql")
     }
 
     @Test
     fun graphiQLPathCustom() {
         val properties = bind("dgs.graphql.graphiql.path", "/private/giql")
-        Assertions.assertThat(properties.graphiql.path).isEqualTo("/private/giql")
+        assertThat(properties.graphiql.path).isEqualTo("/private/giql")
     }
 
     @Test
     fun schemaJsonPathDefault() {
         val properties = bind(Collections.emptyMap())
-        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/schema.json")
+        assertThat(properties.schemaJson.path).isEqualTo("/schema.json")
     }
 
     @Test
     fun schemaJsonPathCustom() {
         val properties = bind("dgs.graphql.schema-json.path", "/private/schema.json")
-        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/private/schema.json")
+        assertThat(properties.schemaJson.path).isEqualTo("/private/schema.json")
     }
 
     @Test
@@ -68,9 +68,9 @@ class DgsWebMvcConfigurationPropertiesTest {
         propertyValues["dgs.graphql.graphiql.path"] = "/private/giql"
         propertyValues["dgs.graphql.schema-json.path"] = "/private/sj"
         val properties = bind(propertyValues)
-        Assertions.assertThat(properties.path).isEqualTo("/private/gql")
-        Assertions.assertThat(properties.graphiql.path).isEqualTo("/private/giql")
-        Assertions.assertThat(properties.schemaJson.path).isEqualTo("/private/sj")
+        assertThat(properties.path).isEqualTo("/private/gql")
+        assertThat(properties.graphiql.path).isEqualTo("/private/giql")
+        assertThat(properties.schemaJson.path).isEqualTo("/private/sj")
     }
 
     private fun bind(name: String, value: String): DgsWebMvcConfigurationProperties {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesValidationTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesValidationTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.autoconfigure
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+
+class DgsWebMvcConfigurationPropertiesValidationTest {
+
+    private val context = ApplicationContextRunner().withConfiguration(
+        AutoConfigurations.of(
+            MockConfigPropsAutoConfiguration::class.java
+        )
+    )!!
+
+    @Test
+    fun graphqlControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun graphqlControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun graphqlControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun graphiqlControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun graphiqlControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun graphiqlControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.graphiql.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: /fooql/")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerInvalidCustomPathDoesNotStartWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: fooql")
+            .run { ctx ->
+                assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("path must start with '/' and not end with '/'")
+            }
+    }
+
+    @Test
+    fun schemaJsonControllerValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.schema-json.path: /fooql")
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun defaultsAreValid() {
+        context
+            .run { ctx ->
+                assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(DgsWebMvcConfigurationProperties::class)
+    open class MockConfigPropsAutoConfiguration
+}


### PR DESCRIPTION
This adds validation to the `DgsWebMvcConfigurationProperties` config props via JSR-303 annotations.

ℹ️ this uses [@Valdiated](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-validation) and JSR-303 validation annotations 
**pros/cons**
* (+) declarative w/ many [built-in validators](https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/#section-builtin-constraints)
* (+) failures give exact context of where in application.yml the problem value is etc..
* (-) requires `kotlin-allopen` plugin to make config props non-final as it now gets cglib'ed via `@Validated`
* (-) requires JSR-303 impl on classpath - default is `hibernate-validator` which is in Spring Boot BOM and has nothing to do w/ Hibernate JPA/ORM. 

ℹ️ an alternate manual approach is #176 

--- 
#### Startup failure looks like this:

<img width="800" src="https://user-images.githubusercontent.com/28907971/111920671-3a9f2800-8a5e-11eb-838a-8fe4312c370d.png" />

--- 

@paulbakker @berngp - which approach are you in favor of? 