### PR TITLE
Allow specifying the operation name and query names

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
@@ -54,7 +54,26 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
             "Content-type" to listOf("application/json")
         )
 
-        private data class Request(val query: String, val variables: Map<String, Any>)
+        private data class Request(val query: String, val variables: Map<String, Any>, val operationName: String?)
+    }
+
+    /**
+     * Executes a query and returns a GraphQLResponse.
+     * The actual HTTP request is done by an implementation of RequestExecutor, which is user provided.
+     * The RequestExecutor is typically provided as a lambda expression.
+     * The Accept and Content-Type headers are set. Additional headers can be set in the RequestExecutor.
+     * @param query The Query as a String
+     * @param variables Query variables. May be empty
+     * @param operationName optional operation name
+     * @param requestExecutor The code that does the actual HTTP request. Typically provided as a lambda expression.
+     * @return GraphQLResponse
+     * @throws GraphQLClientException when the HTTP response code is not 2xx.
+     */
+    override fun executeQuery(query: String, variables: Map<String, Any>, operationName: String?, requestExecutor: RequestExecutor): GraphQLResponse {
+        val serializedRequest = objectMapper.writeValueAsString(Request(query, variables, operationName))
+
+        val response = requestExecutor.execute(url, defaultHeaders, serializedRequest)
+        return handleResponse(response, serializedRequest)
     }
 
     /**
@@ -69,10 +88,7 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
      * @throws GraphQLClientException when the HTTP response code is not 2xx.
      */
     override fun executeQuery(query: String, variables: Map<String, Any>, requestExecutor: RequestExecutor): GraphQLResponse {
-        val serializedRequest = objectMapper.writeValueAsString(Request(query, variables))
-
-        val response = requestExecutor.execute(url, defaultHeaders, serializedRequest)
-        return handleResponse(response, serializedRequest)
+        return executeQuery(query, variables, null, requestExecutor)
     }
 
     /**
@@ -87,7 +103,23 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
      * @throws GraphQLClientException when the HTTP response code is not 2xx.
      */
     override fun reactiveExecuteQuery(query: String, variables: Map<String, Any>, requestExecutor: MonoRequestExecutor): Mono<GraphQLResponse> {
-        val serializedRequest = objectMapper.writeValueAsString(Request(query, variables))
+        return reactiveExecuteQuery(query, variables, null, requestExecutor)
+    }
+
+    /**
+     * Executes a query and returns a reactive Mono<GraphQLResponse>.
+     * The actual HTTP request is done by an implementation of RequestExecutor, which is user provided.
+     * The RequestExecutor is typically provided as a lambda expression.
+     * The Accept and Content-Type headers are set. Additional headers can be set in the RequestExecutor.
+     * @param query The Query as a String
+     * @param variables Query variables. May be empty
+     * @param operationName optional operation name
+     * @param requestExecutor The code that does the actual HTTP request. Typically provided as a lambda expression.
+     * @return Mono<GraphQLResponse>
+     * @throws GraphQLClientException when the HTTP response code is not 2xx.
+     */
+    override fun reactiveExecuteQuery(query: String, variables: Map<String, Any>, operationName: String?, requestExecutor: MonoRequestExecutor): Mono<GraphQLResponse> {
+        val serializedRequest = objectMapper.writeValueAsString(Request(query, variables, operationName))
 
         return requestExecutor.execute(url, defaultHeaders, serializedRequest).map { response ->
             handleResponse(response, serializedRequest)

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
@@ -69,7 +69,12 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
      * @return GraphQLResponse
      * @throws GraphQLClientException when the HTTP response code is not 2xx.
      */
-    override fun executeQuery(query: String, variables: Map<String, Any>, operationName: String?, requestExecutor: RequestExecutor): GraphQLResponse {
+    override fun executeQuery(
+        query: String,
+        variables: Map<String, Any>,
+        operationName: String?,
+        requestExecutor: RequestExecutor
+    ): GraphQLResponse {
         val serializedRequest = objectMapper.writeValueAsString(Request(query, variables, operationName))
 
         val response = requestExecutor.execute(url, defaultHeaders, serializedRequest)
@@ -87,7 +92,11 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
      * @return GraphQLResponse
      * @throws GraphQLClientException when the HTTP response code is not 2xx.
      */
-    override fun executeQuery(query: String, variables: Map<String, Any>, requestExecutor: RequestExecutor): GraphQLResponse {
+    override fun executeQuery(
+        query: String,
+        variables: Map<String, Any>,
+        requestExecutor: RequestExecutor
+    ): GraphQLResponse {
         return executeQuery(query, variables, null, requestExecutor)
     }
 
@@ -102,7 +111,11 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
      * @return Mono<GraphQLResponse>
      * @throws GraphQLClientException when the HTTP response code is not 2xx.
      */
-    override fun reactiveExecuteQuery(query: String, variables: Map<String, Any>, requestExecutor: MonoRequestExecutor): Mono<GraphQLResponse> {
+    override fun reactiveExecuteQuery(
+        query: String,
+        variables: Map<String, Any>,
+        requestExecutor: MonoRequestExecutor
+    ): Mono<GraphQLResponse> {
         return reactiveExecuteQuery(query, variables, null, requestExecutor)
     }
 
@@ -118,7 +131,12 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
      * @return Mono<GraphQLResponse>
      * @throws GraphQLClientException when the HTTP response code is not 2xx.
      */
-    override fun reactiveExecuteQuery(query: String, variables: Map<String, Any>, operationName: String?, requestExecutor: MonoRequestExecutor): Mono<GraphQLResponse> {
+    override fun reactiveExecuteQuery(
+        query: String,
+        variables: Map<String, Any>,
+        operationName: String?,
+        requestExecutor: MonoRequestExecutor
+    ): Mono<GraphQLResponse> {
         val serializedRequest = objectMapper.writeValueAsString(Request(query, variables, operationName))
 
         return requestExecutor.execute(url, defaultHeaders, serializedRequest).map { response ->

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -29,7 +29,12 @@ interface GraphQLClient {
 }
 
 interface MonoGraphQLClient {
-    fun reactiveExecuteQuery(query: String, variables: Map<String, Any>, requestExecutor: MonoRequestExecutor): Mono<GraphQLResponse>
+    fun reactiveExecuteQuery(
+        query: String,
+        variables: Map<String, Any>,
+        requestExecutor: MonoRequestExecutor
+    ): Mono<GraphQLResponse>
+
     fun reactiveExecuteQuery(
         query: String,
         variables: Map<String, Any>,
@@ -71,4 +76,5 @@ fun interface MonoRequestExecutor {
 /**
  * A transport level exception (e.g. a failed connection). This does *not* represent successful GraphQL responses that contain errors.
  */
-class GraphQLClientException(statusCode: Int, url: String, response: String, request: String) : RuntimeException("GraphQL server $url responded with status code $statusCode: '$response'. The request sent to the server was \n$request")
+class GraphQLClientException(statusCode: Int, url: String, response: String, request: String) :
+    RuntimeException("GraphQL server $url responded with status code $statusCode: '$response'. The request sent to the server was \n$request")

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -20,10 +20,22 @@ import reactor.core.publisher.Mono
 
 interface GraphQLClient {
     fun executeQuery(query: String, variables: Map<String, Any>, requestExecutor: RequestExecutor): GraphQLResponse
+    fun executeQuery(
+        query: String,
+        variables: Map<String, Any>,
+        operationName: String?,
+        requestExecutor: RequestExecutor
+    ): GraphQLResponse
 }
 
 interface MonoGraphQLClient {
     fun reactiveExecuteQuery(query: String, variables: Map<String, Any>, requestExecutor: MonoRequestExecutor): Mono<GraphQLResponse>
+    fun reactiveExecuteQuery(
+        query: String,
+        variables: Map<String, Any>,
+        operationName: String?,
+        requestExecutor: MonoRequestExecutor
+    ): Mono<GraphQLResponse>
 }
 
 @FunctionalInterface

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLError.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLError.kt
@@ -24,15 +24,29 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * A representation of a GraphQL error, following the format used by a DGS and Gateway.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class GraphQLError(@JsonProperty val message: String = "", @JsonProperty val path: List<Any> = emptyList(), @JsonProperty val locations: List<Any> = emptyList(), @JsonProperty val extensions: GraphQLErrorExtensions?) {
+data class GraphQLError(
+    @JsonProperty val message: String = "",
+    @JsonProperty val path: List<Any> = emptyList(),
+    @JsonProperty val locations: List<Any> = emptyList(),
+    @JsonProperty val extensions: GraphQLErrorExtensions?
+) {
     val pathAsString = path.joinToString(".")
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class GraphQLErrorExtensions(@JsonProperty val errorType: ErrorType? = null, @JsonProperty val errorDetail: String? = null, @JsonProperty val origin: String = "", @JsonProperty val debugInfo: GraphQLErrorDebugInfo = GraphQLErrorDebugInfo(), @JsonProperty val classification: String = "")
+data class GraphQLErrorExtensions(
+    @JsonProperty val errorType: ErrorType? = null,
+    @JsonProperty val errorDetail: String? = null,
+    @JsonProperty val origin: String = "",
+    @JsonProperty val debugInfo: GraphQLErrorDebugInfo = GraphQLErrorDebugInfo(),
+    @JsonProperty val classification: String = ""
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class GraphQLErrorDebugInfo(@JsonProperty val subquery: String = "", @JsonProperty val variables: Map<String, Any> = emptyMap())
+data class GraphQLErrorDebugInfo(
+    @JsonProperty val subquery: String = "",
+    @JsonProperty val variables: Map<String, Any> = emptyMap()
+)
 
 /**
 The value of the errorType field is an enumeration of error types.

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQuery.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQuery.kt
@@ -18,9 +18,10 @@ package com.netflix.graphql.dgs.client.codegen
 
 import java.util.*
 
-abstract class GraphQLQuery(val operation: String) {
+abstract class GraphQLQuery(val operation: String, val name: String?) {
     val input: MutableMap<String, Any> = LinkedHashMap()
 
+    constructor(operation: String) : this(operation, null)
     constructor() : this("query")
 
     open fun getOperationType(): String? {

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -22,8 +22,11 @@ class GraphQLQueryRequest(private val query: GraphQLQuery, private val projectio
 
     fun serialize(): String {
         val builder = StringBuilder()
-        builder.append(query.getOperationType()).append(" {")
-        builder.append(query.getOperationName())
+        builder.append(query.getOperationType())
+        if (query.name != null) {
+            builder.append(" ").append(query.name)
+        }
+        builder.append(" {").append(query.getOperationName())
         val input: Map<String, Any?> = query.input
         if (input.isNotEmpty()) {
             builder.append("(")

--- a/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
+++ b/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
@@ -63,15 +63,16 @@ public class GraphQLResponseJavaTest {
         server.expect(requestTo(url))
                 .andExpect(method(HttpMethod.POST))
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json("{\"operationName\":\"SubmitReview\"}"))
                 .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
         GraphQLResponse graphQLResponse = client.executeQuery(
-                "query {" +
+                "query SubmitReview {" +
                         "submitReview(review:{movieId:1, description:\"\"}) {" +
                         "submittedBy" +
                         "}" +
                         "}",
-                emptyMap(), requestExecutor
+                emptyMap(), "SubmitReview", requestExecutor
         );
 
         String submittedBy = graphQLResponse.extractValueAsObject("submitReview.submittedBy", String.class);

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLQueryRequestTest.kt
@@ -84,9 +84,25 @@ class GraphQLQueryRequestTest {
         val result = request.serialize()
         assertThat(result).isEqualTo("mutation {testMutation(movie: {movieId:1234, name:\"testMovie\" }){ name movieId } }")
     }
+
+    @Test
+    fun serializeWithName() {
+        val query = TestNamedGraphQLQuery().apply {
+            input["movie"] = Movie(123, "greatMovie")
+        }
+        val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\" }){ name movieId } }")
+    }
 }
 
 class TestGraphQLQuery : GraphQLQuery() {
+    override fun getOperationName(): String {
+        return "test"
+    }
+}
+
+class TestNamedGraphQLQuery : GraphQLQuery("query", "TestNamedQuery") {
     override fun getOperationName(): String {
         return "test"
     }

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
@@ -189,4 +189,33 @@ class GraphQLResponseTest {
         assertThat(listOfSubmittedBy.size).isEqualTo(2)
         server.verify()
     }
+
+    @Test
+    fun useOperationName() {
+
+        val jsonResponse = """
+            {
+              "data": {
+                "submitReview": {
+                  "edges": []
+                }
+              }
+            }
+        """.trimIndent()
+
+        server.expect(requestTo(url))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(content().json("""{"operationName":"SubmitUserReview"}"""))
+            .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON))
+
+        val graphQLResponse = client.executeQuery(
+            """mutation SubmitUserReview {
+              submitReview(review:{movieId:1, starRating:5, description:""}) {}
+            }""",
+            emptyMap(), "SubmitUserReview", requestExecutor
+        )
+
+        server.verify()
+    }
 }


### PR DESCRIPTION
Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Hi All,

this PR allows specifying a query name and also an `operationName` in the request body, as allowed by the spec. Here are some relevant references:

- Query name:
  - <https://spec.graphql.org/June2018/#sec-Language.Operations>
- `operationName` in request body
  - <https://spec.graphql.org/June2018/#sec-Executing-Requests>
  - <https://graphql.org/learn/serving-over-http/#post-request>

I believe that the PR introduces no backward compatibility issues and that the test cases are sufficient, but I would be glad if someone else could check and confirm that.

Thank you very much!


Alternatives considered
----

The name could be added to `GraphQLQueryRequest`.

I would be happy to hear any suggestions.

