### PR TITLE
Updated GraphQL Java Extended Scalars version in platform BOM

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -21,6 +21,7 @@ object Versions {
     const val SPRING_SECURITY_VERSION = "5.3.9.RELEASE"
     const val SPRING_CLOUD_VERSION = "Hoxton.SR10"
     const val GRAPHQL_JAVA = "16.2"
+    const val GRAPHQL_JAVA_EXTENDED_SCALARS = "16.0.1"
     const val GRAPHQL_JAVA_FEDERATION = "0.6.3"
     const val JACKSON_BOM = "2.12.3"
 }

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -49,11 +49,7 @@ dependencies {
             version { require(Versions.GRAPHQL_JAVA) }
         }
         api("com.graphql-java:graphql-java-extended-scalars") {
-            // Note that the version of graphql-java should dictate the version of the scalars,
-            // but until https://github.com/graphql-java/graphql-java-extended-scalars/issues/38 is addressed we
-            // are preferring 15.0.0.
-            // Ref. https://github.com/graphql-java/graphql-java-extended-scalars
-            version { prefer("15.0.0") }
+            version { require(Versions.GRAPHQL_JAVA_EXTENDED_SCALARS) }
         }
         api("com.apollographql.federation:federation-graphql-java-support") {
             version { require(Versions.GRAPHQL_JAVA_FEDERATION) }


### PR DESCRIPTION
Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): BOM update

Changes in this PR
----

As https://github.com/graphql-java/graphql-java-extended-scalars/issues/38 is fixed/closed now and GraphQL Java Extended Scalars `16.0.1` is now on Maven Central the DGS BOM should use it instead of `15.0.0`.

