### PR TITLE
Exclude synthetic fields added by jacoco during serialization of GraphQLQueryRequest

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/GraphQLQueryRequest.kt
@@ -112,8 +112,10 @@ class InputValueSerializer(private val scalars: Map<Class<*>, Coercing<*, *>> = 
         } else {
             val fields = LinkedList<Field>()
             ReflectionUtils.doWithFields(input.javaClass) {
-                ReflectionUtils.makeAccessible(it)
-                fields.add(it)
+                if (! it.isSynthetic) {
+                    ReflectionUtils.makeAccessible(it)
+                    fields.add(it)
+                }
             }
 
             fields.filter { !it.type::class.isCompanion }.mapNotNull {


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Excludes synthetic fields when trying to get all the fields using ReflectionUtils for GraphQLQueryRequest serialization in the `graphql-dgs-client`
Issue #362 

As a result of the bug, the list of fields included a `$jacoco{}` and this was getting added to the GraphQLQueryRequest causing issues.


