### PR TITLE
Revert "Update Gradle Wrapper from 6.8.3 to 7.0"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=eb8b89184261025b0430f5b2233701ff1377f96da1ef5e278af6ae8bac5cc305
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionSha256Sum=7faa7198769f872826c8ef4f1450f839ec27f0b4d5d1e51bade63667cbccd205
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Reverts Netflix/dgs-framework#252, the `license-gradle-plugin` (0.15.0) breaks with Gradle 7.

https://github.com/hierynomus/license-gradle-plugin/issues/179