### PR TITLE
Implement calculation of query complexity metric.

### DIFF
--- a/graphql-dgs-example-java/build.gradle.kts
+++ b/graphql-dgs-example-java/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
     implementation(project(":graphql-dgs-subscriptions-websockets-autoconfigure"))
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("io.projectreactor:reactor-core")
-
     // Enabling Spring Boot Actuators. We are not expressing any opinion on which Metric System should be used
     // please review the Spring Boot Docs in the link below for additional information.
     // https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-metrics-export-simple
@@ -27,5 +26,4 @@ dependencies {
     // Adding the DGS Micrometer integration that provides timers for gql.*
     // For additional information go to the link below:
     // https://netflix.github.io/dgs/advanced/instrumentation/
-    implementation(project(":graphql-dgs-spring-boot-micrometer"))
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
@@ -62,8 +62,11 @@ object DgsMetrics {
         /** The name of the data loader, may or may not be the same as the type of entity. */
         LOADER_NAME("gql.loaderName"),
 
-        /** Used to capture the result of an action, e.g. `ERROR` or `SUCCESS`.*/
-        OUTCOME("outcome")
+        /** Used to capture the result of an action, e.g. `sERROR` or `SUCCESS`.*/
+        OUTCOME("outcome"),
+
+        /** Used to capture the query complexity.*/
+        QUERY_COMPLEXITY("gql.queryComplexity")
     }
 
     enum class GqlTagValue(val owner: GqlTag, val value: String) {

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -110,6 +110,7 @@ class MicrometerServletSmokeTest {
                 Tags.of("execution-tag", "foo")
                     .and("contextual-tag", "foo")
                     .and("outcome", "success")
+                    .and("gql.queryComplexity", "5")
             )
 
         assertThat(meters["gql.resolver"]).isNotNull.hasSize(1)
@@ -177,6 +178,7 @@ class MicrometerServletSmokeTest {
                 Tags.of("execution-tag", "foo")
                     .and("contextual-tag", "foo")
                     .and("outcome", "success")
+                    .and("gql.queryComplexity", "10")
             )
 
         assertThat(meters["gql.resolver"]).isNotNull.hasSize(3)
@@ -239,6 +241,7 @@ class MicrometerServletSmokeTest {
                 Tags.of("execution-tag", "foo")
                     .and("contextual-tag", "foo")
                     .and("outcome", "failure")
+                    .and("gql.queryComplexity", "0")
             )
     }
 
@@ -284,6 +287,7 @@ class MicrometerServletSmokeTest {
                 Tags.of("execution-tag", "foo")
                     .and("contextual-tag", "foo")
                     .and("outcome", "failure")
+                    .and("gql.queryComplexity", "5")
             )
 
         assertThat(meters["gql.resolver"]).isNotNull.hasSize(1)
@@ -339,6 +343,7 @@ class MicrometerServletSmokeTest {
                 Tags.of("execution-tag", "foo")
                     .and("contextual-tag", "foo")
                     .and("outcome", "failure")
+                    .and("gql.queryComplexity", "5")
             )
 
         assertThat(meters["gql.resolver"]).isNotNull.hasSize(1)
@@ -396,6 +401,7 @@ class MicrometerServletSmokeTest {
                 Tags.of("execution-tag", "foo")
                     .and("contextual-tag", "foo")
                     .and("outcome", "failure")
+                    .and("gql.queryComplexity", "5")
             )
 
         assertThat(meters["gql.resolver"]).isNotNull.hasSize(1)


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Query Complexity is the total number of nodes in the query. `graphql-java` provides a MaxQueryComplexityInstrumentation class that users can add and set limits on the query complexity (https://www.javadoc.io/doc/com.graphql-java/graphql-java/2019-07-13T23-07-14-8c71e18/graphql/analysis/MaxQueryComplexityInstrumentation.html)

This PR implements the query complexity calculation and sets the tag `gql.queryComplexity` with the value on the `gql.query` metric. To do so, we override the beginValidation() in the instrumentation class and implement the complexity by traversing the nodes using the same implementation as linked below:
Reference Implementation : https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/analysis/MaxQueryComplexityInstrumentation.java

In addition, we add the result of the query complexity calculation to our execution state for tagging as a metric.

Note that this does not provide any ability to limit the complexity of the query (as intended by MaxQueryComplexityInstrumentation). This implementation is simply for the framework to track the complexity for metrics.

Alternatives considered
----
I looked into using the MaxQueryComplexityFunction (provided as lambda) to extract the result of the query complexity computation, but this does not allow us to set the result in any execution specific state. This would have ideally avoided re-implementing beginValidation(). Since we don't have access to any execution specific state, I resorted to the approach above.

