### PR TITLE
Introduced dgs.graphql.schema-locations configuration property

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -50,8 +51,11 @@ import java.util.*
  * This does NOT have logging, tracing, metrics and security integration.
  */
 @Configuration
+@EnableConfigurationProperties(DgsConfigurationProperties::class)
 @ImportAutoConfiguration(classes = [JacksonAutoConfiguration::class])
-open class DgsAutoConfiguration {
+open class DgsAutoConfiguration(
+    private val configProps: DgsConfigurationProperties
+) {
 
     @Bean
     open fun dgsQueryExecutor(
@@ -126,7 +130,13 @@ open class DgsAutoConfiguration {
         existingCodeRegistry: Optional<GraphQLCodeRegistry>,
         mockProviders: Optional<Set<MockProvider>>
     ): DgsSchemaProvider {
-        return DgsSchemaProvider(applicationContext, federationResolver, existingTypeDefinitionFactory, mockProviders)
+        return DgsSchemaProvider(
+            applicationContext,
+            federationResolver,
+            existingTypeDefinitionFactory,
+            mockProviders,
+            configProps.schemaLocations
+        )
     }
 
     @Bean

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+/**
+ * Configuration properties for DGS framework.
+ */
+@ConstructorBinding
+@ConfigurationProperties(prefix = "dgs.graphql")
+@Suppress("ConfigurationProperties")
+data class DgsConfigurationProperties(
+    /** Location of the GraphQL schema files. */
+    @DefaultValue("classpath*:schema/**/*.graphql*") val schemaLocations: List<String>
+)

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.autoconfig
 
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider.Companion.DEFAULT_SCHEMA_LOCATION
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.bind.DefaultValue
@@ -28,5 +29,5 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 @Suppress("ConfigurationProperties")
 data class DgsConfigurationProperties(
     /** Location of the GraphQL schema files. */
-    @DefaultValue("classpath*:schema/**/*.graphql*") val schemaLocations: List<String>
+    @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>
 )

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationPropertiesTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationPropertiesTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+import java.util.*
+
+class DgsConfigurationPropertiesTest {
+
+    @Test
+    fun schemaLocationsDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.schemaLocations).containsExactly("classpath*:schema/**/*.graphql*")
+    }
+
+    @Test
+    fun schemaLocationsCustom() {
+        val properties = bind("dgs.graphql.schema-locations", "file:/some/resource/path/schema.graphqls")
+        Assertions.assertThat(properties.schemaLocations).containsExactly("file:/some/resource/path/schema.graphqls")
+    }
+
+    @Test
+    fun schemaLocationsMultiple() {
+        val properties = bind("dgs.graphql.schema-locations", "foo.graphqls, bar.graphqls")
+        Assertions.assertThat(properties.schemaLocations).containsExactly("foo.graphqls", "bar.graphqls")
+    }
+
+    private fun bind(name: String, value: String): DgsConfigurationProperties {
+        return bind(Collections.singletonMap(name, value))
+    }
+
+    private fun bind(map: Map<String?, String?>): DgsConfigurationProperties {
+        val source: ConfigurationPropertySource = MapConfigurationPropertySource(map)
+        return Binder(source).bindOrCreate("dgs.graphql", DgsConfigurationProperties::class.java)
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationPropertiesTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationPropertiesTest.kt
@@ -38,7 +38,7 @@ class DgsConfigurationPropertiesTest {
     }
 
     @Test
-    fun schemaLocationsMultiple() {
+    fun schemaLocationsCustomMultiple() {
         val properties = bind("dgs.graphql.schema-locations", "foo.graphqls, bar.graphqls")
         Assertions.assertThat(properties.schemaLocations).containsExactly("foo.graphqls", "bar.graphqls")
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -435,7 +435,7 @@ class DgsSchemaProvider(
                 logger.info("No schema files found, but a schema was provided as an TypeDefinitionRegistry")
                 arrayOf()
             } else {
-                logger.error("No schema files found. Define schema locations with property dgs.graphql.schema-locations")
+                logger.error("No schema files found in ${schemaLocations}. Define schema locations with property dgs.graphql.schema-locations")
                 throw NoSchemaFoundException()
             }
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -435,7 +435,7 @@ class DgsSchemaProvider(
                 logger.info("No schema files found, but a schema was provided as an TypeDefinitionRegistry")
                 arrayOf()
             } else {
-                logger.error("No schema files found in ${schemaLocations}. Define schema locations with property dgs.graphql.schema-locations")
+                logger.error("No schema files found in $schemaLocations. Define schema locations with property dgs.graphql.schema-locations")
                 throw NoSchemaFoundException()
             }
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -425,7 +425,7 @@ class DgsSchemaProvider(
 
         val resolver = PathMatchingResourcePatternResolver(cl)
         val schemas = try {
-            var resources = schemaLocations.flatMap { resolver.getResources(it).toList() }.distinct().toTypedArray()
+            val resources = schemaLocations.flatMap { resolver.getResources(it).toList() }.distinct().toTypedArray()
             if (resources.isEmpty()) {
                 throw NoSchemaFoundException()
             }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -60,8 +60,13 @@ class DgsSchemaProvider(
     private val applicationContext: ApplicationContext,
     private val federationResolver: Optional<DgsFederationResolver>,
     private val existingTypeDefinitionRegistry: Optional<TypeDefinitionRegistry>,
-    private val mockProviders: Optional<Set<MockProvider>>
+    private val mockProviders: Optional<Set<MockProvider>>,
+    private val schemaLocations: List<String> = listOf(DEFAULT_SCHEMA_LOCATION)
 ) {
+
+    companion object {
+        const val DEFAULT_SCHEMA_LOCATION = "classpath*:schema/**/*.graphql*"
+    }
 
     val dataFetcherInstrumentationEnabled = mutableMapOf<String, Boolean>()
     val entityFetchers = mutableMapOf<String, Pair<Any, Method>>()
@@ -415,12 +420,12 @@ class DgsSchemaProvider(
         }
     }
 
-    internal fun findSchemaFiles(basedir: String = "schema", hasDynamicTypeRegistry: Boolean = false): Array<Resource> {
+    internal fun findSchemaFiles(hasDynamicTypeRegistry: Boolean = false): Array<Resource> {
         val cl = Thread.currentThread().contextClassLoader
 
         val resolver = PathMatchingResourcePatternResolver(cl)
         val schemas = try {
-            val resources = resolver.getResources("classpath*:$basedir/**/*.graphql*")
+            var resources = schemaLocations.flatMap { resolver.getResources(it).toList() }.distinct().toTypedArray()
             if (resources.isEmpty()) {
                 throw NoSchemaFoundException()
             }
@@ -430,23 +435,17 @@ class DgsSchemaProvider(
                 logger.info("No schema files found, but a schema was provided as an TypeDefinitionRegistry")
                 arrayOf()
             } else {
-                logger.error("No schema files found. Define schemas in src/main/resources/$basedir/**/*.graphqls")
+                logger.error("No schema files found. Define schema locations with property dgs.graphql.schema-locations")
                 throw NoSchemaFoundException()
             }
         }
 
-        val testSchemas = try {
-            resolver.getResources("classpath:$basedir-test/**/*.graphql*")
-        } catch (ex: Exception) {
-            arrayOf<Resource>()
-        }
-
         val metaInfSchemas = try {
-            resolver.getResources("classpath*:META-INF/$basedir/**/*.graphql*")
+            resolver.getResources("classpath*:META-INF/schema/**/*.graphql*")
         } catch (ex: Exception) {
             arrayOf<Resource>()
         }
 
-        return schemas + testSchemas + metaInfSchemas
+        return schemas + metaInfSchemas
     }
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -80,6 +80,36 @@ internal class DgsSchemaProviderTest {
     }
 
     @Test
+    fun findMultipleSchemaFilesSingleLocation() {
+        val findSchemaFiles = DgsSchemaProvider(
+            applicationContextMock,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            listOf("classpath*:location1/**/*.graphql*")
+        ).findSchemaFiles()
+        assertThat(findSchemaFiles.size).isGreaterThan(2)
+        assertEquals("location1-schema1.graphqls", findSchemaFiles[0].filename)
+        assertEquals("location1-schema2.graphqls", findSchemaFiles[1].filename)
+    }
+
+    @Test
+    fun findMultipleSchemaFilesMultipleLocations() {
+        val findSchemaFiles = DgsSchemaProvider(
+            applicationContextMock,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            listOf("classpath*:location1/**/*.graphql*", "classpath*:location2/**/*.graphql*")
+        ).findSchemaFiles()
+        assertThat(findSchemaFiles.size).isGreaterThan(4)
+        assertEquals("location1-schema1.graphqls", findSchemaFiles[0].filename)
+        assertEquals("location1-schema2.graphqls", findSchemaFiles[1].filename)
+        assertEquals("location2-schema1.graphqls", findSchemaFiles[2].filename)
+        assertEquals("location2-schema2.graphqls", findSchemaFiles[3].filename)
+    }
+
+    @Test
     fun findSchemaFilesEmptyDir() {
         assertThrows<NoSchemaFoundException> {
             DgsSchemaProvider(

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -86,8 +86,9 @@ internal class DgsSchemaProviderTest {
                 applicationContextMock,
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty()
-            ).findSchemaFiles("notexists")
+                Optional.empty(),
+                listOf("classpath*:notexists/**/*.graphql*")
+            ).findSchemaFiles()
         }
     }
 
@@ -97,8 +98,9 @@ internal class DgsSchemaProviderTest {
             applicationContextMock,
             Optional.empty(),
             Optional.of(TypeDefinitionRegistry()),
-            Optional.empty()
-        ).findSchemaFiles("noexists")
+            Optional.empty(),
+            listOf("classpath*:noexists/**/*.graphql*")
+        ).findSchemaFiles()
         assertEquals(0, findSchemaFiles.size)
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -129,9 +129,8 @@ internal class DgsSchemaProviderTest {
             Optional.empty(),
             Optional.of(TypeDefinitionRegistry()),
             Optional.empty(),
-            listOf("classpath*:noexists/**/*.graphql*")
+            listOf("classpath*:notexists/**/*.graphql*")
         ).findSchemaFiles()
-        assertEquals(0, findSchemaFiles.size)
     }
 
     @Test

--- a/graphql-dgs/src/test/resources/location1/location1-schema1.graphqls
+++ b/graphql-dgs/src/test/resources/location1/location1-schema1.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    hello(name:String): String
+}

--- a/graphql-dgs/src/test/resources/location1/location1-schema2.graphqls
+++ b/graphql-dgs/src/test/resources/location1/location1-schema2.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    hello(name:String): String
+}

--- a/graphql-dgs/src/test/resources/location2/location2-schema1.graphqls
+++ b/graphql-dgs/src/test/resources/location2/location2-schema1.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    hello(name:String): String
+}

--- a/graphql-dgs/src/test/resources/location2/location2-schema2.graphqls
+++ b/graphql-dgs/src/test/resources/location2/location2-schema2.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    hello(name:String): String
+}


### PR DESCRIPTION
As discussed before in #165. 
But instead of configurable `schema-base-dir` this PR provides a configurable `schema-locations` property with a default value of `"classpath*:schema/**/*.graphql*"`.

Note that I removed loading schema files from `"classpath:$basedir-test/**/*.graphql*"`, but if needed this can be added again.

 