### PR TITLE
Reverting to use implementation as scope for graphql-dgs-platform.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ configure(subprojects.filterNot { it in internalBomModules }) {
 
     dependencies {
         // Apply the BOM to applicable subprojects.
-        compileOnly(platform(project(":graphql-dgs-platform")))
+        implementation(platform(project(":graphql-dgs-platform")))
         // Speed up processing of AutoConfig's produced by Spring Boot
         annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
         // Produce Config Metadata for properties used in Spring Boot

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -52,6 +52,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
@@ -70,17 +71,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -94,6 +84,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "project": true
@@ -591,6 +582,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
@@ -609,17 +601,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -633,6 +614,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "project": true

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -71,16 +71,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -94,6 +84,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "project": true
@@ -490,16 +481,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -513,6 +494,7 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "project": true

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -56,12 +56,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
@@ -432,12 +426,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -68,15 +68,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
@@ -542,15 +533,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -56,12 +56,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
@@ -445,13 +439,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -56,11 +56,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {
@@ -412,11 +407,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -53,12 +53,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse": {
@@ -430,12 +424,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse": {

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -56,11 +56,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {
@@ -412,11 +407,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -53,12 +53,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets": {
@@ -430,12 +424,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets": {

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -56,11 +56,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {
@@ -418,11 +413,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -52,10 +52,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {
@@ -366,10 +362,6 @@
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types"
-            ],
             "project": true
         },
         "com.netflix.graphql.dgs:graphql-error-types": {


### PR DESCRIPTION
Turns out that if we define the platform import with a compileOnly scope the generation of the locks will fail with the following error.

```
Failed to resolve the following dependencies:
  1. Failed to resolve 'com.apollographql.federation:federation-graphql-java-support' for project 'graphql-dgs'
  2. Failed to resolve 'com.graphql-java:graphql-java' for project 'graphql-dgs'
The following dependencies are missing a version: com.apollographql.federation:federation-graphql-java-support, com.graphql-java:graphql-java
```

Therefore we changed it from:

```
compileOnly(platform(project(":graphql-dgs-platform")))
```

to:

```
implementation(platform(project(":graphql-dgs-platform")))
```