### PR TITLE
DgsQueryExecutor.executeAndExtractJsonPath overloading for httpHeaders

### DIFF
--- a/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/HelloDataFetcher.java
+++ b/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/HelloDataFetcher.java
@@ -22,6 +22,8 @@ import com.netflix.graphql.dgs.example.context.MyContext;
 import graphql.GraphQLException;
 import graphql.schema.DataFetchingEnvironment;
 import org.dataloader.DataLoader;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -39,6 +41,11 @@ public class HelloDataFetcher {
         System.out.println(extensions);
 
         return "hello, " + name + "!";
+    }
+
+    @DgsQuery
+    public String helloWithHeaders(@InputArgument String name, @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+        return "hello, " + authorization + "!";
     }
 
     @DgsData(parentType = "Query", field = "messageFromBatchLoader")

--- a/graphql-dgs-example-java/src/main/resources/schema/schema.graphqls
+++ b/graphql-dgs-example-java/src/main/resources/schema/schema.graphqls
@@ -20,6 +20,9 @@ type Query {
 
     headers: String
     referer: String
+
+    ### To show how to handle HttpHeaders
+    helloWithHeaders(name: String): String
 }
 
 type NestedA {

--- a/graphql-dgs-example-java/src/test/java/com/netflix/graphql/dgs/example/HelloDataFetcherTest.java
+++ b/graphql-dgs-example-java/src/test/java/com/netflix/graphql/dgs/example/HelloDataFetcherTest.java
@@ -21,8 +21,12 @@ import com.netflix.graphql.dgs.exceptions.QueryException;
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
@@ -36,6 +40,22 @@ class HelloDataFetcherTest {
     void helloShouldIncludeName() {
         String message = queryExecutor.executeAndExtractJsonPath("{ hello(name: \"DGS\")}", "data.hello");
         assertThat(message).isEqualTo("hello, DGS!");
+    }
+
+    @Test
+    void helloWithHeadersShouldThrowQueryExceptionForMissingRequestHeaderAuthorization() {
+        assertThrows(QueryException.class, () -> {
+            queryExecutor.executeAndExtractJsonPath("{ helloWithHeaders(name: \"DGSHeader\")}", "data.helloWithHeaders");
+        });
+    }
+
+    @Test
+    void helloWithHeadersShouldReturnTheHeaderValue() {
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add(HttpHeaders.AUTHORIZATION, "dgsToken");
+        HttpHeaders httpHeaders = new HttpHeaders(map);
+        String value = queryExecutor.executeAndExtractJsonPath("{ helloWithHeaders(name: \"DGSHeader\")}", "data.helloWithHeaders", httpHeaders);
+        assertThat(value).isEqualTo("hello, dgsToken!");
     }
 
     @Test

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
@@ -102,6 +102,16 @@ interface DgsQueryExecutor {
     fun <T> executeAndExtractJsonPath(query: String, jsonPath: String, variables: Map<String, Any>): T
 
     /**
+     * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
+     * The method is generic, and tries to cast the result into the type you specify. This does NOT work work Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
+     * @param query Query string
+     * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
+     * @param headers  Request headers represented as a Spring Framework [HttpHeaders]
+     * @return T is the type you specify. This only works for primitive types and map representations. Use [executeAndExtractJsonPathAsObject] for complex types and lists.
+     */
+    fun <T> executeAndExtractJsonPath(query: String, jsonPath: String, headers: HttpHeaders): T
+
+    /**
      * Executes a GraphQL query, parses the returned data, and return a [DocumentContext].
      * A [DocumentContext] can be used to extract multiple values using JsonPath, without re-executing the query.
      * @param query Query string

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsQueryExecutor.kt
@@ -84,7 +84,7 @@ interface DgsQueryExecutor {
 
     /**
      * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
-     * The method is generic, and tries to cast the result into the type you specify. This does NOT work work Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
+     * The method is generic, and tries to cast the result into the type you specify. This does NOT work on Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
      * @param query Query string
      * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
      * @return T is the type you specify. This only works for primitive types and map representations. Use [executeAndExtractJsonPathAsObject] for complex types and lists.
@@ -93,7 +93,7 @@ interface DgsQueryExecutor {
 
     /**
      * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
-     * The method is generic, and tries to cast the result into the type you specify. This does NOT work work Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
+     * The method is generic, and tries to cast the result into the type you specify. This does NOT work on Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
      * @param query Query string
      * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
      * @param variables A Map of variables https://graphql.org/learn/queries/#variables
@@ -103,7 +103,7 @@ interface DgsQueryExecutor {
 
     /**
      * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
-     * The method is generic, and tries to cast the result into the type you specify. This does NOT work work Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
+     * The method is generic, and tries to cast the result into the type you specify. This does NOT work on Lists. Use [executeAndExtractJsonPathAsObject] with a [TypeRef] instead.
      * @param query Query string
      * @param jsonPath JsonPath expression. See https://github.com/json-path/JsonPath for syntax.
      * @param headers  Request headers represented as a Spring Framework [HttpHeaders]

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -150,6 +150,10 @@ class DefaultDgsQueryExecutor(
         return JsonPath.read(getJsonResult(query, variables), jsonPath)
     }
 
+    override fun <T> executeAndExtractJsonPath(query: String, jsonPath: String, headers: HttpHeaders): T {
+        return JsonPath.read(getJsonResult(query, emptyMap(), headers), jsonPath)
+    }
+
     override fun <T> executeAndExtractJsonPathAsObject(query: String, jsonPath: String, clazz: Class<T>): T {
         val jsonResult = getJsonResult(query, emptyMap())
         return try {
@@ -194,8 +198,8 @@ class DefaultDgsQueryExecutor(
         return parseContext.parse(getJsonResult(query, variables))
     }
 
-    private fun getJsonResult(query: String, variables: Map<String, Any>): String {
-        val executionResult = execute(query, variables)
+    private fun getJsonResult(query: String, variables: Map<String, Any>, headers: HttpHeaders? = null): String {
+        val executionResult = execute(query, variables, null, headers, null, null)
 
         if (executionResult.errors.size > 0) {
             throw QueryException(executionResult.errors)


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This PR adds a method overload to support `httpHeaders` for the method `executeAndExtractJsonPath`

Alternatives considered
----

It would be possible to avoid using `@RequestHeader` and rely on `DgsContext.getRequestData(dfe).getHeaders()` but this approach looks to be more straightforward.
In this way, the developer can avoid reinventing the wheel to extract the JSON results when the `httpHeaders` are mandatory

@berngp @srinivasankavitha @paulbakker Thanks for taking the time to review this PR.