### PR TITLE
Added a DgsDataLoaderRegistryConsumer

### DIFF
--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoaderRegistryConsumer.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoaderRegistryConsumer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs;
+
+import org.dataloader.DataLoaderRegistry;
+
+/**
+ * Interface indicating that this DataLoader wants to be call-backed with a reference to the DataLoaderReference.
+ */
+public interface DgsDataLoaderRegistryConsumer {
+
+    /**
+     * Callback to retrieve the DataLoaderRegistry instance.
+     * @param dataLoaderRegistry Typically this is stored as an instance variable for later use.
+     */
+    void setDataLoaderRegistry(DataLoaderRegistry dataLoaderRegistry);
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -144,7 +144,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
-        if(extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
+        if (extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
             extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
@@ -164,7 +164,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
-        if(extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
+        if (extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
             extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
@@ -187,7 +187,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
-        if(extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
+        if (extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
             extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
@@ -210,7 +210,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
-        if(extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
+        if (extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
             extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.internal
 import com.netflix.graphql.dgs.DataLoaderInstrumentationExtensionProvider
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsDataLoader
+import com.netflix.graphql.dgs.DgsDataLoaderRegistryConsumer
 import com.netflix.graphql.dgs.exceptions.InvalidDataLoaderTypeException
 import com.netflix.graphql.dgs.exceptions.UnsupportedSecuredDataLoaderException
 import org.dataloader.*
@@ -50,23 +51,23 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         val startTime = System.currentTimeMillis()
 
         val dataLoaderRegistry = DataLoaderRegistry()
-        batchLoaders.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second)) }
+        batchLoaders.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second, dataLoaderRegistry)) }
         mappedBatchLoaders.forEach {
             dataLoaderRegistry.register(
                 it.second.name,
-                createDataLoader(it.first, it.second)
+                createDataLoader(it.first, it.second, dataLoaderRegistry)
             )
         }
         batchLoadersWithContext.forEach {
             dataLoaderRegistry.register(
                 it.second.name,
-                createDataLoader(it.first, it.second, contextSupplier)
+                createDataLoader(it.first, it.second, contextSupplier, dataLoaderRegistry)
             )
         }
         mappedBatchLoadersWithContext.forEach {
             dataLoaderRegistry.register(
                 it.second.name,
-                createDataLoader(it.first, it.second, contextSupplier)
+                createDataLoader(it.first, it.second, contextSupplier, dataLoaderRegistry)
             )
         }
 
@@ -87,26 +88,27 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         applicationContext.getBeansWithAnnotation(DgsComponent::class.java).values.forEach { dgsComponent ->
             val javaClass = AopUtils.getTargetClass(dgsComponent)
 
-            javaClass.declaredFields.asSequence().filter { it.isAnnotationPresent(DgsDataLoader::class.java) }.forEach { field ->
-                if (AopUtils.isAopProxy(dgsComponent)) {
-                    throw UnsupportedSecuredDataLoaderException(dgsComponent::class.java)
-                }
+            javaClass.declaredFields.asSequence().filter { it.isAnnotationPresent(DgsDataLoader::class.java) }
+                .forEach { field ->
+                    if (AopUtils.isAopProxy(dgsComponent)) {
+                        throw UnsupportedSecuredDataLoaderException(dgsComponent::class.java)
+                    }
 
-                val annotation = field.getAnnotation(DgsDataLoader::class.java)
-                ReflectionUtils.makeAccessible(field)
+                    val annotation = field.getAnnotation(DgsDataLoader::class.java)
+                    ReflectionUtils.makeAccessible(field)
 
-                when (val get = field.get(dgsComponent)) {
-                    is BatchLoader<*, *> ->
-                        batchLoaders.add(get to annotation)
-                    is BatchLoaderWithContext<*, *> ->
-                        batchLoadersWithContext.add(get to annotation)
-                    is MappedBatchLoader<*, *> ->
-                        mappedBatchLoaders.add(get to annotation)
-                    is MappedBatchLoaderWithContext<*, *> ->
-                        mappedBatchLoadersWithContext.add(get to annotation)
-                    else -> throw InvalidDataLoaderTypeException(dgsComponent::class.java)
+                    when (val get = field.get(dgsComponent)) {
+                        is BatchLoader<*, *> ->
+                            batchLoaders.add(get to annotation)
+                        is BatchLoaderWithContext<*, *> ->
+                            batchLoadersWithContext.add(get to annotation)
+                        is MappedBatchLoader<*, *> ->
+                            mappedBatchLoaders.add(get to annotation)
+                        is MappedBatchLoaderWithContext<*, *> ->
+                            mappedBatchLoadersWithContext.add(get to annotation)
+                        else -> throw InvalidDataLoaderTypeException(dgsComponent::class.java)
+                    }
                 }
-            }
         }
     }
 
@@ -131,7 +133,8 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
 
     private fun createDataLoader(
         batchLoader: BatchLoader<*, *>,
-        dgsDataLoader: DgsDataLoader
+        dgsDataLoader: DgsDataLoader,
+        dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<out Any, out Any>? {
         val options = DataLoaderOptions.newOptions()
             .setBatchingEnabled(dgsDataLoader.batching)
@@ -141,12 +144,17 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
+        if(extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
+            extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
+        }
+
         return DataLoader.newDataLoader(extendedBatchLoader, options)
     }
 
     private fun createDataLoader(
         batchLoader: MappedBatchLoader<*, *>,
-        dgsDataLoader: DgsDataLoader
+        dgsDataLoader: DgsDataLoader,
+        dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<out Any, out Any>? {
         val options = DataLoaderOptions.newOptions()
             .setBatchingEnabled(dgsDataLoader.batching)
@@ -156,13 +164,18 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
+        if(extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
+            extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
+        }
+
         return DataLoader.newMappedDataLoader(extendedBatchLoader, options)
     }
 
     private fun <T> createDataLoader(
         batchLoader: BatchLoaderWithContext<*, *>,
         dgsDataLoader: DgsDataLoader,
-        supplier: Supplier<T>
+        supplier: Supplier<T>,
+        dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<out Any, out Any>? {
         val options = DataLoaderOptions.newOptions()
             .setBatchingEnabled(dgsDataLoader.batching)
@@ -174,13 +187,18 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
+        if(extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
+            extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
+        }
+
         return DataLoader.newDataLoader(extendedBatchLoader, options)
     }
 
     private fun <T> createDataLoader(
         batchLoader: MappedBatchLoaderWithContext<*, *>,
         dgsDataLoader: DgsDataLoader,
-        supplier: Supplier<T>
+        supplier: Supplier<T>,
+        dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<out Any, out Any>? {
         val options = DataLoaderOptions.newOptions()
             .setBatchingEnabled(dgsDataLoader.batching)
@@ -192,6 +210,10 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         }
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
+        if(extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
+            extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
+        }
+
         return DataLoader.newMappedDataLoader(extendedBatchLoader, options)
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -120,7 +120,7 @@ class DgsDataLoaderProviderTest {
         provider.findDataLoaders()
         val registry = provider.buildRegistry()
 
-        //Use the dataloader's "load" method to check if the registry was set correctly, because the dataloader instance isn't itself a DgsDataLoaderRegistryConsumer
+        // Use the dataloader's "load" method to check if the registry was set correctly, because the dataloader instance isn't itself a DgsDataLoaderRegistryConsumer
         val dataLoader = registry.getDataLoader<String, String>("withRegistry")
         val load = dataLoader.load("")
         dataLoader.dispatch()
@@ -129,7 +129,7 @@ class DgsDataLoaderProviderTest {
     }
 
     @DgsDataLoader(name = "withRegistry")
-    class ExampleDataLoaderWithRegistry: BatchLoader<String, String>, DgsDataLoaderRegistryConsumer {
+    class ExampleDataLoaderWithRegistry : BatchLoader<String, String>, DgsDataLoaderRegistryConsumer {
 
         lateinit var registry: DataLoaderRegistry
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -21,6 +21,9 @@ import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoaderRegistry
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -28,6 +31,8 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.support.StaticListableBeanFactory
 import org.springframework.context.ApplicationContext
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 
 @ExtendWith(MockKExtension::class)
 class DgsDataLoaderProviderTest {
@@ -104,5 +109,36 @@ class DgsDataLoaderProviderTest {
 
         val privateDataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("privateExampleMappedLoaderFromField")
         Assertions.assertNotNull(privateDataLoader)
+    }
+
+    @Test
+    fun dataLoaderConsumer() {
+        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf("withRegistry" to ExampleDataLoaderWithRegistry())
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
+
+        val provider = DgsDataLoaderProvider(applicationContextMock)
+        provider.findDataLoaders()
+        val registry = provider.buildRegistry()
+
+        //Use the dataloader's "load" method to check if the registry was set correctly, because the dataloader instance isn't itself a DgsDataLoaderRegistryConsumer
+        val dataLoader = registry.getDataLoader<String, String>("withRegistry")
+        val load = dataLoader.load("")
+        dataLoader.dispatch()
+        val loaderKeys = load.get()
+        assertThat(loaderKeys).isEqualTo(registry.keys.toMutableList()[0])
+    }
+
+    @DgsDataLoader(name = "withRegistry")
+    class ExampleDataLoaderWithRegistry: BatchLoader<String, String>, DgsDataLoaderRegistryConsumer {
+
+        lateinit var registry: DataLoaderRegistry
+
+        override fun setDataLoaderRegistry(dataLoaderRegistry: DataLoaderRegistry) {
+            this.registry = dataLoaderRegistry
+        }
+
+        override fun load(keys: List<String>): CompletionStage<MutableList<String>>? {
+            return CompletableFuture.completedFuture(registry.keys.toMutableList())
+        }
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This adds an optional interface that a `@DgsDataLoader` class can implement. It gives a callback to that dataloader to retrieve an instance to the dataloader registry.
The registry can be used to get access to other dataloaders. This is for example useful for this pattern: https://github.com/graphql/dataloader#loading-by-alternative-keys which users have asked for repeatedly.

Issue #138

Alternatives considered
----

I had two other ideas that were both dead ends.
1) Give access to the datafetchingenvironment: This isn't possible because the datafetchingenvironment is only available after dataloaders are created.
2) Add the registry to the dataloader context. The context gets created after the registry, so this isn't possible either.
