### PR TITLE
Have the CI Gradle Build provide additional info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
       - name: Build
         run: |
-          ./gradlew build
+          ./gradlew build --info
       # - name: Publish Test Report
       #   if: ${{ always() }}
       #   uses: scacap/action-surefire-report@v1


### PR DESCRIPTION
Configure the `gradle build` to provide additional information via the `--info` flag.
