### PR TITLE
Added TYPE_HIERARCHY strategy to DsgData annotation scanning

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -196,10 +196,10 @@ class DgsSchemaProvider(
             val javaClass = AopUtils.getTargetClass(dgsComponent)
 
             javaClass.methods.asSequence()
-                .filter { method -> MergedAnnotations.from(method).isPresent(DgsData::class.java) }
+                .filter { method -> MergedAnnotations.from(method, MergedAnnotations.SearchStrategy.TYPE_HIERARCHY).isPresent(DgsData::class.java) }
                 .forEach { method ->
 
-                    val dgsDataAnnotation = MergedAnnotations.from(method).get(DgsData::class.java)
+                    val dgsDataAnnotation = MergedAnnotations.from(method, MergedAnnotations.SearchStrategy.TYPE_HIERARCHY).get(DgsData::class.java)
                     val field = dgsDataAnnotation.getString("field").ifEmpty { method.name }
                     val parentType = dgsDataAnnotation.getString("parentType")
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -68,6 +68,16 @@ internal class DgsSchemaProviderTest {
         }
     }
 
+    private interface DefaultHelloFetcherInterface {
+        @DgsData(parentType = "Query", field = "hello")
+        fun someFetcher(): String
+    }
+
+    private val interfaceHelloFetcher = object : DefaultHelloFetcherInterface {
+        override fun someFetcher(): String =
+            "Hello"
+    }
+
     @Test
     fun findSchemaFiles() {
         val findSchemaFiles = DgsSchemaProvider(
@@ -340,6 +350,22 @@ internal class DgsSchemaProviderTest {
             Pair(
                 "helloFetcher",
                 defaultHelloFetcher
+            )
+        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+
+        val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+        provider.schema()
+        assertThat(provider.dataFetcherInstrumentationEnabled).containsKey("Query.hello")
+        assertThat(provider.dataFetcherInstrumentationEnabled["Query.hello"]).isTrue
+    }
+
+    @Test
+    fun enableInstrumentationForDataFetchersFromInterfaces() {
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
+            Pair(
+                "helloFetcher",
+                interfaceHelloFetcher
             )
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first: https://github.com/Netflix/dgs-framework/discussions/234
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): extends Spring DI to type hierarchy

Changes in this PR
----

Allows Spring DI to pick up `@Dgs*` annotations from implemented interfaces.

With this change, the same behavior can be achieved as with Spring WebMVC annotations.

For example an [interface generated by the OpenAPI generator](https://github.com/zaenk/specification-first-with-openapi-example/blob/main/build/generated/src/main/kotlin/com/example/api/apis/PetsApi.kt) contains all wiring required by the specification, so [implementations](https://github.com/zaenk/specification-first-with-openapi-example/blob/main/src/main/kotlin/com/example/specfirstopenapi/rest/PetController.kt) don't have to bother with that.

This behavior is required for https://github.com/Netflix/dgs-codegen/pull/126

Alternatives considered
----

The Java dgs generator has an option to generate example data fetchers, that can be copied into sources and implemented. While it's adequate for the first implementation, when a schema is extended later it is not obvious what and where needs to be implemented. Generating interfaces for data fetchers as generated sources would help that.