### PR TITLE
BOM Using mathematical notation when defining versions

### DIFF
--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -52,16 +52,16 @@ dependencies {
             version { require(Versions.GRAPHQL_JAVA_FEDERATION) }
         }
         api("com.jayway.jsonpath:json-path") {
-            version { require("2.5.+") }
+            version { require("[2.5,)") }
         }
         api("io.reactivex.rxjava3:rxjava") {
-            version { require("3.0.+") }
+            version { require("[3.0,)") }
         }
         api("io.projectreactor:reactor-core") {
-            version { require("3.4.+") }
+            version { require("[3.4,)") }
         }
         api("io.projectreactor:reactor-test"){
-            version { require("3.4.+") }
+            version { require("[3.4,)") }
         }
     }
 }


### PR DESCRIPTION
Changing the Gradle Build to use mathematical notation when defining the version.
Sonatype deployment will fail with the following message otherwise.
```
Invalid POM: /com/netflix/graphql/dgs/graphql-dgs-platform/3.10.0/graphql-dgs-platform-3.10.0.pom: Invalid version for Dependency {groupId=com.jayway.jsonpath, artifactId=json-path, version=2.5.+, type=jar} - uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher. Invalid version for Dependency {groupId=io.reactivex.rxjava3, artifactId=rxjava, version=3.0.+, type=jar} - uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher. Invalid version for Dependency {groupId=io.projectreactor, artifactId=reactor-core, version=3.4.+, type=jar} - uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher. Invalid version for Dependency {groupId=io.projectreactor, artifactId=reactor-test, version=3.4.+, type=jar} - uses invalid dynamic version syntax. Replace with a fixed version or standard mathematical notation e.g., [1.5,) for version 1.5 and higher.
```