### PR TITLE
DgsContextBuilder should not have state 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,14 +110,14 @@ subprojects {
     tasks {
         compileKotlin {
             kotlinOptions {
-                // freeCompilerArgs = listOf("-Xjsr305=strict")
+                freeCompilerArgs = listOf("-Xjvm-default=all")
                 jvmTarget = "1.8"
             }
         }
 
         compileTestKotlin {
             kotlinOptions {
-                // freeCompilerArgs = listOf("-Xjsr305=strict")
+                freeCompilerArgs = listOf("-Xjvm-default=all")
                 jvmTarget = "1.8"
             }
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsContextBuilder.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsContextBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,17 @@
 package com.netflix.graphql.dgs
 
 import com.netflix.graphql.dgs.context.DgsContext
+import com.netflix.graphql.dgs.internal.DgsRequestData
 
 /**
  * A DgsContext is created for each request to hold state during that request.
  * This builder abstraction is used to plugin implementations with more or less functionality.
  * Typically not implemented by users. See [com.netflix.graphql.dgs.context.DgsCustomContextBuilder] instead for adding custom state to the context.
  */
+@Deprecated("It is not recommended to create a custom DgsContextBuilder. Use a DgsCustomContextBuilder or DgsCustomContextBuilderWithRequest to add custom state to the context. This interface will be removed in the next major version.")
 interface DgsContextBuilder {
     fun build(): DgsContext
+
+    @JvmDefault
+    fun build(dgsRequestData: DgsRequestData): DgsContext = build()
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
@@ -40,7 +40,14 @@ interface DgsQueryExecutor {
     fun execute(query: String, variables: Map<String, Any>, extensions: Map<String, Any>?, headers: HttpHeaders): ExecutionResult =
         execute(query = query, variables = variables, extensions = extensions, headers = headers, operationName = null)
 
-    fun execute(query: String, variables: Map<String, Any>, extensions: Map<String, Any>?, headers: HttpHeaders, operationName: String? = null, webRequest: WebRequest? = null): ExecutionResult
+    fun execute(
+        query: String,
+        variables: Map<String, Any>,
+        extensions: Map<String, Any>?,
+        headers: HttpHeaders?,
+        operationName: String? = null,
+        webRequest: WebRequest? = null
+    ): ExecutionResult
 
     fun <T> executeAndExtractJsonPath(query: String, jsonPath: String): T
     fun <T> executeAndExtractJsonPath(query: String, jsonPath: String, variables: Map<String, Any>): T


### PR DESCRIPTION

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Added new method to `DgsContextBuilder` which receives `DgsRequestData`. This is a default method for backward compatibility. Also deprecated this interface because there is not really any reason to provide your own implementation.

Issue #180

Alternatives considered
----

Ideally, we remove the `DgsContextBuilder` interface. With the `DgsCustomContextBuilder` mechanism in place there is really no reason to implement your own `DgsContextBuilder`. 
Once we get rid of the interface in the next major version, we can simplify the mechanism by just creating an instance of `DefaultDgsContextBuilder` instead of providing it as a Spring bean.

