### PR TITLE
Switch to -Xjvm-default=enable compiler flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
     repositories {
         mavenCentral()
@@ -113,21 +115,14 @@ configure(subprojects.filterNot { it in internalBomModules }) {
         }
     }
 
+    tasks.withType<KotlinCompile>().configureEach {
+        kotlinOptions {
+            freeCompilerArgs += "-Xjvm-default=enable"
+            jvmTarget = "1.8"
+        }
+    }
+
     tasks {
-        compileKotlin {
-            kotlinOptions {
-                freeCompilerArgs = listOf("-Xjvm-default=all")
-                jvmTarget = "1.8"
-            }
-        }
-
-        compileTestKotlin {
-            kotlinOptions {
-                freeCompilerArgs = listOf("-Xjvm-default=all")
-                jvmTarget = "1.8"
-            }
-        }
-
         test {
             useJUnitPlatform()
         }


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Switch from -Xjvm-default=all to -Xjvm-default=enable compiler flag. -Xjvm-default=all causes warnings to be emitted by the compiler when a consumer extends interfaces that don't even have default methods; compiling with both flags, one can see the bytecode for the interface itself is the same, but the data embedded in the Kotlin `@Metadata` annotation differs.

I've reported this as a compiler bug here: https://youtrack.jetbrains.com/issue/KT-45919
