### PR TITLE
DataFetchResultProcessor: add DFE as an argument

### DIFF
--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/ReactiveDataFetcherResultProcessor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/ReactiveDataFetcherResultProcessor.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.reactive.internal
 
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
 import com.netflix.graphql.dgs.internal.DataFetcherResultProcessor
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -26,7 +27,7 @@ class MonoDataFetcherResultProcessor : DataFetcherResultProcessor {
         return originalResult is Mono<*>
     }
 
-    override fun process(originalResult: Any): Any {
+    override fun process(originalResult: Any, dfe: DgsDataFetchingEnvironment): Any {
         if (originalResult is Mono<*>) {
             return originalResult.toFuture()
         } else {
@@ -40,7 +41,7 @@ class FluxDataFetcherResultProcessor : DataFetcherResultProcessor {
         return originalResult is Flux<*>
     }
 
-    override fun process(originalResult: Any): Any {
+    override fun process(originalResult: Any, dfe: DgsDataFetchingEnvironment): Any {
         if (originalResult is Flux<*>) {
             return originalResult.collectList().toFuture()
         } else {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -284,13 +284,14 @@ class DgsSchemaProvider(
 
     private fun createBasicDataFetcher(method: Method, dgsComponent: Any, isSubscription: Boolean): DataFetcher<Any?> {
         return DataFetcher<Any?> { environment ->
-            val result = invokeDataFetcher(method, dgsComponent, DgsDataFetchingEnvironment(environment))
+            val dfe = DgsDataFetchingEnvironment(environment)
+            val result = invokeDataFetcher(method, dgsComponent, dfe)
             when {
                 isSubscription -> {
                     result
                 }
                 result != null -> {
-                    dataFetcherResultProcessors.find { it.supportsType(result) }?.process(result) ?: result
+                    dataFetcherResultProcessors.find { it.supportsType(result) }?.process(result, dfe) ?: result
                 }
                 else -> {
                     result
@@ -553,5 +554,7 @@ class DgsSchemaProvider(
 
 interface DataFetcherResultProcessor {
     fun supportsType(originalResult: Any): Boolean
-    fun process(originalResult: Any): Any
+    fun process(originalResult: Any, dfe: DgsDataFetchingEnvironment): Any = process(originalResult)
+    @Deprecated("Replaced with process(originalResult, dfe)")
+    fun process(originalResult: Any): Any = originalResult
 }


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This will allow custom contexts to inject data into the result by type
as necessary based on the DataFetchingEnvironment.

For instance, in WebFlux apps this will allow a way to inject Mono's
ContextView object into the result processor via custom contexts.
Allowing the passing of SecurityContext through the stack, etc...

Not sure if this is the best approach, or we are harming the interface
by adding the DFE. Would there be other scenarios where adding the
DFE would also be useful? I was thinking maybe something like using
schema annotations to filter values but there might be other ways to
do that?

Issue https://github.com/Netflix/dgs-framework/issues/375

Alternatives considered
----

May have overlooked something here, this feels like the easiest path; although it might not be the best.

This does not fix the entire issue attached, supporting the Mono's context through the stack to Mono/Flux return types for reactive applications. However, this is one step towards adding a ReactiveDgsContext which might be a solution for the mentioned ticket.

Example usage
----

```kt
@Component
 class MonoDataFetcherResultProcessor : DataFetcherResultProcessor {
     override fun supportsType(originalResult: Any): Boolean {
         return originalResult is Mono<*>
     }

     override fun process(originalResult: Any, dfe: DgsDataFetchingEnvironment): Any {
         if (originalResult is Mono<*>) {
             val webContext = (dfe.getDgsContext().customContext as WebContext)
             return originalResult.contextWrite(webContext.monoContext).toFuture()
         } else {
             throw IllegalArgumentException("Instance passed to ${this::class.qualifiedName} was not a Mono<*>. It was a ${originalResult::class.qualifiedName} instead")
         }
     }
 }

 @Component
 class FluxDataFetcherResultProcessor : DataFetcherResultProcessor {
     override fun supportsType(originalResult: Any): Boolean {
         return originalResult is Flux<*>
     }

     override fun process(originalResult: Any, dfe: DgsDataFetchingEnvironment): Any {
         if (originalResult is Flux<*>) {
             val webContext = (dfe.getDgsContext().customContext as WebContext)
             return originalResult.contextWrite(webContext.monoContext).collectList().toFuture()
         } else {
             throw IllegalArgumentException("Instance passed to ${this::class.qualifiedName} was not a Flux<*>. It was a ${originalResult::class.qualifiedName} instead")
         }
     }
 }

 @Component
 class MonoContextBuilder : DgsReactiveCustomContextBuilderWithRequest<WebContext> {
     override fun build(
         extensions: Map<String, Any>?,
         headers: HttpHeaders?,
         serverRequest: ServerRequest?
     ): Mono<WebContext> {
         return Mono.deferContextual { context -> Mono.just(WebContext(context)) }
     }
 }
 
 class WebContext(val monoContext: ContextView) {
 }

```
