### PR TITLE
add httpHeaders for executeAndGetDocumentContext and fix typo

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfigurationTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfigurationTest.kt
@@ -19,7 +19,7 @@ package com.netflix.graphql.dgs.autoconfig
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.autoconfig.testcomponents.CustomContextBuilderConfig
 import com.netflix.graphql.dgs.autoconfig.testcomponents.DataLoaderConfig
-import com.netflix.graphql.dgs.autoconfig.testcomponents.HelloDatFetcherConfig
+import com.netflix.graphql.dgs.autoconfig.testcomponents.HelloDataFetcherConfig
 import com.netflix.graphql.dgs.exceptions.NoSchemaFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -40,7 +40,7 @@ class DgsAutoConfigurationTest {
 
     @Test
     fun setsUpQueryExecutorWithDataFetcher() {
-        context.withUserConfiguration(HelloDatFetcherConfig::class.java).run { ctx ->
+        context.withUserConfiguration(HelloDataFetcherConfig::class.java).run { ctx ->
             assertThat(ctx).getBean(DgsQueryExecutor::class.java).extracting {
                 val executeQuery = it.executeAndExtractJsonPath<String>("query {hello}", "data.hello")
                 assertThat(executeQuery).isEqualTo("Hello!")

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/HelloDataFetcher.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/HelloDataFetcher.kt
@@ -21,12 +21,14 @@ import com.netflix.graphql.dgs.DgsData
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.web.bind.annotation.RequestHeader
 
 /*
     Config class for the Hello data fetcher test
      */
 @Configuration
-open class HelloDatFetcherConfig {
+open class HelloDataFetcherConfig {
     @Bean
     open fun createDgsComponent(): HelloDataFetcher {
         return HelloDataFetcher()
@@ -53,5 +55,10 @@ class HelloDataFetcher {
     @DgsData(parentType = "Query", field = "withNonNullableNull")
     fun withNonNullableNull(): String? {
         return null
+    }
+
+    @DgsData(parentType = "Query", field = "helloWithHeader")
+    fun helloWithHeader(@RequestHeader(HttpHeaders.AUTHORIZATION) authorization: String): String {
+        return "ciao"
     }
 }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/resources/schema/schema.graphqls
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/resources/schema/schema.graphqls
@@ -11,6 +11,9 @@ type Query {
     deny: String
     errorTest: String
 
+    #Header example
+    helloWithHeader(name: String): String
+
     withNullableNull: String
 
     withNonNullableNull: String!

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
@@ -147,6 +147,17 @@ public interface DgsQueryExecutor {
     DocumentContext executeAndGetDocumentContext(String query, Map<String, Object> variables);
 
     /**
+     * Executes a GraphQL query, parses the returned data, and return a {@link DocumentContext}.
+     * A {@link DocumentContext} can be used to extract multiple values using JsonPath, without re-executing the query.
+     * @param query Query string
+     * @param variables A Map of variables
+     * @param headers Spring {@link HttpHeaders}
+     * @return {@link DocumentContext} is a JsonPath type used to extract values from.
+     * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
+     */
+    DocumentContext executeAndGetDocumentContext(String query, Map<String, Object> variables, HttpHeaders headers);
+
+    /**
      * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
      * Be aware that this method can't guarantee type safety.
      * @param query Query string

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -142,6 +142,14 @@ class DefaultDgsQueryExecutor(
         return parseContext.parse(getJsonResult(query, variables))
     }
 
+    override fun executeAndGetDocumentContext(
+        query: String,
+        variables: MutableMap<String, Any>,
+        headers: HttpHeaders?
+    ): DocumentContext {
+        return parseContext.parse(getJsonResult(query, variables, headers))
+    }
+
     private fun getJsonResult(query: String, variables: Map<String, Any>, headers: HttpHeaders? = null): String {
         val executionResult = execute(query, variables, null, headers, null, null)
 


### PR DESCRIPTION
Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [X] Make sure the PR doesn't introduce backward compatibility issues
- [X] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This PR adds a method overload to support httpHeaders for the method executeAndGetDocumentContext

Alternatives considered
----

It would be possible to avoid using `@RequestHeader` and rely on `DgsContext.getRequestData(dfe).getHeaders()` but this approach looks to be more straightforward.
In this way, the developer can avoid reinventing the wheel to extract the JSON results when the `httpHeaders` are mandatory

@berngp @srinivasankavitha @paulbakker Thanks for taking the time to review this PR.

It is similar to my previous PR. https://github.com/Netflix/dgs-framework/pull/302 
I am using this method to test my query in a federated graph.
I looked at the example for the federation use cases and I figured out that it was missing the `httpHeader` parameter like in the previous case