### PR TITLE
Serialize extended scalar types OffsetDateTime, OffsetTime, LocalDate…

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -16,6 +16,11 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.util.*
+
 class GraphQLQueryRequest(private val query: GraphQLQuery, private val projection: BaseProjectionNode?) {
 
     constructor(query: GraphQLQuery) : this(query, null)
@@ -36,21 +41,27 @@ class GraphQLQueryRequest(private val query: GraphQLQuery, private val projectio
                 if (value != null) {
                     builder.append(key)
                     builder.append(": ")
-                    if (value is String) {
-                        builder.append("\"")
-                        builder.append(value.toString())
-                        builder.append("\"")
-                    } else if (value is List<*>) {
-                        if (value.isNotEmpty() && value[0] is String) {
-                            builder.append("[")
-                            val result = value.joinToString(separator = "\", \"", prefix = "\"", postfix = "\"")
-                            builder.append(result)
-                            builder.append("]")
-                        } else {
+                    when (value) {
+                        is String,
+                        is OffsetDateTime,
+                        is OffsetTime,
+                        is LocalDate,
+                        is Locale -> {
+                            builder.append("\"")
                             builder.append(value.toString())
+                            builder.append("\"")
                         }
-                    } else {
-                        builder.append(value.toString())
+                        is List<*> -> {
+                            if (value.isNotEmpty() && value[0] is String) {
+                                builder.append("[")
+                                val result = value.joinToString(separator = "\", \"", prefix = "\"", postfix = "\"")
+                                builder.append(result)
+                                builder.append("]")
+                            } else {
+                                builder.append(value.toString())
+                            }
+                        }
+                        else -> builder.append(value.toString())
                     }
                 }
                 if (inputEntryIterator.hasNext()) {

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLQueryRequestTest.kt
@@ -21,6 +21,9 @@ import com.netflix.graphql.dgs.client.codegen.GraphQLQuery
 import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.*
+import java.time.ZoneOffset.UTC
+import java.util.*
 
 class GraphQLQueryRequestTest {
     @Test
@@ -93,6 +96,46 @@ class GraphQLQueryRequestTest {
         val request = GraphQLQueryRequest(query, MovieProjection().name().movieId())
         val result = request.serialize()
         assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\" }){ name movieId } }")
+    }
+
+    @Test
+    fun testSerializeInputClassOffsetDateTime() {
+        val query = TestGraphQLQuery().apply {
+            input["dateTime"] = OffsetDateTime.ofInstant(Instant.EPOCH, ZoneId.from(UTC))
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(dateTime: \"1970-01-01T00:00Z\") }")
+    }
+
+    @Test
+    fun testSerializeInputClassOffsetTime() {
+        val query = TestGraphQLQuery().apply {
+            input["time"] = OffsetTime.MIN
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(time: \"00:00+18:00\") }")
+    }
+
+    @Test
+    fun testSerializeInputClassLocalDate() {
+        val query = TestGraphQLQuery().apply {
+            input["date"] = LocalDate.of(2021, Month.APRIL, 1)
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(date: \"2021-04-01\") }")
+    }
+
+    @Test
+    fun testSerializeInputClassLocale() {
+        val query = TestGraphQLQuery().apply {
+            input["locale"] = Locale.UK
+        }
+        val request = GraphQLQueryRequest(query)
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query {test(locale: \"en_GB\") }")
     }
 }
 


### PR DESCRIPTION
…, Locale as String value wrapped in double quote.

Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Fixes java client serialisation issue to extended scalar types OffsetDateTime, OffsetTime, LocalDate and Locale.


_Describe the new behavior from this PR, and why it's needed_
Issue #
https://github.com/Netflix/dgs-framework/issues/290

Alternatives considered
----
New feature that allows for custom serializers this gives full control on how the objects will be serialized.

I have an example on the branch explaining the approach
https://github.com/amitgupta1202/dgs-framework/tree/feature/custom_serializer

