### PR TITLE
Fix/subscription

### DIFF
--- a/graphql-dgs-subscriptions-sse/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandlerTest.kt
+++ b/graphql-dgs-subscriptions-sse/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandlerTest.kt
@@ -82,6 +82,34 @@ internal class DgsSSESubscriptionHandlerTest {
     }
 
     @Test
+    fun queryWithoutSubscriptionOperationError() {
+
+        val query = " { stocks { name, price }}"
+        val queryPayload = DgsSSESubscriptionHandler.QueryPayload(operationName = "MySubscription", query = query)
+        val base64 = Base64.getEncoder().encodeToString(jacksonObjectMapper().writeValueAsBytes(queryPayload))
+
+        every { dgsQueryExecutor.execute(query, any()) } returns executionResultMock
+        // every { executionResultMock.errors } returns listOf(ValidationError.newValidationError().build())
+
+        val responseEntity = DgsSSESubscriptionHandler(dgsQueryExecutor).subscriptionWithId(base64)
+        assertThat(responseEntity.statusCode.is4xxClientError).isTrue
+    }
+
+    @Test
+    fun queryWithQueryOperationError() {
+
+        val query = " query { stocks { name, price }}"
+        val queryPayload = DgsSSESubscriptionHandler.QueryPayload(operationName = "MySubscription", query = query)
+        val base64 = Base64.getEncoder().encodeToString(jacksonObjectMapper().writeValueAsBytes(queryPayload))
+
+        every { dgsQueryExecutor.execute(query, any()) } returns executionResultMock
+        // every { executionResultMock.errors } returns listOf(ValidationError.newValidationError().build())
+
+        val responseEntity = DgsSSESubscriptionHandler(dgsQueryExecutor).subscriptionWithId(base64)
+        assertThat(responseEntity.statusCode.is4xxClientError).isTrue
+    }
+
+    @Test
     fun invalidJson() {
 
         val query = "subscription { stocks { name, price }}"
@@ -124,7 +152,7 @@ internal class DgsSSESubscriptionHandlerTest {
     @Test
     @Suppress("ReactiveStreamsUnusedPublisher")
     fun success() {
-        val query = "query { stocks { name, price }}"
+        val query = "subscription { stocks { name, price }}"
         val queryPayload = DgsSSESubscriptionHandler.QueryPayload(operationName = "MySubscription", query = query)
         val base64 = Base64.getEncoder().encodeToString(jacksonObjectMapper().writeValueAsBytes(queryPayload))
 


### PR DESCRIPTION

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Check for the operation type in a subscription query and return an error. If not specified, the operation is assumed to be a query and the error is misleading.
 ```
subscription { someSubscription { fieldA } } // This is the expected form
{ someSubscription { fieldA } } // This should result in an error and not execute the query
query { someSubscription {fieldA } } // This should result in an error and not execute the query
``
This check is important especially if the schema has both a query and subscription with the same name, i.e. `someSubscription` in the above example.
