### PR TITLE
Added docs to DgsQueryExecutor

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
@@ -33,13 +33,46 @@ import org.springframework.web.context.request.WebRequest
  * See https://netflix.github.io/dgs/query-execution-testing/
  */
 interface DgsQueryExecutor {
+    /**
+     * @param query The query string
+     * @return Returns a GraphQL [ExecutionResult]. This includes data and errors.
+     */
     fun execute(query: String): ExecutionResult = execute(query = query, variables = emptyMap())
+
+    /**
+     * @param query The query string
+     * @param variables A map of variables https://graphql.org/learn/queries/#variables
+     * @return Returns a GraphQL [ExecutionResult]. This includes data and errors.
+     */
     fun execute(query: String, variables: Map<String, Any>): ExecutionResult = execute(query = query, variables = variables, operationName = null)
+
+    /**
+     * @param query The query string
+     * @param variables A map of variables https://graphql.org/learn/queries/#variables
+     * @param operationName The operation name https://graphql.org/learn/queries/#operation-name
+     * @return Returns a GraphQL [ExecutionResult]. This includes data and errors.
+     */
     fun execute(query: String, variables: Map<String, Any> = mutableMapOf(), operationName: String? = null): ExecutionResult
 
+    /**
+     * @param query The query string
+     * @param variables A map of variables https://graphql.org/learn/queries/#variables
+     * @param extensions A map representing GraphQL extensions. This is made available in the [com.netflix.graphql.dgs.internal.DgsRequestData] object on [com.netflix.graphql.dgs.context.DgsContext].
+     * @return Returns a GraphQL [ExecutionResult]. This includes data and errors.
+     */
     fun execute(query: String, variables: Map<String, Any>, extensions: Map<String, Any>?, headers: HttpHeaders): ExecutionResult =
         execute(query = query, variables = variables, extensions = extensions, headers = headers, operationName = null)
 
+    /**
+     * Executes a GraphQL query. This method is used internally by all other methods in this interface.
+     * @param query The query string
+     * @param variables A map of variables https://graphql.org/learn/queries/#variables
+     * @param extensions A map representing GraphQL extensions. This is made available in the [com.netflix.graphql.dgs.internal.DgsRequestData] object on [com.netflix.graphql.dgs.context.DgsContext].
+     * @param headers Request headers represented as a Spring Framework [HttpHeaders]
+     * @param operationName Operation name https://graphql.org/learn/queries/#operation-name
+     * @param webRequest A Spring [WebRequest] giving access to request details. Can cast to an environment specific class such as [org.springframework.web.context.request.ServletWebRequest].
+     * @return Returns a GraphQL [ExecutionResult]. This includes data and errors.
+     */
     fun execute(
         query: String,
         variables: Map<String, Any>,
@@ -49,14 +82,85 @@ interface DgsQueryExecutor {
         webRequest: WebRequest? = null
     ): ExecutionResult
 
+    /**
+     * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
+     * The method is generic, and tries to cast the result into the type you specify. This does NOT work work Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
+     * @param query Query string
+     * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
+     * @return T is the type you specify. This only works for primitive types and map representations. Use [executeAndExtractJsonPathAsObject] for complex types and lists.
+     */
     fun <T> executeAndExtractJsonPath(query: String, jsonPath: String): T
+
+    /**
+     * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
+     * The method is generic, and tries to cast the result into the type you specify. This does NOT work work Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
+     * @param query Query string
+     * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
+     * @param variables A Map of variables https://graphql.org/learn/queries/#variables
+     * @return T is the type you specify. This only works for primitive types and map representations. Use [executeAndExtractJsonPathAsObject] for complex types and lists.
+     */
     fun <T> executeAndExtractJsonPath(query: String, jsonPath: String, variables: Map<String, Any>): T
 
+    /**
+     * Executes a GraphQL query, parses the returned data, and return a [DocumentContext].
+     * A [DocumentContext] can be used to extract multiple values using JsonPath, without re-executing the query.
+     * @param query Query string
+     * @return [DocumentContext] is a JsonPath type used to extract values from.
+     */
     fun executeAndGetDocumentContext(query: String): DocumentContext
+
+    /**
+     * Executes a GraphQL query, parses the returned data, and return a [DocumentContext].
+     * A [DocumentContext] can be used to extract multiple values using JsonPath, without re-executing the query.
+     * @param query Query string
+     * @param variables A Map of variables https://graphql.org/learn/queries/#variables
+     * @return [DocumentContext] is a JsonPath type used to extract values from.
+     */
     fun executeAndGetDocumentContext(query: String, variables: Map<String, Any>): DocumentContext
 
+    /**
+     * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
+     * Be aware that this method can't guarantee type safety.
+     * @param query Query string
+     * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
+     * @param clazz The type to convert the extracted value to.
+     * @return The extracted value from the result, converted to type T
+     */
     fun <T> executeAndExtractJsonPathAsObject(query: String, jsonPath: String, clazz: Class<T>): T
+
+    /**
+     * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
+     * Be aware that this method can't guarantee type safety.
+     * @param query Query string
+     * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
+     * @param variables A Map of variables https://graphql.org/learn/queries/#variables
+     * @param clazz The type to convert the extracted value to.
+     * @return The extracted value from the result, converted to type T
+     */
     fun <T> executeAndExtractJsonPathAsObject(query: String, jsonPath: String, variables: Map<String, Any>, clazz: Class<T>): T
+
+    /**
+     * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
+     * Uses a [TypeRef] to specify the expected type, which is useful for Lists and Maps.
+     * Details about [TypeRef] can be found in the JsonPath documentation: https://github.com/json-path/JsonPath#what-is-returned-when
+     * Be aware that this method can't guarantee type safety.
+     * @param query Query string
+     * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
+     * @param typeRef A JsonPath [TypeRef] representing the expected result type.
+     * @return The extracted value from the result, converted to type T
+     */
     fun <T> executeAndExtractJsonPathAsObject(query: String, jsonPath: String, typeRef: TypeRef<T>): T
+
+    /**
+     * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
+     * Uses a [TypeRef] to specify the expected type, which is useful for Lists and Maps.
+     * Details about [TypeRef] can be found in the JsonPath documentation: https://github.com/json-path/JsonPath#what-is-returned-when
+     * Be aware that this method can't guarantee type safety.
+     * @param query Query string
+     * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
+     * @param variables A Map of variables https://graphql.org/learn/queries/#variables
+     * @param typeRef A JsonPath [TypeRef] representing the expected result type.
+     * @return The extracted value from the result, converted to type T
+     */
     fun <T> executeAndExtractJsonPathAsObject(query: String, jsonPath: String, variables: Map<String, Any>, typeRef: TypeRef<T>): T
 }


### PR DESCRIPTION
I noticed we didn't have docs on the DgsQueryExecutor, which should obviously be there.