### PR TITLE
Avoid graphql-dgs-platform from being exported in submodules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ configure(subprojects.filterNot { it in internalBomModules }) {
 
     dependencies {
         // Apply the BOM to applicable subprojects.
-        api(platform(project(":graphql-dgs-platform")))
+        compileOnly(platform(project(":graphql-dgs-platform")))
         // Speed up processing of AutoConfig's produced by Spring Boot
         annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
         // Produce Config Metadata for properties used in Spring Boot


### PR DESCRIPTION
This commit prevents the `graphql-dgs-platform` to be exported in submodules `dependencyManagement` blocks. This allows users to easily override, if needed, versions.