### PR TITLE
Adopt kotlinter-gradle instead of org.jlleitschuh.gradle:ktlint-gradle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GW_OPT_DISABLE_LOCAL=
 
 
 format: ## Formats source code
-	$(GW_CMD) ktlintFormat
+	$(GW_CMD) formatKotlin
 
 
 publish-local: ## Clans, bulds, and publishes the Codegen artifacts to mavenLocal, as a SNAPSHOT.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
     `java-library`
     id("nebula.netflixoss") version "10.3.0"
     id("nebula.dependency-recommender") version "11.0.0"
-    id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
+    id("org.jmailen.kotlinter") version "3.6.0"
     kotlin("jvm") version Versions.KOTLIN_VERSION
     kotlin("kapt") version Versions.KOTLIN_VERSION
     idea
@@ -67,7 +67,7 @@ configure(subprojects.filterNot { it in internalBomModules }) {
         plugin("java-library")
         plugin("kotlin")
         plugin("kotlin-kapt")
-        plugin("org.jlleitschuh.gradle.ktlint")
+        plugin("org.jmailen.kotlinter")
     }
 
     /**
@@ -132,7 +132,10 @@ configure(subprojects.filterNot { it in internalBomModules }) {
         }
     }
 
-    configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
-        disabledRules.set(setOf("no-wildcard-imports"))
+    kotlinter {
+        indentSize = 4
+        reporters = arrayOf("checkstyle", "plain")
+        experimentalRules = false
+        disabledRules = arrayOf("no-wildcard-imports")
     }
 }

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebRequestTestWithCustomContext.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebRequestTestWithCustomContext.kt
@@ -100,7 +100,6 @@ class WebRequestTestWithCustomContext {
                             .type(TypeName("String"))
                             .build()
                     )
-
                     .build()
             newRegistry.add(query)
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Migrate the _Kotlin Format Task_ from `org.jlleitschuh.gradle.ktlint` to `org.jmailen.kotlinter` due recent failures while upgrading the first's minor version.


Alternatives considered
----

We could keep attempting to use `org.jlleitschuh.gradle.ktlint` and understand why 10.1.0 fails to serialize the `com.pinterest.ktlint.reporter.plain.PlainReporterProvider`. Error stacktrace below.

```
Caused by: java.io.NotSerializableException: com.pinterest.ktlint.reporter.plain.PlainReporterProvider
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
        at java.util.ArrayList.writeObject(ArrayList.java:768)
        at sun.reflect.GeneratedMethodAccessor605.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1154)
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1496)
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
        at org.jlleitschuh.gradle.ktlint.worker.CurrentKtLintClassesSerializer.saveReporterProviders(KtLintClassesSerializer.kt:91)
        at org.jlleitschuh.gradle.ktlint.worker.LoadReportersWorkAction.execute(LoadReportersWorkAction.kt:33)
```

