### PR TITLE
Added @DgsMutation, @DgsQuery and @DgsSubscription

### DIFF
--- a/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/HelloDataFetcher.java
+++ b/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/HelloDataFetcher.java
@@ -16,10 +16,7 @@
 
 package com.netflix.graphql.dgs.example.datafetcher;
 
-import com.netflix.graphql.dgs.DgsComponent;
-import com.netflix.graphql.dgs.DgsData;
-import com.netflix.graphql.dgs.DgsEnableDataFetcherInstrumentation;
-import com.netflix.graphql.dgs.InputArgument;
+import com.netflix.graphql.dgs.*;
 import com.netflix.graphql.dgs.context.DgsContext;
 import com.netflix.graphql.dgs.example.context.MyContext;
 import graphql.GraphQLException;
@@ -30,7 +27,7 @@ import java.util.concurrent.CompletableFuture;
 
 @DgsComponent
 public class HelloDataFetcher {
-    @DgsData(parentType = "Query", field = "hello")
+    @DgsQuery
     @DgsEnableDataFetcherInstrumentation(false)
     public String hello(@InputArgument String name) {
         if (name == null) {

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -31,5 +31,6 @@ dependencies {
 
     testImplementation("org.springframework.security:spring-security-core")
     testImplementation("io.reactivex.rxjava3:rxjava:3.+")
+    testImplementation("io.projectreactor:reactor-core:3.4.0")
     testImplementation("io.mockk:mockk:1.10.3-jdk8")
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsData.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsData.java
@@ -26,11 +26,11 @@ import java.lang.annotation.*;
  * The field is the name of the field this data fetcher is responsible for.
  * See https://netflix.github.io/dgs/getting-started/
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface DgsData {
     String parentType();
 
-    String field();
+    String field() default "";
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsMutation.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsMutation.java
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.example.datafetcher;
+package com.netflix.graphql.dgs;
 
-import com.netflix.graphql.dgs.DgsComponent;
-import com.netflix.graphql.dgs.DgsSubscription;
-import com.netflix.graphql.dgs.example.types.Stock;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import java.time.Duration;
-
-@DgsComponent
-public class SubscriptionDataFetcher {
-    @DgsSubscription
-    public Publisher<Stock> stocks() {
-        return Flux.interval(Duration.ofSeconds(0), Duration.ofSeconds(1)).map(t -> new Stock("NFLX", t));
-    }
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@DgsData(parentType = "Mutation")
+public @interface DgsMutation {
+    String field() default "";
 }
-

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQuery.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQuery.java
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.example.datafetcher;
+package com.netflix.graphql.dgs;
 
-import com.netflix.graphql.dgs.DgsComponent;
-import com.netflix.graphql.dgs.DgsSubscription;
-import com.netflix.graphql.dgs.example.types.Stock;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import java.time.Duration;
-
-@DgsComponent
-public class SubscriptionDataFetcher {
-    @DgsSubscription
-    public Publisher<Stock> stocks() {
-        return Flux.interval(Duration.ofSeconds(0), Duration.ofSeconds(1)).map(t -> new Stock("NFLX", t));
-    }
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@DgsData(parentType = "Query")
+public @interface DgsQuery {
+    String field() default "";
 }
-

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsSubscription.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsSubscription.java
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.example.datafetcher;
+package com.netflix.graphql.dgs;
 
-import com.netflix.graphql.dgs.DgsComponent;
-import com.netflix.graphql.dgs.DgsSubscription;
-import com.netflix.graphql.dgs.example.types.Stock;
-import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import java.time.Duration;
-
-@DgsComponent
-public class SubscriptionDataFetcher {
-    @DgsSubscription
-    public Publisher<Stock> stocks() {
-        return Flux.interval(Duration.ofSeconds(0), Duration.ofSeconds(1)).map(t -> new Stock("NFLX", t));
-    }
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@DgsData(parentType = "Subscription")
+public @interface DgsSubscription {
+    String field() default "";
 }
-

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -18,6 +18,7 @@ package com.netflix.graphql.dgs
 
 import com.netflix.graphql.dgs.exceptions.NoSchemaFoundException
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.language.FieldDefinition
 import graphql.language.ObjectTypeExtensionDefinition
@@ -31,13 +32,16 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
+import io.reactivex.rxjava3.subscribers.TestSubscriber
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
+import org.reactivestreams.Publisher
 import org.springframework.context.ApplicationContext
+import reactor.core.publisher.Flux
 import java.time.LocalDateTime
 import java.util.*
 import java.util.concurrent.CompletableFuture
@@ -659,6 +663,68 @@ internal class DgsSchemaProviderTest {
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
+    @Test
+    fun `Subscription dataFetcher with @DgsSubscription annotation without field name`() {
+        val fetcher = object : Any() {
+            @DgsSubscription
+            fun messages(): Publisher<String> {
+                return Flux.just("hello")
+            }
+        }
+
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
+            Pair(
+                "helloFetcher",
+                fetcher
+            )
+        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+
+        val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+        val schema = provider.schema(
+            """
+            type Subscription {
+                messages: String
+            }
+            """.trimIndent()
+        )
+        val build = GraphQL.newGraphQL(schema).build()
+        assertSubscription(build)
+
+        verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
+    }
+
+    @Test
+    fun `Subscription dataFetcher with @DgsSubscription annotation with field name`() {
+        val fetcher = object : Any() {
+            @DgsSubscription(field = "messages")
+            fun someMethod(): Publisher<String> {
+                return Flux.just("hello")
+            }
+        }
+
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
+            Pair(
+                "helloFetcher",
+                fetcher
+            )
+        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+
+        val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+        val schema = provider.schema(
+            """
+            type Subscription {
+                messages: String
+            }
+            """.trimIndent()
+        )
+        val build = GraphQL.newGraphQL(schema).build()
+        assertSubscription(build)
+
+        verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
+    }
+
     private fun assertHello(build: GraphQL) {
         val executionResult = build.execute("{hello}")
         assertTrue(executionResult.isDataPresent)
@@ -672,6 +738,15 @@ internal class DgsSchemaProviderTest {
         val data = executionResult.getData<Map<String, *>>()
         val video = data["video"] as Map<*, *>
         assertEquals("ShowA", video["title"])
+    }
+
+    private fun assertSubscription(build: GraphQL) {
+        val executionResult = build.execute("subscription {messages}")
+        assertTrue(executionResult.isDataPresent)
+        val data = executionResult.getData<Publisher<ExecutionResult>>()
+        val testSubscriber = TestSubscriber<ExecutionResult>()
+        data.subscribe(testSubscriber)
+        testSubscriber.assertValue { it.getData<Map<String, String>>()["messages"] == "hello" }
     }
 
     private fun assertInputMessage(build: GraphQL) {


### PR DESCRIPTION
Added @DgsMutation, @DgsQuery and @DgsSubscription as shorthand annotations. Also, the "field" argument on @DgsData is now optional, it will use the method name if no field name is provided.

All the examples below have the same effect: A `hello` datafetcher on the `Query` type.
The same mechanism also works for `@DgsMutation` and `@DgsSubscription`, but for their respective parent types.

Annotation only.
```java
 @DgsQuery
public String hello() {
      return "Hello!";
}
```

Field name specified.
```java
 @DgsQuery(field = "hello")
public String someMethod() {
      return "Hello!";
}
```

On top of that, the `field` argument on  `@DgsData` is now optional. If not provided, the method name is used.
```java
@DgsData(parentType = "Query")
public String hello() { 
    return "Hello!";
}
```

This implements feature request #92 