### PR TITLE
Enable Projection Types to define the Schema Type explicitly

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseProjectionNode.kt
@@ -19,7 +19,19 @@ package com.netflix.graphql.dgs.client.codegen
 import java.util.*
 import kotlin.collections.LinkedHashMap
 
-abstract class BaseProjectionNode {
+abstract class BaseProjectionNode(
+    /**
+     * Explicit GraphQL Schema type. This, for example, is used to define the GraphQL Type when resolving a _fragment_.
+     * For example, let's say the `schemaType` is `"Movie"`, then  the _Entity fragment_ associated to
+     * this node will be:
+     *
+     * ```
+     *  ... on Movie {
+     * ```
+     */
+    val schemaType: Optional<String> = Optional.empty()
+) {
+
     val fields: MutableMap<String, Any?> = LinkedHashMap()
     val fragments: MutableList<BaseSubProjectionNode<*, *>> = LinkedList()
     val inputArguments: MutableMap<String, List<InputArgument>> = LinkedHashMap()

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseSubProjectionNode.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/BaseSubProjectionNode.kt
@@ -16,7 +16,15 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
-abstract class BaseSubProjectionNode<T, R>(val parent: T, val root: R) : BaseProjectionNode() {
+import java.util.*
+
+abstract class BaseSubProjectionNode<T, R>(
+    val parent: T,
+    val root: R,
+    schemaType: Optional<String> = Optional.empty()
+) : BaseProjectionNode(schemaType) {
+
+    constructor(parent: T, root: R) : this(parent, root, schemaType = Optional.empty())
 
     fun parent(): T {
         return parent

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializer.kt
@@ -19,16 +19,24 @@ package com.netflix.graphql.dgs.client.codegen
 import java.util.*
 
 class ProjectionSerializer(private val inputValueSerializer: InputValueSerializer) {
+
     fun serialize(projection: BaseProjectionNode, isFragment: Boolean = false): String {
         if (projection.fields.isEmpty() && projection.fragments.isEmpty()) {
             return ""
         }
 
         val prefix = if (isFragment) {
-            "... on ${projection::class.java.name.substringAfterLast(".").substringAfterLast("_").substringBefore("Projection")} { "
+            val schemaType = projection.schemaType.orElse(
+                projection::class.java.name
+                    .substringAfterLast(".")
+                    .substringAfterLast("_")
+                    .substringBefore("Projection")
+            )
+            "... on $schemaType { "
         } else {
             "{ "
         }
+
         val joiner = StringJoiner(" ", prefix, " }")
         projection.fields.forEach { (key, value) ->
             val field = if (projection.inputArguments[key] != null) {

--- a/graphql-dgs-client/src/test/java/com/netflix/graphql/client/codegen/exampleprojection/EntitiesMoviesKeyProjection.kt
+++ b/graphql-dgs-client/src/test/java/com/netflix/graphql/client/codegen/exampleprojection/EntitiesMoviesKeyProjection.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.client.codegen.exampleprojection
+
+import com.netflix.graphql.dgs.client.codegen.BaseProjectionNode
+import com.netflix.graphql.dgs.client.codegen.BaseSubProjectionNode
+import java.util.*
+
+class EntitiesMovieKeyProjection(
+    parent: EntitiesProjectionRoot,
+    root: EntitiesProjectionRoot,
+    schemaType: Optional<String>
+) : BaseSubProjectionNode<EntitiesProjectionRoot, EntitiesProjectionRoot>(
+    parent,
+    root,
+    schemaType = schemaType
+) {
+
+    fun moveId(): EntitiesMovieKeyProjection {
+        fields["moveId"] = null
+        return this
+    }
+
+    fun title(): EntitiesMovieKeyProjection {
+        fields["title"] = null
+        return this
+    }
+
+    fun releaseYear(): EntitiesMovieKeyProjection {
+        fields["releaseYear"] = null
+        return this
+    }
+
+    fun reviews(username: String, score: Int): Movies_ReviewsProjection {
+        val projection = Movies_ReviewsProjection(this, root)
+        fields["reviews"] = projection
+        inputArguments.computeIfAbsent("reviews") { mutableListOf() }
+        (inputArguments["reviews"] as MutableList).add(InputArgument("username", username))
+        (inputArguments["reviews"] as MutableList).add(InputArgument("score", score))
+        return projection
+    }
+
+    init {
+        fields["__typename"] = null
+    }
+}
+
+class EntitiesProjectionRoot : BaseProjectionNode() {
+    fun onMovie(schemaType: Optional<String>): EntitiesMovieKeyProjection {
+        val fragment = EntitiesMovieKeyProjection(this, this, schemaType)
+        fragments.add(fragment)
+        return fragment
+    }
+}
+
+class Movies_ReviewsProjection(parent: EntitiesMovieKeyProjection, root: EntitiesProjectionRoot) :
+    BaseSubProjectionNode<EntitiesMovieKeyProjection, EntitiesProjectionRoot>(parent, root) {
+    fun username(): Movies_ReviewsProjection {
+        fields["username"] = null
+        return this
+    }
+
+    fun score(): Movies_ReviewsProjection {
+        fields["score"] = null
+        return this
+    }
+}

--- a/graphql-dgs-client/src/test/java/com/netflix/graphql/client/codegen/exampleprojection/ShowsProjectionRoot.java
+++ b/graphql-dgs-client/src/test/java/com/netflix/graphql/client/codegen/exampleprojection/ShowsProjectionRoot.java
@@ -22,6 +22,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 
 public class ShowsProjectionRoot extends BaseProjectionNode {
+
     public Shows_ReviewsProjection reviews() {
         Shows_ReviewsProjection projection = new Shows_ReviewsProjection(this, this);
         getFields().put("reviews", projection);

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/codegen/ProjectionSerializerTest.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.client.codegen
 
+import com.netflix.graphql.client.codegen.exampleprojection.EntitiesProjectionRoot
 import com.netflix.graphql.client.codegen.exampleprojection.ShowsProjectionRoot
 import graphql.scalars.ExtendedScalars
 import graphql.schema.Coercing
@@ -23,17 +24,45 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.*
 
 internal class ProjectionSerializerTest {
 
     @Test
     fun `Projection with argument that requires a scalar`() {
-        val scalars: Map<Class<*>, Coercing<*, *>> = mapOf(OffsetDateTime::class.java to ExtendedScalars.DateTime.coercing)
+        val scalars: Map<Class<*>, Coercing<*, *>> =
+            mapOf(OffsetDateTime::class.java to ExtendedScalars.DateTime.coercing)
         val projectionSerializer = ProjectionSerializer(InputValueSerializer(scalars))
 
         val projection = ShowsProjectionRoot()
             .reviews(3, OffsetDateTime.of(2021, 6, 16, 15, 20, 0, 0, ZoneOffset.UTC)).starScore().root
         val serialize = projectionSerializer.serialize(projection)
         assertThat(serialize).isEqualTo("{ reviews(minScore: 3, since: \"2021-06-16T15:20:00Z\")   { starScore } }")
+    }
+
+    @Test
+    fun `Projection for entity with explicit schema type`() {
+        // given
+        val root = EntitiesProjectionRoot()
+        root.onMovie(Optional.of("Movie"))
+            .moveId().title().releaseYear()
+            .reviews(username = "Foo", score = 10).username().score()
+        // when
+        val serialize = ProjectionSerializer(InputValueSerializer()).serialize(root, isFragment = true)
+        // then
+        assertThat(serialize).isEqualTo("""... on Entities { ... on Movie { __typename moveId title releaseYear reviews(username: "Foo", score: 10)   { username score } } }""")
+    }
+
+    @Test
+    fun `Projection for entity with no explicit schema type`() {
+        // given
+        val root = EntitiesProjectionRoot()
+        root.onMovie(Optional.empty())
+            .moveId().title().releaseYear()
+            .reviews(username = "Foo", score = 10).username().score()
+        // when
+        val serialize = ProjectionSerializer(InputValueSerializer()).serialize(root, isFragment = true)
+        // then
+        assertThat(serialize).isEqualTo("""... on Entities { ... on EntitiesMovieKey { __typename moveId title releaseYear reviews(username: "Foo", score: 10)   { username score } } }""")
     }
 }


### PR DESCRIPTION
This provides a mechanism to explicitly define a _GraphQL Schema Type_
that will be used by a _projection_. This is useful when the projection
is not expressing the _GraphQL Schema Type_ via its Java class name.

