### PR TITLE
Define a recommendation for graphql-java-extended-scalars

### DIFF
--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -48,6 +48,13 @@ dependencies {
         api("com.graphql-java:graphql-java") {
             version { require(Versions.GRAPHQL_JAVA) }
         }
+        api("com.graphql-java:graphql-java-extended-scalars") {
+            // Note that the version of graphql-java should dictate the version of the scalars,
+            // but until https://github.com/graphql-java/graphql-java-extended-scalars/issues/38 is addressed we
+            // are preferring 15.0.0.
+            // Ref. https://github.com/graphql-java/graphql-java-extended-scalars
+            version { prefer("15.0.0") }
+        }
         api("com.apollographql.federation:federation-graphql-java-support") {
             version { require(Versions.GRAPHQL_JAVA_FEDERATION) }
         }


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----

This commit adds a recommendation for graphql-java-extended-scalars that will accommodate the requirements of compatibly in relationship with graphql-java. The latter is already part of the recommendations.

Per graphql-java-extended-scalars

> use 1.0.1 or above for graphql-java 14.x and above
> use 15.0.0 or above for graphql-java 15.x and above
> use 16.0.0 or above for graphql-java 16.x and above

Reference https://github.com/graphql-java/graphql-java-extended-scalars

### Note
The graphql-java-extended-scalars 16.0.0 artifact is not published in Maven Central. 
For this reason we are recommending 15.0.0, with a _preferred_ scope, until  https://github.com/graphql-java/graphql-java-extended-scalars/issues/38 is fixed.

Alternatives considered
----

We could not have a recommendation, but this will mean that developers will then have to figure out which version of `graphql-java-extended-scalars` to use according to the version of `graphql-java` that we do recommend.
