### PR TITLE
Scalar in client

### DIFF
--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("org.springframework:spring-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("com.graphql-java:graphql-java")
 
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework:spring-test")

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -38,6 +38,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
         },
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.5.0"
         },
@@ -45,7 +48,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -220,6 +223,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
         },
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.5.0"
         },
@@ -227,7 +233,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -284,6 +290,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
         },
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.5.0"
         },
@@ -294,7 +303,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -343,6 +352,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
         },
+        "com.graphql-java:graphql-java": {
+            "locked": "16.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.5.0"
         },
@@ -353,7 +365,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -73,6 +73,7 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
         }
 
         val type = input::class.java
+
         return if (scalars.contains(type)) {
             """"${scalars[type]!!.serialize(input)}""""
         } else if (type.isPrimitive || type == Integer::class.java || type == Long::class.java || type == Double::class.java || type == Float::class.java || type == Boolean::class.java || type == Short::class.java || type == Byte::class.java || type.isEnum) {
@@ -82,10 +83,10 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
         } else if (input is List<*>) {
             """[${input.filterNotNull().joinToString(", ") { listItem -> serialize(listItem) ?: "" }}]"""
         } else {
-            input.javaClass.declaredFields.map {
+            input.javaClass.declaredFields.filter { !it.type::class.isCompanion }.map {
                 it.isAccessible = true
                 val nestedValue = it.get(input)
-                if (nestedValue != null) {
+                if (nestedValue != null && !nestedValue::class.isCompanion) {
                     """${it.name}:${serialize(nestedValue)}"""
                 } else {
                     null

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -19,17 +19,17 @@ package com.netflix.graphql.dgs.client.codegen
 import graphql.schema.Coercing
 import org.springframework.util.ReflectionUtils
 import java.lang.reflect.Field
+import java.time.*
 import java.util.*
 
 class GraphQLQueryRequest(
     private val query: GraphQLQuery,
     private val projection: BaseProjectionNode?,
-    private val scalars: Map<Class<*>, Coercing<*, *>>?
+    scalars: Map<Class<*>, Coercing<*, *>>?
 ) {
 
     constructor(query: GraphQLQuery) : this(query, null, null)
     constructor(query: GraphQLQuery, projection: BaseProjectionNode?) : this(query, projection, null)
-
     private val inputValueSerializer = InputValueSerializer(scalars ?: emptyMap())
 
     fun serialize(): String {
@@ -70,6 +70,20 @@ class GraphQLQueryRequest(
 }
 
 class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = emptyMap()) {
+    companion object {
+        val toStringClasses = setOf(
+            String::class.java,
+            LocalDateTime::class.java,
+            LocalDate::class.java,
+            LocalTime::class.java,
+            TimeZone::class.java,
+            Date::class.java,
+            OffsetDateTime::class.java,
+            Currency::class.java,
+            Instant::class.java
+        )
+    }
+
     fun serialize(input: Any?): String? {
         if (input == null) {
             return null
@@ -81,7 +95,8 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
             """"${scalars[type]!!.serialize(input)}""""
         } else if (type.isPrimitive || type.isAssignableFrom(java.lang.Integer::class.java) || type.isAssignableFrom(java.lang.Long::class.java) || type.isAssignableFrom(java.lang.Double::class.java) || type.isAssignableFrom(java.lang.Float::class.java) || type.isAssignableFrom(java.lang.Boolean::class.java) || type.isAssignableFrom(java.lang.Short::class.java) || type.isAssignableFrom(java.lang.Byte::class.java) || type.isEnum) {
             input.toString()
-        } else if (type == String::class.java) {
+        } else if (toStringClasses.contains(type)) {
+            // Call toString for known types, in case no scalar is found. This is for backward compatibility.
             """"$input""""
         } else if (input is List<*>) {
             """[${input.filterNotNull().joinToString(", ") { listItem -> serialize(listItem) ?: "" }}]"""
@@ -94,7 +109,9 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
 
             fields.filter { !it.type::class.isCompanion }.mapNotNull {
                 val nestedValue = it.get(input)
-                if (nestedValue != null && !nestedValue::class.isCompanion) {
+                if (nestedValue != null && nestedValue::class.java == input::class.java) {
+                    """${it.name}:$nestedValue"""
+                } else if (nestedValue != null && !nestedValue::class.isCompanion) {
                     """${it.name}:${serialize(nestedValue)}"""
                 } else {
                     null

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -76,7 +76,7 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
 
         return if (scalars.contains(type)) {
             """"${scalars[type]!!.serialize(input)}""""
-        } else if (type.isPrimitive || type == Integer::class.java || type == Long::class.java || type == Double::class.java || type == Float::class.java || type == Boolean::class.java || type == Short::class.java || type == Byte::class.java || type.isEnum) {
+        } else if (type.isPrimitive || type.isAssignableFrom(java.lang.Integer::class.java) || type.isAssignableFrom(java.lang.Long::class.java) || type.isAssignableFrom(java.lang.Double::class.java) || type.isAssignableFrom(java.lang.Float::class.java) || type.isAssignableFrom(java.lang.Boolean::class.java) || type.isAssignableFrom(java.lang.Short::class.java) || type.isAssignableFrom(java.lang.Byte::class.java) || type.isEnum) {
             input.toString()
         } else if (type == String::class.java) {
             """"$input""""

--- a/graphql-dgs-client/src/test/java/com/netflix/graphql/dgs/client/MovieInput.java
+++ b/graphql-dgs-client/src/test/java/com/netflix/graphql/dgs/client/MovieInput.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client;
+
+import com.netflix.graphql.dgs.client.scalar.DateRange;
+
+import java.util.List;
+
+public class MovieInput {
+    private int movieId;
+    private String title;
+    private Genre genre;
+    private Director director;
+    private List<Actor> actor;
+    private DateRange releaseWindow;
+
+    public MovieInput(int movieId, String title, Genre genre, Director director, List<Actor> actor, DateRange releaseWindow) {
+        this.movieId = movieId;
+        this.title = title;
+        this.genre = genre;
+        this.director = director;
+        this.actor = actor;
+        this.releaseWindow = releaseWindow;
+    }
+
+    public MovieInput(int movieId) {
+        this.movieId = movieId;
+    }
+
+    public enum Genre {
+        ACTION,DRAMA
+    }
+
+    public static class Director {
+        private String name;
+
+        Director(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class Actor {
+        private String name;
+        private String roleName;
+
+        Actor(String name, String roleName) {
+            this.name = name;
+            this.roleName = roleName;
+        }
+    }
+}

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLQueryRequestTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLQueryRequestTest.kt
@@ -19,15 +19,11 @@ package com.netflix.graphql.dgs.client
 import com.netflix.graphql.dgs.client.codegen.BaseProjectionNode
 import com.netflix.graphql.dgs.client.codegen.GraphQLQuery
 import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest
-import graphql.language.StringValue
-import graphql.schema.Coercing
-import graphql.schema.CoercingParseLiteralException
-import graphql.schema.CoercingParseValueException
-import graphql.schema.CoercingSerializeException
+import com.netflix.graphql.dgs.client.scalar.DateRange
+import com.netflix.graphql.dgs.client.scalar.DateRangeScalar
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 class GraphQLQueryRequestTest {
     @Test
@@ -114,6 +110,18 @@ class GraphQLQueryRequestTest {
         val result = request.serialize()
         assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\" }, dateRange: \"01/01/2020-05/11/2021\") }")
     }
+
+    @Test
+    fun serializeWithNestedScalar() {
+        val query = TestNamedGraphQLQuery().apply {
+            input["movie"] = Movie(123, "greatMovie", DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 5, 11)))
+        }
+        val request =
+            GraphQLQueryRequest(query, MovieProjection(), mapOf(DateRange::class.java to DateRangeScalar()))
+
+        val result = request.serialize()
+        assertThat(result).isEqualTo("query TestNamedQuery {test(movie: {movieId:123, name:\"greatMovie\", window:\"01/01/2020-05/11/2021\" }) }")
+    }
 }
 
 class TestGraphQLQuery : GraphQLQuery() {
@@ -134,11 +142,7 @@ class TestGraphQLMutation : GraphQLQuery("mutation") {
     }
 }
 
-data class Movie(private val movieId: Int, private val name: String) {
-    override fun toString(): String {
-        return "{movieId:$movieId, name:\"$name\" }"
-    }
-}
+data class Movie(val movieId: Int, val name: String, val window: DateRange? = null)
 
 class MovieProjection : BaseProjectionNode() {
     fun movieId(): MovieProjection {
@@ -151,31 +155,3 @@ class MovieProjection : BaseProjectionNode() {
         return this
     }
 }
-
-class DateRangeScalar : Coercing<DateRange, String> {
-    private var formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
-
-    @Throws(CoercingSerializeException::class)
-    override fun serialize(dataFetcherResult: Any): String {
-        val range: DateRange = dataFetcherResult as DateRange
-        return range.from.format(formatter) + "-" + range.to.format(formatter)
-    }
-
-    @Throws(CoercingParseValueException::class)
-    override fun parseValue(input: Any): DateRange {
-        val split = (input as String).split("-").toTypedArray()
-        val from = LocalDate.parse(split[0], formatter)
-        val to = LocalDate.parse(split[0], formatter)
-        return DateRange(from, to)
-    }
-
-    @Throws(CoercingParseLiteralException::class)
-    override fun parseLiteral(input: Any): DateRange {
-        val split = (input as StringValue).value.split("-").toTypedArray()
-        val from = LocalDate.parse(split[0], formatter)
-        val to = LocalDate.parse(split[0], formatter)
-        return DateRange(from, to)
-    }
-}
-
-class DateRange(val from: LocalDate, val to: LocalDate)

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.client.scalar.DateRangeScalar
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class InputValueSerializerTest {
 
@@ -126,6 +127,13 @@ class InputValueSerializerTest {
         assertThat(serialize).isEqualTo("{stars:1500, name:\"DGS\" }")
     }
 
+    @Test
+    fun `Date without scalar`() {
+        val input = WithLocalDateTime(LocalDateTime.of(2021, 5, 13, 4, 34))
+        val serialize = InputValueSerializer().serialize(input)
+        assertThat(serialize).isEqualTo("""{date:"2021-05-13T04:34" }""")
+    }
+
     data class MyDataWithCompanion(val title: String) {
         public companion object {}
     }
@@ -133,4 +141,6 @@ class InputValueSerializerTest {
     open class MyBaseClass(private val name: String)
 
     class MySubClass(name: String, val stars: Int) : MyBaseClass(name)
+
+    class WithLocalDateTime(val date: LocalDateTime)
 }

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
@@ -45,6 +45,25 @@ class InputValueSerializerTest {
     }
 
     @Test
+    fun `List of a complex object`() {
+
+        val movieInput = MovieInput(
+            1,
+            "Some movie",
+            MovieInput.Genre.ACTION,
+            MovieInput.Director("The Director"),
+            listOf(
+                MovieInput.Actor("Actor 1", "Role 1"),
+                MovieInput.Actor("Actor 2", "Role 2"),
+            ),
+            DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 1, 1))
+        )
+
+        val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(listOf(movieInput))
+        assertThat(serialize).isEqualTo("[{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\" }, actor:[{name:\"Actor 1\", roleName:\"Role 1\" }, {name:\"Actor 2\", roleName:\"Role 2\" }], releaseWindow:\"01/01/2020-01/01/2021\" }]")
+    }
+
+    @Test
     fun `Null values should be skipped`() {
 
         val movieInput = MovieInput(1)
@@ -87,6 +106,12 @@ class InputValueSerializerTest {
     fun `Companion objects should be ignored`() {
         val serialize = InputValueSerializer().serialize(MyDataWithCompanion("some title"))
         assertThat(serialize).isEqualTo("{title:\"some title\" }")
+    }
+
+    @Test
+    fun `List of Integer`() {
+        val serialize = InputValueSerializer().serialize(listOf(1, 2, 3))
+        assertThat(serialize).isEqualTo("[1, 2, 3]")
     }
 
     data class MyDataWithCompanion(val title: String) {

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
@@ -114,7 +114,17 @@ class InputValueSerializerTest {
         assertThat(serialize).isEqualTo("[1, 2, 3]")
     }
 
+    @Test
+    fun `Base class properties should be found`() {
+        val serialize = InputValueSerializer().serialize(MySubClass("DGS", 1500))
+        assertThat(serialize).isEqualTo("{stars:1500, name:\"DGS\" }")
+    }
+
     data class MyDataWithCompanion(val title: String) {
         public companion object {}
     }
+
+    open class MyBaseClass(private val name: String)
+
+    class MySubClass(name: String, val stars: Int) : MyBaseClass(name)
 }

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+import com.netflix.graphql.dgs.client.codegen.InputValueSerializer
+import com.netflix.graphql.dgs.client.scalar.DateRange
+import com.netflix.graphql.dgs.client.scalar.DateRangeScalar
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class InputValueSerializerTest {
+
+    @Test
+    fun `Serialize a complex object`() {
+
+        val movieInput = MovieInput(
+            1,
+            "Some movie",
+            MovieInput.Genre.ACTION,
+            MovieInput.Director("The Director"),
+            listOf(
+                MovieInput.Actor("Actor 1", "Role 1"),
+                MovieInput.Actor("Actor 2", "Role 2"),
+            ),
+            DateRange(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 1, 1))
+        )
+
+        val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
+        println(serialize)
+    }
+
+    @Test
+    fun `Null values should be skipped`() {
+
+        val movieInput = MovieInput(1)
+
+        val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
+        println(serialize)
+    }
+
+    @Test
+    fun `String value`() {
+        val serialize = InputValueSerializer().serialize("some string")
+        println(serialize)
+    }
+}

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
@@ -60,6 +60,30 @@ class InputValueSerializerTest {
     }
 
     @Test
+    fun `int value`() {
+        val serialize = InputValueSerializer().serialize(1)
+        assertThat(serialize).isEqualTo("1")
+    }
+
+    @Test
+    fun `long value`() {
+        val serialize = InputValueSerializer().serialize(1L)
+        assertThat(serialize).isEqualTo("1")
+    }
+
+    @Test
+    fun `boolean value`() {
+        val serialize = InputValueSerializer().serialize(true)
+        assertThat(serialize).isEqualTo("true")
+    }
+
+    @Test
+    fun `double value`() {
+        val serialize = InputValueSerializer().serialize(1.1)
+        assertThat(serialize).isEqualTo("1.1")
+    }
+
+    @Test
     fun `Companion objects should be ignored`() {
         val serialize = InputValueSerializer().serialize(MyDataWithCompanion("some title"))
         assertThat(serialize).isEqualTo("{title:\"some title\" }")

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
@@ -79,6 +79,12 @@ class InputValueSerializerTest {
     }
 
     @Test
+    fun `String with slashes`() {
+        val serialize = InputValueSerializer().serialize("some \\ \"string\"")
+        assertThat(serialize).isEqualTo("\"some \\ \"string\"\"")
+    }
+
+    @Test
     fun `int value`() {
         val serialize = InputValueSerializer().serialize(1)
         assertThat(serialize).isEqualTo("1")

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.client
 import com.netflix.graphql.dgs.client.codegen.InputValueSerializer
 import com.netflix.graphql.dgs.client.scalar.DateRange
 import com.netflix.graphql.dgs.client.scalar.DateRangeScalar
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -40,7 +41,7 @@ class InputValueSerializerTest {
         )
 
         val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
-        println(serialize)
+        assertThat(serialize).isEqualTo("{movieId:1, title:\"Some movie\", genre:ACTION, director:{name:\"The Director\" }, actor:[{name:\"Actor 1\", roleName:\"Role 1\" }, {name:\"Actor 2\", roleName:\"Role 2\" }], releaseWindow:\"01/01/2020-01/01/2021\" }")
     }
 
     @Test
@@ -49,12 +50,22 @@ class InputValueSerializerTest {
         val movieInput = MovieInput(1)
 
         val serialize = InputValueSerializer(mapOf(DateRange::class.java to DateRangeScalar())).serialize(movieInput)
-        println(serialize)
+        assertThat(serialize).isEqualTo("{movieId:1 }")
     }
 
     @Test
     fun `String value`() {
         val serialize = InputValueSerializer().serialize("some string")
-        println(serialize)
+        assertThat(serialize).isEqualTo("\"some string\"")
+    }
+
+    @Test
+    fun `Companion objects should be ignored`() {
+        val serialize = InputValueSerializer().serialize(MyDataWithCompanion("some title"))
+        assertThat(serialize).isEqualTo("{title:\"some title\" }")
+    }
+
+    data class MyDataWithCompanion(val title: String) {
+        public companion object {}
     }
 }

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/scalar/DateRangeScalar.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/scalar/DateRangeScalar.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client.scalar
+
+import graphql.language.StringValue
+import graphql.schema.Coercing
+import graphql.schema.CoercingParseLiteralException
+import graphql.schema.CoercingParseValueException
+import graphql.schema.CoercingSerializeException
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class DateRangeScalar : Coercing<DateRange, String> {
+    private var formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
+
+    @Throws(CoercingSerializeException::class)
+    override fun serialize(dataFetcherResult: Any): String {
+        val range: DateRange = dataFetcherResult as DateRange
+        return range.from.format(formatter) + "-" + range.to.format(formatter)
+    }
+
+    @Throws(CoercingParseValueException::class)
+    override fun parseValue(input: Any): DateRange {
+        val split = (input as String).split("-").toTypedArray()
+        val from = LocalDate.parse(split[0], formatter)
+        val to = LocalDate.parse(split[0], formatter)
+        return DateRange(from, to)
+    }
+
+    @Throws(CoercingParseLiteralException::class)
+    override fun parseLiteral(input: Any): DateRange {
+        val split = (input as StringValue).value.split("-").toTypedArray()
+        val from = LocalDate.parse(split[0], formatter)
+        val to = LocalDate.parse(split[0], formatter)
+        return DateRange(from, to)
+    }
+}
+
+class DateRange(val from: LocalDate, val to: LocalDate)

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -128,7 +128,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -347,6 +347,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -439,7 +440,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -654,7 +655,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -738,6 +739,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -833,7 +835,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -125,7 +125,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -343,6 +343,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -441,7 +442,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
@@ -682,7 +683,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -765,6 +766,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -866,7 +868,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -83,7 +83,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -338,7 +338,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -485,7 +485,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -608,7 +608,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -470,7 +470,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -547,6 +547,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -631,7 +632,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -440,7 +440,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -563,7 +563,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -119,7 +119,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.10.20"
@@ -533,7 +533,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.10.20"
@@ -616,6 +616,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -700,7 +701,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -103,7 +103,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -317,6 +317,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -382,7 +383,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
@@ -571,7 +572,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -650,6 +651,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -718,7 +720,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -468,7 +468,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -601,7 +601,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -421,7 +421,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -525,7 +525,7 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -430,7 +430,7 @@
             "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -540,7 +540,7 @@
             "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -110,7 +110,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -324,6 +324,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -396,7 +397,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -586,7 +587,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -665,6 +666,7 @@
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
@@ -740,7 +742,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -371,10 +371,10 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -457,10 +457,10 @@
             "locked": "1.10.3-jdk8"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.5"
+            "locked": "3.4.6"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Issue #290 

For query parameters of a complex scalar such as DateTime, code generation will create a query method using the Java type that represents the scalar. This is currently now correctly serialized.
Inputs are serialized using the objects `toString()` method. In some cases this may work, but in more complex cases (DateTime), it doesn't.

In a DGS, the serialization of scalars is implemented in a `Coercing` implementation. Because this code is already available, the same code should be used for serialization in the client.

In this PR a map of types mapped to a scalar implementation can optionally be passed into the `GraphQLQueryRequest`.
If an input has the type of one of the mapped types, its scalar will be used during serialization.

The following is an example.

```java
GraphQLQueryRequest request = new GraphQLQueryRequest(
                ReviewsGraphQLQuery.newRequest().dateRange(new DateRange(LocalDate.of(2020, 01, 01), LocalDate.now())).build(),
                new ReviewsProjectionRoot().submittedDate().starScore(),
                Map.of(DateRange.class, new DateRangeScalar())
        );
```

The following is the `DateRange` type and custom `Coercing` implementation.

```java
public class DateRange {
    private final LocalDate from;
    private final LocalDate to;

    public DateRange(LocalDate from, LocalDate to) {
        this.from = from;
        this.to = to;
    }

    public LocalDate getFrom() {
        return from;
    }

    public LocalDate getTo() {
        return to;
    }
}

public class DateRangeScalar implements Coercing<DateRange, String> {
    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy");

    @Override
    public String serialize(Object dataFetcherResult) throws CoercingSerializeException {
        DateRange range = (DateRange) dataFetcherResult;

        return range.getFrom().format(formatter) + "-" + range.getTo().format(formatter);
    }

    @Override
    public DateRange parseValue(Object input) throws CoercingParseValueException {
        String[] split = ((String) input).split("-");
        LocalDate from = LocalDate.parse(split[0], formatter);
        LocalDate to = LocalDate.parse(split[0], formatter);
        return new DateRange(from, to);
    }

    @Override
    public DateRange parseLiteral(Object input) throws CoercingParseLiteralException {
        String[] split = ((StringValue)input).getValue().split("-");
        LocalDate from = LocalDate.parse(split[0], formatter);
        LocalDate to = LocalDate.parse(split[0], formatter);
        return new DateRange(from, to);
    }
}

```

When invoking the `request.serialize()` method, the `DateRangeScalar.serialize` method will be used to serialize the `DateRange` input.

**Optional extras**

We can consider providing a number of well-known scalars (date types, etc.) out of the box. This is not included in this PR yet.


Alternatives considered
----

This idea came out of this [PR](https://github.com/Netflix/dgs-framework/pull/292) which started some discussion how we could implement this in a more extendable way.


