### PR TITLE
Bugfix: Allow JSON Documents with DateTime scalars to be deserialized to Objects

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -18,6 +18,7 @@ package com.netflix.graphql.dgs.internal
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.jayway.jsonpath.*
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider
@@ -64,6 +65,7 @@ class DefaultDgsQueryExecutor(
                 .mappingProvider(
                     JacksonMappingProvider(
                         jacksonObjectMapper()
+                            .registerModule(JavaTimeModule())
                             .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
                             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                     )


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Allow the DgsQueryExecutor to deserialize JSON responses to Objects for documents containing scalar DateTime types.
Resolves #269 
