### PR TITLE
Escape quotes and backslashes on request serialization

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -97,7 +97,7 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
             input.toString()
         } else if (toStringClasses.contains(type)) {
             // Call toString for known types, in case no scalar is found. This is for backward compatibility.
-            """"$input""""
+            """"${input.toString().replace("\\", "\\\\").replace("\"", "\\\"")}""""
         } else if (input is List<*>) {
             """[${input.filterNotNull().joinToString(", ") { listItem -> serialize(listItem) ?: "" }}]"""
         } else if (input is Map<*, *>) {

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/InputValueSerializerTest.kt
@@ -82,7 +82,7 @@ class InputValueSerializerTest {
     @Test
     fun `String with slashes`() {
         val serialize = InputValueSerializer().serialize("some \\ \"string\"")
-        assertThat(serialize).isEqualTo("\"some \\ \"string\"\"")
+        assertThat(serialize).isEqualTo("\"some \\\\ \\\"string\\\"\"")
     }
 
     @Test


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

If a string contains quotes or backslashes, they need to be escaped in the serialized GraphQL query.

This is a fix on top of PR #333 
Fixing issue #290 