### PR TITLE
Handle non null scalar types as input

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -313,6 +313,10 @@ class DgsSchemaProvider(
                     } else if (environment.fieldDefinition.arguments.find { it.name == parameterName }?.type is GraphQLScalarType) {
                         // Return the value with it's type for scalars
                         parameterValue
+                    } else if (environment.fieldDefinition.arguments.find { it.name == parameterName }?.type is GraphQLNonNull
+                              && environment.fieldDefinition.arguments.find { it.name == parameterName }?.type?.originalWrappedType is GraphQLScalarType) {
+                        // Return the value with it's type for scalars
+                        parameterValue
                     } else {
                         // Return the converted value mapped to the defined type
                         if (parameter.type.isAssignableFrom(Optional::class.java)) {


### PR DESCRIPTION
If you have a custom scalar type and you take it as an input argument in non-null form you get an exception, this should fix it.

Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Handle non null scalar types as input


