### PR TITLE
Visibility of the `MetricsInstrumentationState.tags` method.

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -1,5 +1,6 @@
 package com.netflix.graphql.dgs.metrics.micrometer
 
+import com.netflix.graphql.dgs.Internal
 import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlMetric
 import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlTag
 import com.netflix.graphql.dgs.metrics.micrometer.tagging.DgsGraphQLMetricsTagsProvider
@@ -209,7 +210,8 @@ class DgsGraphQLMetricsInstrumentation(
             this.timerSample.ifPresent { it.stop(timer.register(this.registry)) }
         }
 
-        internal fun tags(): Tags {
+        @Internal
+        fun tags(): Tags {
             return Tags
                 .of(
                     GqlTag.QUERY_COMPLEXITY.key,

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/SpectatorLimitedTagMetricResolver.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/SpectatorLimitedTagMetricResolver.kt
@@ -44,4 +44,8 @@ internal class SpectatorLimitedTagMetricResolver(
             DgsGraphQLMetricsProperties.CardinalityLimiterKind.ROLLUP -> CardinalityLimiters.rollup(properties.limit)
         }
     }
+
+    override fun toString(): String {
+        return "SpectatorLimitedTagMetricResolver(tagsProperties=$tagsProperties, dynamicTags=$dynamicTags)"
+    }
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/Internal.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/Internal.java
@@ -25,8 +25,7 @@ import static java.lang.annotation.ElementType.FIELD;
 
 
 /**
- * This represents code considered internal to the DGS framework and therefore its API is not stable between within releases.
- * In general unnecessary changes will be avoided but you should not depend on internal classes.
+ * This represents code considered internal to the DGS framework and therefore its API is not stable between releases.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {CONSTRUCTOR, METHOD, TYPE, FIELD})


### PR DESCRIPTION
Make sure that the `MetricsInstrumentationState.tags` is visible so that other libraries and frameworks can leverage it. It already implements cardinality controls for the `gql.operation.name` and `gql.query.sigh.hash` tags.
