### PR TITLE
Add open keyword to class definition of @RestController classes

### DIFF
--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -62,7 +62,7 @@ import org.springframework.web.multipart.MultipartFile
  */
 
 @RestController
-class DgsRestController(private val dgsQueryExecutor: DgsQueryExecutor) {
+open class DgsRestController(private val dgsQueryExecutor: DgsQueryExecutor) {
 
     val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
 

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController
  * Provides an HTTP endpoint to retrieve the available schema.
  */
 @RestController
-class DgsRestSchemaJsonController(private val schemaProvider: DgsSchemaProvider) {
+open class DgsRestSchemaJsonController(private val schemaProvider: DgsSchemaProvider) {
 
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
     @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.schemaJson.path}", produces = ["application/json"])

--- a/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
+++ b/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets
 import java.util.*
 
 @RestController
-class DgsSSESubscriptionHandler(private val dgsQueryExecutor: DgsQueryExecutor) {
+open class DgsSSESubscriptionHandler(private val dgsQueryExecutor: DgsQueryExecutor) {
     private val logger = LoggerFactory.getLogger(DgsSSESubscriptionHandler::class.java)
 
     @RequestMapping("/subscriptions", produces = ["text/event-stream"])


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
The classes `DgsRestController`, `DgsRestSchemaJsonController`, and `DgsSSESubscriptionHandler` have been changed to be declared as `open class`.

We (company) use Spring AOP along with [CGLIB proxying](https://docs.spring.io/spring-framework/docs/current/reference/html/core.html#beans-factory-scopes-other-injection-proxies), which causes issues if beans on final classes are introduced. I am aware this is candidate for improvement on our side, however it's an easy fix if the remaining 3 beans in dgs-framework were changed to be open classes.
This might improve usability for other users with side dependencies like Spring AOP aswell.
As far as I am aware, this change doesn't introduce any side effects or change in functionality of the library.

