### PR TITLE
Integrating Dependabot to Github Actions to flag version updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
> When Dependabot identifies an outdated dependency, it raises a pull request to update the manifest to the
> latest version of the dependency. For vendored dependencies, Dependabot raises a pull request to replace the
> outdated dependency with the new version directly. You check that your tests pass, review the changelog and
> release notes included in the pull request summary, and then merge it.

Ref.

* https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/about-dependabot-version-updates
* https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot