### PR TITLE
Remove Java Package name from Projection serialization

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
@@ -25,7 +25,7 @@ class ProjectionSerializer(private val inputValueSerializer: InputValueSerialize
         }
 
         val prefix = if (isFragment) {
-            "... on ${projection::class.java.name.substringAfterLast("_").substringBefore("Projection")} { "
+            "... on ${projection::class.java.name.substringAfterLast(".").substringAfterLast("_").substringBefore("Projection")} { "
         } else {
             "{ "
         }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Address the case where a Java Class representing a projection doesn't
contain an `_` character to segregate the _projection_ name. e.g.

`com.netflix.dgs.federation.example.client.EntitiesMovieKeyProjection`

