### PR TITLE
Add Httpheader argument in executeAndExtractJsonPathAsObject

### DIFF
--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
@@ -181,7 +181,23 @@ public interface DgsQueryExecutor {
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
-    <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Map<String, Object> variables, Class<T> clazz);
+    default <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Map<String, Object> variables, Class<T> clazz) {
+        return executeAndExtractJsonPathAsObject(query, jsonPath, null, Collections.emptyMap(), clazz);
+    }
+
+    /**
+     * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
+     * Be aware that this method can't guarantee type safety.
+     * @param query Query string
+     * @param jsonPath JsonPath expression.
+     * @param headers Request headers represented as a Spring Framework {@link HttpHeaders}
+     * @param variables A Map of variables
+     * @param clazz The type to convert the extracted value to.
+     * @return The extracted value from the result, converted to type T
+     * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
+     * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
+     */
+    <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, HttpHeaders headers, Map<String, Object> variables, Class<T> clazz);
 
     /**
      * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
@@ -211,5 +227,23 @@ public interface DgsQueryExecutor {
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      * @see <a href="https://github.com/json-path/JsonPath#what-is-returned-when">Using TypeRef</a>
      */
-    <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Map<String, Object> variables, TypeRef<T> typeRef);
+    default <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Map<String, Object> variables, TypeRef<T> typeRef) {
+        return executeAndExtractJsonPathAsObject(query, jsonPath, null,  Collections.emptyMap(), typeRef);
+    }
+
+    /**
+     * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
+     * Uses a {@link TypeRef} to specify the expected type, which is useful for Lists and Maps.
+     * Be aware that this method can't guarantee type safety.
+     * @param query Query string
+     * @param jsonPath JsonPath expression.
+     * @param headers Request headers represented as a Spring Framework {@link HttpHeaders}
+     * @param variables A Map of variables
+     * @param typeRef A JsonPath {@link TypeRef} representing the expected result type.
+     * @return The extracted value from the result, converted to type T
+     * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
+     * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
+     * @see <a href="https://github.com/json-path/JsonPath#what-is-returned-when">Using TypeRef</a>
+     */
+    <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, HttpHeaders headers, Map<String, Object> variables, TypeRef<T> typeRef);
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
@@ -167,7 +167,7 @@ public interface DgsQueryExecutor {
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      */
     default <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Class<T> clazz) {
-        return executeAndExtractJsonPathAsObject(query, jsonPath,  Collections.emptyMap(), clazz);
+        return executeAndExtractJsonPathAsObject(query, jsonPath,  Collections.emptyMap(), clazz, null);
     }
 
     /**
@@ -182,7 +182,7 @@ public interface DgsQueryExecutor {
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
     default <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Map<String, Object> variables, Class<T> clazz) {
-        return executeAndExtractJsonPathAsObject(query, jsonPath, null, Collections.emptyMap(), clazz);
+        return executeAndExtractJsonPathAsObject(query, jsonPath, variables, clazz, null);
     }
 
     /**
@@ -190,14 +190,14 @@ public interface DgsQueryExecutor {
      * Be aware that this method can't guarantee type safety.
      * @param query Query string
      * @param jsonPath JsonPath expression.
-     * @param headers Request headers represented as a Spring Framework {@link HttpHeaders}
      * @param variables A Map of variables
      * @param clazz The type to convert the extracted value to.
+     * @param headers Request headers represented as a Spring Framework {@link HttpHeaders}
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
-    <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, HttpHeaders headers, Map<String, Object> variables, Class<T> clazz);
+    <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Map<String, Object> variables, Class<T> clazz, HttpHeaders headers);
 
     /**
      * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
@@ -211,7 +211,7 @@ public interface DgsQueryExecutor {
      * @see <a href="https://github.com/json-path/JsonPath#what-is-returned-when">Using TypeRef</a>
      */
     default <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, TypeRef<T> typeRef) {
-        return executeAndExtractJsonPathAsObject(query, jsonPath,  Collections.emptyMap(), typeRef);
+        return executeAndExtractJsonPathAsObject(query, jsonPath,  Collections.emptyMap(), typeRef, null);
     }
 
     /**
@@ -228,7 +228,7 @@ public interface DgsQueryExecutor {
      * @see <a href="https://github.com/json-path/JsonPath#what-is-returned-when">Using TypeRef</a>
      */
     default <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Map<String, Object> variables, TypeRef<T> typeRef) {
-        return executeAndExtractJsonPathAsObject(query, jsonPath, null,  Collections.emptyMap(), typeRef);
+        return executeAndExtractJsonPathAsObject(query, jsonPath,  variables, typeRef, null);
     }
 
     /**
@@ -237,13 +237,13 @@ public interface DgsQueryExecutor {
      * Be aware that this method can't guarantee type safety.
      * @param query Query string
      * @param jsonPath JsonPath expression.
-     * @param headers Request headers represented as a Spring Framework {@link HttpHeaders}
      * @param variables A Map of variables
      * @param typeRef A JsonPath {@link TypeRef} representing the expected result type.
+     * @param headers Request headers represented as a Spring Framework {@link HttpHeaders}
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      * @see <a href="https://github.com/json-path/JsonPath#what-is-returned-when">Using TypeRef</a>
      */
-    <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, HttpHeaders headers, Map<String, Object> variables, TypeRef<T> typeRef);
+    <T> T executeAndExtractJsonPathAsObject(String query, String jsonPath, Map<String, Object> variables, TypeRef<T> typeRef, HttpHeaders headers);
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -113,10 +113,11 @@ class DefaultDgsQueryExecutor(
     override fun <T> executeAndExtractJsonPathAsObject(
         query: String,
         jsonPath: String,
+        headers: HttpHeaders?,
         variables: Map<String, Any>,
         clazz: Class<T>
     ): T {
-        val jsonResult = getJsonResult(query, variables)
+        val jsonResult = getJsonResult(query, variables, headers)
         return try {
             parseContext.parse(jsonResult).read(jsonPath, clazz)
         } catch (ex: MappingException) {
@@ -127,10 +128,11 @@ class DefaultDgsQueryExecutor(
     override fun <T> executeAndExtractJsonPathAsObject(
         query: String,
         jsonPath: String,
+        headers: HttpHeaders?,
         variables: Map<String, Any>,
         typeRef: TypeRef<T>
     ): T {
-        val jsonResult = getJsonResult(query, variables)
+        val jsonResult = getJsonResult(query, variables, headers)
         return try {
             parseContext.parse(jsonResult).read(jsonPath, typeRef)
         } catch (ex: MappingException) {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -113,9 +113,9 @@ class DefaultDgsQueryExecutor(
     override fun <T> executeAndExtractJsonPathAsObject(
         query: String,
         jsonPath: String,
-        headers: HttpHeaders?,
         variables: Map<String, Any>,
-        clazz: Class<T>
+        clazz: Class<T>,
+        headers: HttpHeaders?
     ): T {
         val jsonResult = getJsonResult(query, variables, headers)
         return try {
@@ -128,9 +128,9 @@ class DefaultDgsQueryExecutor(
     override fun <T> executeAndExtractJsonPathAsObject(
         query: String,
         jsonPath: String,
-        headers: HttpHeaders?,
         variables: Map<String, Any>,
-        typeRef: TypeRef<T>
+        typeRef: TypeRef<T>,
+        headers: HttpHeaders?
     ): T {
         val jsonResult = getJsonResult(query, variables, headers)
         return try {

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
@@ -227,7 +227,7 @@ internal class DefaultDgsQueryExecutorTest {
             object : TypeRef<String>() {}
         )
 
-        assertThat(expectedMessage).isEqualTo(message)
+        assertThat(message).isEqualTo(expectedMessage)
     }
 
     @Test
@@ -244,7 +244,7 @@ internal class DefaultDgsQueryExecutorTest {
             httpHeaders
         )
 
-        assertThat(expectedMessage).isEqualTo(message)
+        assertThat(message).isEqualTo(expectedMessage)
     }
 
     @Test
@@ -257,7 +257,7 @@ internal class DefaultDgsQueryExecutorTest {
             String::class.java
         )
 
-        assertThat(expectedMessage).isEqualTo(message)
+        assertThat(message).isEqualTo(expectedMessage)
     }
 
     @Test
@@ -274,7 +274,7 @@ internal class DefaultDgsQueryExecutorTest {
             httpHeaders
         )
 
-        assertThat(expectedMessage).isEqualTo(message)
+        assertThat(message).isEqualTo(expectedMessage)
     }
 
     @Test


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

We have HttpHeaders in `executeAndExtractJsonPath`, but doesn't in `executeAndExtractJsonPathAsObject`. Therefore, make `executeAndExtractJsonPathAsObject` take the HttpHeaders in the arguments. 


_Describe the new behavior from this PR, and why it's needed_
Issue #

This is helpful when we writing the Unit Test with header values. One example is the auth token in the header. Without this PR, we need to do something like
```
HttpHeaders httpHeaders = new HttpHeaders();
    httpHeaders.add("Authorization", formatAuthorizationToken(loginUser.getToken()));

    Object executorResult =
        dgsQueryExecutor.executeAndExtractJsonPath(
            graphQLQueryRequest.serialize(), "data.login", httpHeaders);

    LoginUser registerUser = objectMapper.convertValue(executorResult, LoginUser.class);
```

With this PR, we can do it in just one line
```
HttpHeaders httpHeaders = new HttpHeaders();
    httpHeaders.add("Authorization", formatAuthorizationToken(loginUser.getToken()));

    LoginUser registerUser = dgsQueryExecutor.executeAndExtractJsonPathAsObject(
            graphQLQueryRequest.serialize(), "data.login", httpHeaders, LoginUser.class);
```

Alternatives considered
----

_Describe alternative implementation you have considered_
No
