### PR TITLE
Test Example Application as part of the CI Process

### DIFF
--- a/.github/workflows/ci-compatibility.yml
+++ b/.github/workflows/ci-compatibility.yml
@@ -1,0 +1,76 @@
+name: CI Compatibility Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk-version: [ 1.8 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Java ${{ matrix.jdk-version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk-version }}
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Python modules
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f scripts/requirements.txt ]; then pip install -r scripts/requirements.txt; fi
+
+      - uses: actions/cache@v1
+        id: gradle-wrapper-cache
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
+          restore-keys: ${{ runner.os }}-gradlewrapper-
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Maven cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and publish Locally
+        run: |
+          ./gradlew --info check publishToMavenLocal --warning-mode all
+
+      - name: Clone dgs-examples-java
+        uses: actions/checkout@master
+        with:
+          repository: Netflix/dgs-examples-java
+          path: build/examples/dgs-examples-java
+
+      - name: Clone dgs-examples-kotlin
+        uses: actions/checkout@master
+        with:
+          repository: Netflix/dgs-examples-kotlin
+          path: build/examples/dgs-examples-kotlin
+
+      - name: Build Examples
+        run: |
+          find /home/runner/.m2/repository/ -type f -name "*graphql-dgs-codegen-gradle*"
+          ./scripts/test-examples.py -v --path=./build/examples

--- a/.github/workflows/ci-compatibility.yml
+++ b/.github/workflows/ci-compatibility.yml
@@ -8,17 +8,14 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jdk-version: [ 1.8 ]
-
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup Java ${{ matrix.jdk-version }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.jdk-version }}
+          distribution: 'zulu'
+          java-version: 8
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -30,7 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f scripts/requirements.txt ]; then pip install -r scripts/requirements.txt; fi
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,10 @@ jobs:
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: 8
       # Runs a single command using the runners shell
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ buildSrc/.gradle/
 /.idea/vcs.xml
 /graphql-dgs-example-java/ui-example/node_modules/
 /.idea/kotlinScripting.xml
+scripts/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.PHONY: help all
+.DEFAULT_GOAL := help
+
+SHELL = /bin/sh
+
+## Gradle
+GW = ./gradlew
+GFLAGS ?=
+GW_CMD = $(GW) $(GFLAGS)
+
+# GW_OPT_DISABLE_LOCAL=-x autoLintGradle
+GW_OPT_DISABLE_LOCAL=
+
+
+format: ## Formats source code
+	$(GW_CMD) ktlintFormat
+
+
+publish-local: ## Clans, bulds, and publishes the Codegen artifacts to mavenLocal, as a SNAPSHOT.
+	$(GW_CMD) $(GW_OPT_DISABLE_LOCAL) clean build publishToMavenLocal
+
+
+test-examples_py: ## Modify the examples to use the latest Codegen SNAPSHOT, publishes the snapshot locally, and builds the examples.
+	scripts/test-examples.py -v -g --path=build/examples
+
+test-examples: ## Modify the examples to use the latest Codegen SNAPSHOT, publishes the snapshot locally, and builds the examples.
+	$(MAKE) publish-local
+	$(MAKE) test-examples_py
+
+install-py-libs: ## Installs the Python Modules required by the scripts.
+	 pip3 install -r scripts/requirements.txt
+
+
+all: test-examples ## Cleans, checks/tests, publishes the plugin locally and runs the examples.
+
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,0 +1,45 @@
+class State:
+    verbose = False
+
+
+class BColors:
+    """ Catalog of colors that can be used in the console. """
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+class Out:
+    @staticmethod
+    def debug(message, flag=True):
+        if flag:
+            print(f"DEBUG: {message}")
+
+    @staticmethod
+    def info(message):
+        print(f"{BColors.OKBLUE}INFO{BColors.ENDC}: {message}")
+
+    @staticmethod
+    def ok(message):
+        print(f"{BColors.OKGREEN}{BColors.BOLD}INFO{BColors.ENDC}: {message}")
+
+    @staticmethod
+    def warn(message, *args):
+        print(f"{BColors.WARNING}{BColors.BOLD}WARN{BColors.ENDC}: {message}", *args)
+
+    @staticmethod
+    def error(message, *args):
+        print(f"{BColors.FAIL}{BColors.BOLD}ERROR{BColors.ENDC}: {message}", *args)
+
+    @staticmethod
+    def usage(command, help_message):
+        print(f"""
+        {BColors.HEADER}Command: {BColors.ENDC}{command}
+        {help_message}
+        """)

--- a/scripts/config.yml
+++ b/scripts/config.yml
@@ -1,0 +1,23 @@
+#
+#   Copyright 2020 Netflix, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Currently Github Actions require us to explicitly clone the repository
+# as part of the job steps. If we try to clone them as part of
+# the Python scripts instead it will fail. Because of this, the list of examples
+# is duplicated in the ./github/workflows/ci-beta.yml file.
+repositories:
+    - "git@github.com:Netflix/dgs-examples-java.git"
+    - "git@github.com:Netflix/dgs-examples-kotlin.git"

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+GitPython
+PyYAML

--- a/scripts/scripts.iml
+++ b/scripts/scripts.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.9" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/scripts/test-examples.py
+++ b/scripts/test-examples.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+#
+#   Copyright 2020 Netflix, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import getopt
+import os
+import re
+import subprocess
+import shutil
+import sys
+import yaml
+import git
+
+from common import Out
+from common import BColors
+from common import State
+
+base_path = os.path.dirname(os.path.realpath(__file__))
+config_file = os.path.abspath(f"{base_path}/config.yml")
+
+examples_path = os.path.abspath(f"{base_path}/../build/examples")
+settings_gradle_kts_template = os.path.abspath(f"{base_path}/settings.gradle.kts")
+
+gradle_wd = os.path.abspath(f"{base_path}/..")
+gradlew = os.path.abspath(f"{base_path}/../gradlew")
+
+
+def load_config():
+    with open(config_file, "r") as yml_file:
+        config = yaml.load(yml_file, Loader=yaml.SafeLoader)
+    Out.debug(f"Configuration loaded from [{config_file}]:\n{config}\n", State.verbose)
+    return config
+
+
+def clone_repos(config, target):
+    if not target:
+        Out.error("Unable to determine the target path for the cloned repos,"
+                  " make sure the config defines a target value.")
+        exit(-2)
+    if not os.path.exists(target):
+        Out.info(f"Dir [{target}] is missing, creating... ")
+        os.mkdir(target)
+
+    cloned_repos = []
+
+    git_uris = config["repositories"]
+    if not git_uris:
+        Out.error("The repositories to clone are missing, make sure the config file defines a repos section.")
+        exit(-2)
+    for g_uri in git_uris:
+        try:
+            cloned_repo = git.Git(target).clone(g_uri)
+            if cloned_repo:
+                cloned_repos.append(cloned_repo)
+                Out.info(f"Repository [{g_uri}] cloned to [{target}].")
+        except git.exc.GitCommandError as git_error:
+            Out.warn(f"Unable to clone [{g_uri}].", git_error)
+
+
+def infer_version():
+    regex = re.compile(r"Inferred project: dgs-framework, version: ([0-9A-Z\-.]+)")
+    out = subprocess.check_output([gradlew, "-p", gradle_wd, "project"]).decode("utf-8")
+    Out.debug(f"Process output:\n{out}", State.verbose)
+    match = re.search(regex, out)
+    return match.group(1) if match else ""
+
+
+def infer_build_file(project_dir):
+    if os.path.isfile(f"{project_dir}/build.gradle.kts"):
+        build_file = f"{project_dir}/build.gradle.kts"
+    elif os.path.isfile(f"{project_dir}/build.gradle"):
+        Out.error(f"We only support Gradle Kotlin (build.gradle.kts) files.")
+        sys.exit(2)
+    else:
+        Out.error(f"Unable to infer the build file for project [{project_dir}]~")
+        sys.exit(2)
+    return build_file
+
+
+def infer_gradle_settings_file(project_dir):
+    if os.path.isfile(f"{project_dir}/settings.gradle.kts"):
+        file = f"{project_dir}/settings.gradle.kts"
+    elif os.path.isfile(f"{project_dir}/settings.gradle"):
+        file = f"{project_dir}/settings.gradle"
+    else:
+        file = ""
+    return file
+
+
+def find_replace_version(content, version):
+    regex = re.compile(r"graphql-dgs-platform-dependencies:([0-9\w\-.]+)")
+    return re.sub(regex, f"graphql-dgs-platform-dependencies:{version}", content)
+
+
+def update_build(build_file, version):
+    file = open(build_file, 'r')
+    file_data = file.read()
+    file.close()
+
+    file_data = find_replace_version(file_data, version)
+
+    file = open(build_file, 'w')
+    file.write(file_data)
+    file.close()
+
+
+def run_example_build(project_dir, build_file="", settings_file=""):
+    command = [gradlew, "-p", project_dir, "-s", "-w"]
+
+    if settings_file:
+        command.extend(["-c", settings_file])
+    else:
+        Out.error(f"The project {project_dir} is missing a Gradle settings file!")
+        sys.exit(2)
+
+    command.extend(["clean", "check"])
+    str_cmd = " ".join(command)
+    try:
+        Out.info(f"Running {str_cmd}")
+        p = subprocess.check_output(command)
+        Out.info(p.decode("utf-8"))
+    except subprocess.SubprocessError as error:
+        Out.error(f"Unable to test {project_dir}, command '{str_cmd}' failed!", error)
+        sys.exit(2)
+
+
+def main(argv):
+    script_name = os.path.basename(__file__)
+
+    help_message = f"""
+        {BColors.HEADER}Options{BColors.ENDC}:
+            -c | codegen=   : Version we need to apply, if left empty it will calculate the version based
+                              on Gradle's Project task.
+            -p | path=      : Path where the examples should be found. Defaults to [{examples_path}].
+            -g              : Clone the examples before attempting to execute them, this is done via git-clone.
+                              The repositories are specified via the "repositories:" section in {config_file}.
+            -k              : By default the directory defined in the path will be removed on success.
+                              If this flag is set the directory will be kept.
+            -v              : Verbose
+
+        {BColors.HEADER}Example{BColors.ENDC}: {script_name} -c <codegen version>
+        """
+
+    projects_dir = examples_path
+    codegen_version = ""
+    git_clone_projects = False
+    keep_project_dir = False
+    try:
+        opts, args = getopt.getopt(argv, "hvkgc:p:", ["codegen=", "path="])
+    except getopt.GetoptError:
+        Out.usage(script_name, help_message)
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == '-h':
+            Out.usage(script_name, help_message)
+            sys.exit()
+        elif opt in ("-c", "--codegen"):
+            codegen_version = arg
+        elif opt in ("-p", "--path"):
+            projects_dir = os.path.abspath(arg)
+        elif opt in "-g":
+            git_clone_projects = True
+        elif opt in "-k":
+            keep_project_dir = True
+        elif opt in "-v":
+            State.verbose = True
+
+    if not codegen_version:
+        Out.info("Version not supplied, inferring...")
+        codegen_version = infer_version()
+        if codegen_version:
+            Out.info(f"Version resolved to {BColors.OKGREEN}{codegen_version}{BColors.ENDC}")
+        else:
+            Out.error("Unable to resolved a version!")
+            exit(2)
+
+    if git_clone_projects:
+        Out.info(f"Cloning example repositories to {projects_dir}...")
+        clone_repos(load_config(), projects_dir)
+
+    if not os.path.exists(projects_dir):
+        Out.error(f"Can not find projects to build, the path {projects_dir} doesn't exist!")
+        exit(2)
+
+    projects = next(os.walk(projects_dir))[1]
+    if not projects:
+        Out.error(f"No projects available at [{projects_dir}]!")
+        exit(2)
+
+    for project in projects:
+        project_root = f"{projects_dir}/{project}"
+        Out.info(f"Processing project [{project_root}]...")
+        build_file = infer_build_file(project_root)
+        settings_file = infer_gradle_settings_file(project_root)
+        update_build(build_file, codegen_version)
+        run_example_build(project_root, build_file=build_file, settings_file=settings_file)
+
+    if not keep_project_dir:
+        Out.info(f"Removing {projects_dir}...")
+        try:
+            shutil.rmtree(projects_dir)
+        except Exception as error:
+            Out.error(f"Failed deleting {projects_dir}.", error)
+    Out.ok(f"Build successful.")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Summary
=======

This commit, via the ci-compatibility.yml workflow action, will use the build's snapshot version and apply it to a set of example applications. This will help us see if the current changes are compatible with an application using the previous released version.

Implementation
==============

Via the `scripts/test-examples.py` we are adding the ability to download defined git repositories that we want to use to assert the build changes. Before running a `clean build`, this script will update the downloaded projects' build file to use the specific dgs-framework snapshot generated from a local build.

Requirements of Example Projects.

1. Should build with the same JDK as this project. In this case JDK 1.8.
2. Should use the BOM, since its through the BOM how we control de versions.

Running The Example Tests Locally
=================================

1. You will need Python3 and have `pip3` and `python3` available in your
   path.
2. You will need to install the Python3 required modules defined in `scripts/requirements.txt`.
   You can just run `make install-py-libs`.
3. Run the `make test-examples` tasks.

You can also run `./scripts/test-examples.py` manually. Explore the options with the `-h` flag.

