### PR TITLE
Adjusting the none DGS artifact in the BOM to express their version as preferred 

### DIFF
--- a/graphql-dgs-platform-dependencies/build.gradle.kts
+++ b/graphql-dgs-platform-dependencies/build.gradle.kts
@@ -59,13 +59,17 @@ afterEvaluate {
     val passThroughRecommendations =
         rootProject.dependencyRecommendations.mavenBomProvider.recommendations
             .filterNot { it.key in ignoreExternalModules }
-            .map { "${it.key}:${it.value}" }
+            .map { it.key to it.value }
 
     project.dependencies {
         constraints {
-            (passThroughRecommendations).forEach {
-                logger.info("Adding ${it} as constraint.")
-                api(it)
+            passThroughRecommendations.forEach {
+                logger.info("Adding ${it.first} as prefer constraint for ${it.second}.")
+                api(it.first) {
+                    version {
+                        prefer(it.second)
+                    }
+                }
             }
         }
     }

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -41,13 +41,28 @@ rootProject.subprojects
     }
 
 dependencies {
+    // The following constraints leverage the _rich versioning_ exposed by Gradle,
+    // this will be published as Maven Metadata.
+    // For more information at https://docs.gradle.org/current/userguide/rich_versions.html
     constraints {
-        api("com.graphql-java:graphql-java:${Versions.GRAPHQL_JAVA}")
-        api("com.apollographql.federation:federation-graphql-java-support:${Versions.GRAPHQL_JAVA_FEDERATION}")
-        api("com.jayway.jsonpath:json-path:2.5.+")
-        api("io.reactivex.rxjava3:rxjava:3.+")
-        api("io.projectreactor:reactor-core:3.4.+")
-        api("io.projectreactor:reactor-test:3.4.+")
+        api("com.graphql-java:graphql-java") {
+            version { require(Versions.GRAPHQL_JAVA) }
+        }
+        api("com.apollographql.federation:federation-graphql-java-support") {
+            version { require(Versions.GRAPHQL_JAVA_FEDERATION) }
+        }
+        api("com.jayway.jsonpath:json-path") {
+            version { require("2.5.+") }
+        }
+        api("io.reactivex.rxjava3:rxjava") {
+            version { require("3.0.+") }
+        }
+        api("io.projectreactor:reactor-core") {
+            version { require("3.4.+") }
+        }
+        api("io.projectreactor:reactor-test"){
+            version { require("3.4.+") }
+        }
     }
 }
 
@@ -71,9 +86,10 @@ afterEvaluate {
 
     project.dependencies {
         constraints {
-            (subprojectRecommendations).forEach {
+            subprojectRecommendations.forEach {
                 logger.info("Adding ${it} as constraint.")
                 api(it)
+
             }
         }
     }


### PR DESCRIPTION
We are reducing how _opinionated_ we are in the versions of none-DGS artifacts exposed in the BOMs.

> prefer
> This is a very soft version declaration. It applies only if there is no stronger non dynamic
> opinion on a version for the module. This term does not support dynamic versions.
Ref. https://docs.gradle.org/current/userguide/rich_versions.html

## graphql-dgs-platform-dependencies

* All artifact versions that are being picked up from the BOMs are expressed with `prefer` versions.
