### PR TITLE
Fix for #130

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.exceptions.DgsBadRequestException
 import com.netflix.graphql.dgs.metrics.micrometer.tagging.DgsContextualTagCustomizer
 import com.netflix.graphql.dgs.metrics.micrometer.tagging.DgsExecutionTagCustomizer
 import com.netflix.graphql.dgs.metrics.micrometer.tagging.DgsFieldFetchTagCustomizer
+import com.netflix.graphql.types.errors.ErrorDetail
 import com.netflix.graphql.types.errors.TypedGraphQLError
 import graphql.GraphQLError
 import graphql.execution.DataFetcherExceptionHandler
@@ -623,7 +624,8 @@ class MicrometerServletSmokeTest {
                 val exception = handlerParameters.exception
                 val graphqlError: GraphQLError =
                     TypedGraphQLError
-                        .ENHANCE_YOUR_CALM
+                        .newBuilder()
+                        .errorDetail(ErrorDetail.Common.ENHANCE_YOUR_CALM)
                         .message(exception.message)
                         .path(handlerParameters.path)
                         .build()

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
@@ -43,16 +43,17 @@ class DefaultDataFetcherExceptionHandler : DataFetcherExceptionHandler {
         }
 
         val graphqlError = if (springSecurityAvailable && exception is org.springframework.security.access.AccessDeniedException) {
-            TypedGraphQLError.PERMISSION_DENIED.message("%s: %s", exception::class.java.name, exception.message)
+            TypedGraphQLError.newPermissionDeniedBuilder()
+                .message("%s: %s", exception::class.java.name, exception.message)
                 .path(handlerParameters.path).build()
         } else if (exception is DgsEntityNotFoundException) {
-            TypedGraphQLError.NOT_FOUND.message("%s: %s", exception::class.java.name, exception.message)
+            TypedGraphQLError.newNotFoundBuilder().message("%s: %s", exception::class.java.name, exception.message)
                 .path(handlerParameters.path).build()
         } else if (exception is DgsBadRequestException) {
-            TypedGraphQLError.BAD_REQUEST.message("%s: %s", exception::class.java.name, exception.message)
+            TypedGraphQLError.newBadRequestBuilder().message("%s: %s", exception::class.java.name, exception.message)
                 .path(handlerParameters.path).build()
         } else {
-            TypedGraphQLError.INTERNAL.message("%s: %s", exception::class.java.name, exception.message)
+            TypedGraphQLError.newInternalErrorBuilder().message("%s: %s", exception::class.java.name, exception.message)
                 .path(handlerParameters.path).build()
         }
 

--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
@@ -70,46 +70,118 @@ public class TypedGraphQLError implements GraphQLError {
         return extensions;
     }
 
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder UNKNOWN = newBuilder();
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newInternalErrorBuilder() instead.
+     */
     @Deprecated
     public static Builder INTERNAL = newBuilder().errorType(ErrorType.INTERNAL);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newNotFoundBuilder() instead.
+     */
     @Deprecated
     public static Builder NOT_FOUND = newBuilder().errorType(ErrorType.NOT_FOUND);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder UNAUTHENTICATED = newBuilder().errorType(ErrorType.UNAUTHENTICATED);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newPermissionDeniedBuilder() instead.
+     */
     @Deprecated
     public static Builder PERMISSION_DENIED = newBuilder().errorType(ErrorType.PERMISSION_DENIED);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBadRequestBuilder() instead.
+     */
     @Deprecated
     public static Builder BAD_REQUEST = newBuilder().errorType(ErrorType.BAD_REQUEST);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder UNAVAILABLE = newBuilder().errorType(ErrorType.UNAVAILABLE);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder FAILED_PRECONDITION = newBuilder().errorType(ErrorType.FAILED_PRECONDITION);
 
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder FIELD_NOT_FOUND = newBuilder().errorDetail(ErrorDetail.Common.FIELD_NOT_FOUND);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder INVALID_CURSOR = newBuilder().errorDetail(ErrorDetail.Common.INVALID_CURSOR);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder UNIMPLEMENTED = newBuilder().errorDetail(ErrorDetail.Common.UNIMPLEMENTED);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder INVALID_ARGUMENT = newBuilder().errorDetail(ErrorDetail.Common.INVALID_ARGUMENT);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder DEADLINE_EXCEEDED = newBuilder().errorDetail(ErrorDetail.Common.DEADLINE_EXCEEDED);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder SERVICE_ERROR = newBuilder().errorDetail(ErrorDetail.Common.SERVICE_ERROR);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder ENHANCE_YOUR_CALM = newBuilder().errorDetail(ErrorDetail.Common.ENHANCE_YOUR_CALM);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder THROTTLED_CPU = newBuilder().errorDetail(ErrorDetail.Common.THROTTLED_CPU);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder THROTTLED_CONCURRENCY = newBuilder().errorDetail(ErrorDetail.Common.THROTTLED_CONCURRENCY);
+
+    /**
+     * @deprecated Static builder fields are thread-unsafe. Use TypedGraphQLError.newBuilder() instead.
+     */
     @Deprecated
     public static Builder MISSING_RESOURCE = newBuilder().errorDetail(ErrorDetail.Common.MISSING_RESOURCE);
 
     /**
      * Create new Builder instance to customize error.
+     *
+     * @return A new TypedGraphQLError.Builder instance to further customize the error.
      */
     public static Builder newBuilder() {
         return new Builder();
@@ -117,7 +189,7 @@ public class TypedGraphQLError implements GraphQLError {
 
     /**
      * Create new Builder instance to customize error.
-     * Pre-sets ErrorType.INTERNAL.
+     * @return A new TypedGraphQLError.Builder instance to further customize the error. Pre-sets ErrorType.INTERNAL.
      */
     public static Builder newInternalErrorBuilder() {
         return new Builder().errorType(ErrorType.INTERNAL);
@@ -125,7 +197,7 @@ public class TypedGraphQLError implements GraphQLError {
 
     /**
      * Create new Builder instance to customize error.
-     * Pre-sets ErrorType.NOT_FOUND.
+     * @return A new TypedGraphQLError.Builder instance to further customize the error. Pre-sets ErrorType.NOT_FOUND.
      */
     public static Builder newNotFoundBuilder() {
         return new Builder().errorType(ErrorType.NOT_FOUND);
@@ -133,7 +205,7 @@ public class TypedGraphQLError implements GraphQLError {
 
     /**
      * Create new Builder instance to customize error.
-     * Pre-sets ErrorType.PERMISSION_DENIED.
+     * @return A new TypedGraphQLError.Builder instance to further customize the error. Pre-sets ErrorType.PERMISSION_DENIED.
      */
     public static Builder newPermissionDeniedBuilder() {
         return new Builder().errorType(ErrorType.PERMISSION_DENIED);
@@ -141,7 +213,7 @@ public class TypedGraphQLError implements GraphQLError {
 
     /**
      * Create new Builder instance to customize error.
-     * Pre-sets ErrorType.BAD_REQUEST.
+     * @return A new TypedGraphQLError.Builder instance to further customize the error. Pre-sets ErrorType.BAD_REQUEST.
      */
     public static Builder newBadRequestBuilder() {
         return new Builder().errorType(ErrorType.BAD_REQUEST);

--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
@@ -70,29 +70,83 @@ public class TypedGraphQLError implements GraphQLError {
         return extensions;
     }
 
+    @Deprecated
     public static Builder UNKNOWN = newBuilder();
+    @Deprecated
     public static Builder INTERNAL = newBuilder().errorType(ErrorType.INTERNAL);
+    @Deprecated
     public static Builder NOT_FOUND = newBuilder().errorType(ErrorType.NOT_FOUND);
+    @Deprecated
     public static Builder UNAUTHENTICATED = newBuilder().errorType(ErrorType.UNAUTHENTICATED);
+    @Deprecated
     public static Builder PERMISSION_DENIED = newBuilder().errorType(ErrorType.PERMISSION_DENIED);
+    @Deprecated
     public static Builder BAD_REQUEST = newBuilder().errorType(ErrorType.BAD_REQUEST);
+    @Deprecated
     public static Builder UNAVAILABLE = newBuilder().errorType(ErrorType.UNAVAILABLE);
+    @Deprecated
     public static Builder FAILED_PRECONDITION = newBuilder().errorType(ErrorType.FAILED_PRECONDITION);
 
+    @Deprecated
     public static Builder FIELD_NOT_FOUND = newBuilder().errorDetail(ErrorDetail.Common.FIELD_NOT_FOUND);
+    @Deprecated
     public static Builder INVALID_CURSOR = newBuilder().errorDetail(ErrorDetail.Common.INVALID_CURSOR);
+    @Deprecated
     public static Builder UNIMPLEMENTED = newBuilder().errorDetail(ErrorDetail.Common.UNIMPLEMENTED);
+    @Deprecated
     public static Builder INVALID_ARGUMENT = newBuilder().errorDetail(ErrorDetail.Common.INVALID_ARGUMENT);
+    @Deprecated
     public static Builder DEADLINE_EXCEEDED = newBuilder().errorDetail(ErrorDetail.Common.DEADLINE_EXCEEDED);
+    @Deprecated
     public static Builder SERVICE_ERROR = newBuilder().errorDetail(ErrorDetail.Common.SERVICE_ERROR);
+    @Deprecated
     public static Builder ENHANCE_YOUR_CALM = newBuilder().errorDetail(ErrorDetail.Common.ENHANCE_YOUR_CALM);
+    @Deprecated
     public static Builder THROTTLED_CPU = newBuilder().errorDetail(ErrorDetail.Common.THROTTLED_CPU);
+    @Deprecated
     public static Builder THROTTLED_CONCURRENCY = newBuilder().errorDetail(ErrorDetail.Common.THROTTLED_CONCURRENCY);
+    @Deprecated
     public static Builder MISSING_RESOURCE = newBuilder().errorDetail(ErrorDetail.Common.MISSING_RESOURCE);
 
+    /**
+     * Create new Builder instance to customize error.
+     */
     public static Builder newBuilder() {
         return new Builder();
     }
+
+    /**
+     * Create new Builder instance to customize error.
+     * Pre-sets ErrorType.INTERNAL.
+     */
+    public static Builder newInternalErrorBuilder() {
+        return new Builder().errorType(ErrorType.INTERNAL);
+    }
+
+    /**
+     * Create new Builder instance to customize error.
+     * Pre-sets ErrorType.NOT_FOUND.
+     */
+    public static Builder newNotFoundBuilder() {
+        return new Builder().errorType(ErrorType.NOT_FOUND);
+    }
+
+    /**
+     * Create new Builder instance to customize error.
+     * Pre-sets ErrorType.PERMISSION_DENIED.
+     */
+    public static Builder newPermissionDeniedBuilder() {
+        return new Builder().errorType(ErrorType.PERMISSION_DENIED);
+    }
+
+    /**
+     * Create new Builder instance to customize error.
+     * Pre-sets ErrorType.BAD_REQUEST.
+     */
+    public static Builder newBadRequestBuilder() {
+        return new Builder().errorType(ErrorType.BAD_REQUEST);
+    }
+
 
     @Override
     public String toString() {


### PR DESCRIPTION
Deprecate all static builder fields in TypedGraphQLError since they are thread-unsafe. Added a few builder shortcuts for the most common error types.

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

The static builder fields in TypedGraphQLError are thread-unsafe and should be removed. Because users may depend on these fields directly, I've deprecated the fields, and replaced them with a few convenience builder shortcuts.

Issue #130
