### PR TITLE
Use AopUtils when looking for @DgsTypeResolver

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -427,7 +427,8 @@ class DgsSchemaProvider(
         val registeredTypeResolvers = mutableSetOf<String>()
 
         dgsComponents.values.forEach { dgsComponent ->
-            dgsComponent.javaClass.methods.filter { it.isAnnotationPresent(DgsTypeResolver::class.java) }
+            val javaClass = AopUtils.getTargetClass(dgsComponent)
+            javaClass.methods.filter { it.isAnnotationPresent(DgsTypeResolver::class.java) }
                 .forEach { method ->
                     val annotation = method.getAnnotation(DgsTypeResolver::class.java)
 


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Account for (AOP) proxy classes when searching for `@DgsTypeResolver`.

_Describe the new behavior from this PR, and why it's needed_
Previously, when a `@DgsTypeResolver` was in the same class as a `@Secured` method, the type resolver would not be found. `@Secured` causes the class to be proxied, so we need to account for that when scanning for annotations.
We do this for other methods, but not for type resolvers.
