### PR TITLE
Fix handling of null variables for subscriptions and properly cleanup websocket subscriptions.

### DIFF
--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketHandler.kt
@@ -149,4 +149,4 @@ const val GQL_CONNECTION_TERMINATE = "connection_terminate"
 
 data class DataPayload(val data: Any?, val errors: List<Any>? = emptyList())
 data class OperationMessage(@JsonProperty("type") val type: String, @JsonProperty("payload") val payload: Any? = null, @JsonProperty("id", required = false) val id: String? = "")
-data class QueryPayload(@JsonProperty("variables") val variables: Map<String, Any> = emptyMap(), @JsonProperty("extensions") val extensions: Map<String, Any> = emptyMap(), @JsonProperty("operationName") val operationName: String?, @JsonProperty("query") val query: String)
+data class QueryPayload(@JsonProperty("variables") val variables: Map<String, Any>?, @JsonProperty("extensions") val extensions: Map<String, Any> = emptyMap(), @JsonProperty("operationName") val operationName: String?, @JsonProperty("query") val query: String)


### PR DESCRIPTION

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This PR fixes 2 issues reported below.
1. Handle null  variables as input to subscription queries
2. Properly clean up the subscription from the session map on receiving GQL_STOP. The wrong session map was use to do this previously.


_Describe the new behavior from this PR, and why it's needed_
Issue #452 
Issue #449
