### PR TITLE
Use the exception handlers to process exceptions for _entities query.

### DIFF
--- a/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/DefaultDgsReactiveQueryExecutorTest.kt
+++ b/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/DefaultDgsReactiveQueryExecutorTest.kt
@@ -105,6 +105,7 @@ internal class DefaultDgsReactiveQueryExecutorTest {
         val provider = DgsSchemaProvider(
             applicationContextMock,
             federationResolver = Optional.empty(),
+            dataFetcherExceptionHandler = Optional.empty(),
             existingTypeDefinitionRegistry = Optional.empty(),
             mockProviders = Optional.empty()
         )

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -129,11 +129,11 @@ open class DgsAutoConfiguration(
     open fun dgsSchemaProvider(
         applicationContext: ApplicationContext,
         federationResolver: Optional<DgsFederationResolver>,
-        dataFetcherExceptionHandler: DataFetcherExceptionHandler,
         existingTypeDefinitionFactory: Optional<TypeDefinitionRegistry>,
         existingCodeRegistry: Optional<GraphQLCodeRegistry>,
         mockProviders: Optional<Set<MockProvider>>,
         dataFetcherResultProcessors: List<DataFetcherResultProcessor>,
+        dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler> = Optional.empty(),
     ): DgsSchemaProvider {
         return DgsSchemaProvider(
             applicationContext,
@@ -142,6 +142,7 @@ open class DgsAutoConfiguration(
             mockProviders,
             configProps.schemaLocations,
             dataFetcherResultProcessors,
+            dataFetcherExceptionHandler,
         )
     }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -21,14 +21,12 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.dgs.*
 import com.netflix.graphql.dgs.context.DgsContext
-import com.netflix.graphql.dgs.exceptions.DgsInvalidInputArgumentException
-import com.netflix.graphql.dgs.exceptions.InvalidDgsConfigurationException
-import com.netflix.graphql.dgs.exceptions.InvalidTypeResolverException
-import com.netflix.graphql.dgs.exceptions.NoSchemaFoundException
+import com.netflix.graphql.dgs.exceptions.*
 import com.netflix.graphql.dgs.federation.DefaultDgsFederationResolver
 import com.netflix.graphql.mocking.DgsSchemaTransformer
 import com.netflix.graphql.mocking.MockProvider
 import graphql.TypeResolutionEnvironment
+import graphql.execution.DataFetcherExceptionHandler
 import graphql.language.InterfaceTypeDefinition
 import graphql.language.TypeName
 import graphql.language.UnionTypeDefinition
@@ -70,6 +68,7 @@ class DgsSchemaProvider(
     private val mockProviders: Optional<Set<MockProvider>>,
     private val schemaLocations: List<String> = listOf(DEFAULT_SCHEMA_LOCATION),
     private val dataFetcherResultProcessors: List<DataFetcherResultProcessor> = emptyList(),
+    private val dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler> = Optional.empty()
 ) {
 
     companion object {
@@ -102,7 +101,7 @@ class DgsSchemaProvider(
             mergedRegistry = mergedRegistry.merge(existingTypeDefinitionRegistry.get())
         }
 
-        val federationResolverInstance = federationResolver.orElseGet { DefaultDgsFederationResolver(this) }
+        val federationResolverInstance = federationResolver.orElseGet { DefaultDgsFederationResolver(this, dataFetcherExceptionHandler) }
 
         val entityFetcher = federationResolverInstance.entitiesFetcher()
         val typeResolver = federationResolverInstance.typeResolver()

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
@@ -99,6 +99,7 @@ internal class DefaultDgsQueryExecutorTest {
         val provider = DgsSchemaProvider(
             applicationContextMock,
             federationResolver = Optional.empty(),
+            dataFetcherExceptionHandler = Optional.empty(),
             existingTypeDefinitionRegistry = Optional.empty(),
             mockProviders = Optional.empty()
         )


### PR DESCRIPTION



Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
We recently improved error handling for entity fetcher when handling federated queries such that we return null data with partial results in case of errors. However, this does not use the default or custom exception handler for populating the errors in the response as was previously the case. This PR addresses that gap by using the exception handler - ether default or custom to handle exceptions from data fetchers. This keeps the error handling paths consistent across regular data fetchers and the `_entities` query.

