### PR TITLE
Add basic support for coroutines in datafetchers

### DIFF
--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -48,7 +48,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -233,7 +233,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -293,6 +293,9 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "16.0.1"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.6.0"
         },
@@ -303,7 +306,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -355,6 +358,9 @@
         "com.graphql-java:graphql-java": {
             "locked": "16.2"
         },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "16.0.1"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.6.0"
         },
@@ -365,7 +371,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -128,7 +128,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -440,7 +440,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -465,6 +465,19 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -655,7 +668,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -835,7 +848,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -860,6 +873,19 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -125,7 +125,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -442,7 +442,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
@@ -474,6 +474,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -683,7 +695,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -868,7 +880,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
@@ -900,6 +912,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -83,7 +83,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -338,7 +338,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -358,6 +358,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -485,7 +497,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -608,7 +620,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -628,6 +640,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -313,6 +313,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -470,7 +482,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -632,7 +644,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
@@ -661,6 +673,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-reactive/build.gradle.kts
+++ b/graphql-dgs-reactive/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework:spring-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     testImplementation(project(":graphql-dgs-spring-boot-oss-autoconfigure"))
     testImplementation("io.projectreactor:reactor-test")
 }

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -80,6 +80,9 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.3.8"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.9.RELEASE"
         },
@@ -313,6 +316,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -440,7 +455,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -454,6 +469,9 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.3.8"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.9.RELEASE"
@@ -563,7 +581,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -583,6 +601,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -128,7 +128,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.10.20"
@@ -400,6 +400,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -566,7 +578,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.10.20"
@@ -746,7 +758,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
@@ -778,6 +790,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -335,6 +335,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -579,6 +591,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -103,7 +103,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -383,7 +383,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
@@ -411,6 +411,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -572,7 +584,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -720,7 +732,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
@@ -748,6 +760,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -330,6 +330,19 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -468,7 +481,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -601,7 +614,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -622,6 +635,19 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -341,6 +341,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -612,6 +624,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -316,6 +316,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -534,6 +546,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -327,6 +327,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -566,6 +578,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -313,6 +313,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -421,7 +433,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -525,7 +537,7 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -537,6 +549,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -324,6 +324,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -563,6 +575,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -316,6 +316,18 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -430,7 +442,7 @@
             "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -540,7 +552,7 @@
             "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -552,6 +564,18 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -110,7 +110,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -397,7 +397,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -420,6 +420,19 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -587,7 +600,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -742,7 +755,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -765,6 +778,19 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("com.apollographql.federation:federation-graphql-java-support")
     implementation("org.springframework.security:spring-security-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
 
     testImplementation("org.springframework.security:spring-security-core")
     testImplementation("io.projectreactor:reactor-core")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -71,6 +71,12 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "locked": "1.3.8"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.9.RELEASE"
         },
@@ -283,6 +289,12 @@
             ],
             "locked": "1.4.32"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "locked": "1.3.8"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -371,10 +383,10 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -385,6 +397,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "locked": "1.3.8"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.9.RELEASE"
@@ -457,10 +475,10 @@
             "locked": "1.11.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.6"
+            "locked": "3.4.7"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.4.32"
@@ -471,6 +489,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.4.32"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
@@ -18,13 +18,14 @@ package com.netflix.graphql.dgs.context
 
 import com.netflix.graphql.dgs.internal.DgsRequestData
 import graphql.schema.DataFetchingEnvironment
+import kotlinx.coroutines.CoroutineScope
 import org.dataloader.BatchLoaderEnvironment
 
 /**
  * Context class that is created per request, and is added to both DataFetchingEnvironment and BatchLoaderEnvironment.
  * Custom data can be added by providing a [DgsCustomContextBuilder].
  */
-open class DgsContext(val customContext: Any? = null, val requestData: DgsRequestData?) {
+open class DgsContext(val customContext: Any? = null, val requestData: DgsRequestData?, val coroutineScope: CoroutineScope? = null) {
 
     companion object {
         @JvmStatic

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
@@ -18,14 +18,13 @@ package com.netflix.graphql.dgs.context
 
 import com.netflix.graphql.dgs.internal.DgsRequestData
 import graphql.schema.DataFetchingEnvironment
-import kotlinx.coroutines.CoroutineScope
 import org.dataloader.BatchLoaderEnvironment
 
 /**
  * Context class that is created per request, and is added to both DataFetchingEnvironment and BatchLoaderEnvironment.
  * Custom data can be added by providing a [DgsCustomContextBuilder].
  */
-open class DgsContext(val customContext: Any? = null, val requestData: DgsRequestData?, val coroutineScope: CoroutineScope? = null) {
+open class DgsContext(val customContext: Any? = null, val requestData: DgsRequestData?) {
 
     companion object {
         @JvmStatic

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
@@ -20,8 +20,6 @@ import com.netflix.graphql.dgs.context.DgsContext
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilder
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilderWithRequest
 import com.netflix.graphql.dgs.internal.utils.TimeTracer
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
@@ -58,7 +56,6 @@ open class DefaultDgsGraphQLContextBuilder(
         return DgsContext(
             customContext,
             dgsRequestData,
-            CoroutineScope(Dispatchers.Default)
         )
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
@@ -20,6 +20,8 @@ import com.netflix.graphql.dgs.context.DgsContext
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilder
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilderWithRequest
 import com.netflix.graphql.dgs.internal.utils.TimeTracer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
@@ -55,7 +57,8 @@ open class DefaultDgsGraphQLContextBuilder(
 
         return DgsContext(
             customContext,
-            dgsRequestData
+            dgsRequestData,
+            CoroutineScope(Dispatchers.Default)
         )
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -431,7 +431,7 @@ class DgsSchemaProvider(
             }
         }
 
-        return if(method.kotlinFunction?.isSuspend == true) {
+        return if (method.kotlinFunction?.isSuspend == true) {
             val dgsContext = environment.getContext<DgsContext>()
             val launch = dgsContext.coroutineScope?.async {
                 return@async method.kotlinFunction!!.callSuspend(dgsComponent, *args.toTypedArray())

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -39,6 +39,8 @@ import graphql.schema.idl.TypeDefinitionRegistry
 import graphql.schema.idl.TypeRuntimeWiring
 import graphql.schema.visibility.DefaultGraphqlFieldVisibility
 import graphql.schema.visibility.GraphqlFieldVisibility
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.future.asCompletableFuture
 import org.slf4j.LoggerFactory
@@ -432,8 +434,8 @@ class DgsSchemaProvider(
         }
 
         return if (method.kotlinFunction?.isSuspend == true) {
-            val dgsContext = environment.getContext<DgsContext>()
-            val launch = dgsContext.coroutineScope?.async {
+
+            val launch = CoroutineScope(Dispatchers.Unconfined).async {
                 return@async method.kotlinFunction!!.callSuspend(dgsComponent, *args.toTypedArray())
             }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -39,6 +39,8 @@ import graphql.schema.idl.TypeDefinitionRegistry
 import graphql.schema.idl.TypeRuntimeWiring
 import graphql.schema.visibility.DefaultGraphqlFieldVisibility
 import graphql.schema.visibility.GraphqlFieldVisibility
+import kotlinx.coroutines.async
+import kotlinx.coroutines.future.asCompletableFuture
 import org.slf4j.LoggerFactory
 import org.springframework.aop.support.AopUtils
 import org.springframework.context.ApplicationContext
@@ -59,6 +61,9 @@ import java.nio.charset.StandardCharsets
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
+import kotlin.coroutines.Continuation
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.jvm.kotlinFunction
 
 /**
  * Main framework class that scans for components and configures a runtime executable schema.
@@ -303,7 +308,7 @@ class DgsSchemaProvider(
     private fun invokeDataFetcher(method: Method, dgsComponent: Any, environment: DataFetchingEnvironment): Any? {
         val args = mutableListOf<Any?>()
         val parameterNames = defaultParameterNameDiscoverer.getParameterNames(method) ?: emptyArray()
-        method.parameters.forEachIndexed { idx, parameter ->
+        method.parameters.filter { it.type != Continuation::class.java }.forEachIndexed { idx, parameter ->
 
             when {
                 parameter.isAnnotationPresent(InputArgument::class.java) -> {
@@ -426,7 +431,16 @@ class DgsSchemaProvider(
             }
         }
 
-        return ReflectionUtils.invokeMethod(method, dgsComponent, *args.toTypedArray())
+        return if(method.kotlinFunction?.isSuspend == true) {
+            val dgsContext = environment.getContext<DgsContext>()
+            val launch = dgsContext.coroutineScope?.async {
+                return@async method.kotlinFunction!!.callSuspend(dgsComponent, *args.toTypedArray())
+            }
+
+            launch?.asCompletableFuture()
+        } else {
+            ReflectionUtils.invokeMethod(method, dgsComponent, *args.toTypedArray())
+        }
     }
 
     private fun getValueAsOptional(value: Any?, parameter: Parameter) =

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
@@ -53,7 +53,7 @@ class CoroutineDataFetcherTest {
                     repeat(from.rangeTo(to).count()) {
                         sum++
 
-                        //Forcing a blocking call to demonstrate running with a thread pool
+                        // Forcing a blocking call to demonstrate running with a thread pool
                         Thread.sleep(50)
                     }
                     println("after $from")

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
@@ -70,8 +70,6 @@ class CoroutineDataFetcherTest {
 
         val build = GraphQL.newGraphQL(schema).build()
 
-
-
         val context = DgsContext(
             null,
             null,
@@ -79,28 +77,32 @@ class CoroutineDataFetcherTest {
         )
 
         val concurrentTime = measureTimeMillis {
-            val executionResult = build.execute(ExecutionInput.newExecutionInput().context(context).query(
-                """
+            val executionResult = build.execute(
+                ExecutionInput.newExecutionInput().context(context).query(
+                    """
             {
                 first: concurrent(from: 1, to: 10)
                 second: concurrent(from: 1, to: 10)               
                 third: concurrent(from: 1, to: 10)               
                 fourth: concurrent(from: 1, to: 10)               
             }
-            """.trimIndent()
-            ).build())
+                    """.trimIndent()
+                ).build()
+            )
 
             assertThat(executionResult.isDataPresent).isTrue()
         }
 
         val singleTime = measureTimeMillis {
-            val executionResult = build.execute(ExecutionInput.newExecutionInput().context(context).query(
-                """
+            val executionResult = build.execute(
+                ExecutionInput.newExecutionInput().context(context).query(
+                    """
             {
                 first: concurrent(from: 1, to: 10)
             }
-            """.trimIndent()
-            ).build())
+                    """.trimIndent()
+                ).build()
+            )
 
             assertThat(executionResult.isDataPresent).isTrue()
         }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import com.netflix.graphql.dgs.context.DgsContext
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import graphql.ExecutionInput
+import graphql.GraphQL
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Percentage
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.context.ApplicationContext
+import java.util.*
+import kotlin.system.measureTimeMillis
+
+@ExtendWith(MockKExtension::class)
+class CoroutineDataFetcherTest {
+    @MockK
+    lateinit var applicationContextMock: ApplicationContext
+
+    @Test
+    fun `Suspend functions should be supported as datafetchers`() {
+        val fetcher = object : Any() {
+            @DgsQuery
+            suspend fun concurrent(@InputArgument from: Int, to: Int): Int = coroutineScope {
+                var sum = 0
+
+                repeat(from.rangeTo(to).count()) {
+                    sum++
+                    delay(50)
+                }
+
+                sum
+            }
+        }
+
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("concurrentFetcher", fetcher))
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+
+        val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+        val schema = provider.schema(
+            """
+            type Query {
+                concurrent(from: Int, to: Int): Int
+            }           
+            """.trimIndent()
+        )
+
+        val build = GraphQL.newGraphQL(schema).build()
+
+
+
+        val context = DgsContext(
+            null,
+            null,
+            CoroutineScope(Dispatchers.Default)
+        )
+
+        val concurrentTime = measureTimeMillis {
+            val executionResult = build.execute(ExecutionInput.newExecutionInput().context(context).query(
+                """
+            {
+                first: concurrent(from: 1, to: 10)
+                second: concurrent(from: 1, to: 10)               
+                third: concurrent(from: 1, to: 10)               
+                fourth: concurrent(from: 1, to: 10)               
+            }
+            """.trimIndent()
+            ).build())
+
+            assertThat(executionResult.isDataPresent).isTrue()
+        }
+
+        val singleTime = measureTimeMillis {
+            val executionResult = build.execute(ExecutionInput.newExecutionInput().context(context).query(
+                """
+            {
+                first: concurrent(from: 1, to: 10)
+            }
+            """.trimIndent()
+            ).build())
+
+            assertThat(executionResult.isDataPresent).isTrue()
+        }
+
+        assertThat(concurrentTime).isCloseTo(singleTime, Percentage.withPercentage(200.0))
+    }
+}


### PR DESCRIPTION
A datafetcher defined as a coroutine is async, without using CompletableFuture.
This does *not* change the way dataloaders work, because the dataloader API requires CompletableFuture.

Issue #413.

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

