### PR TITLE
graphiql to autoupdate url parameters

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/static/graphiql/index.html
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/static/graphiql/index.html
@@ -36,62 +36,103 @@
 ></script>
 
 <script>
-    // Parse the search string to get url parameters.
-    var search = window.location.search;
-    var parameters = {};
-    search.substr(1).split('&').forEach(function (entry) {
-      var eq = entry.indexOf('=');
-      if (eq >= 0) {
-        parameters[decodeURIComponent(entry.slice(0, eq))] =
-          decodeURIComponent(entry.slice(eq + 1));
+      // Parse the search string to get url parameters.
+      var search = window.location.search;
+      var parameters = {};
+      search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+          parameters[decodeURIComponent(entry.slice(0, eq))] =
+            decodeURIComponent(entry.slice(eq + 1));
+        }
+      });
+      // if variables was provided, try to format it.
+      if (parameters.variables) {
+        try {
+          parameters.variables =
+            JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+          // Do nothing, we want to display the invalid JSON as a string, rather
+          // than present an error.
+        }
       }
-    });
-    // if variables was provided, try to format it.
-    if (parameters.variables) {
-      try {
-        parameters.variables =
-          JSON.stringify(JSON.parse(parameters.variables), null, 2);
-      } catch (e) {
-        // Do nothing, we want to display the invalid JSON as a string, rather
-        // than present an error.
+      // When the query and variables string is edited, update the URL bar so
+      // that it can be easily shared
+      function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
       }
-    }
-    // When the query and variables string is edited, update the URL bar so
-    // that it can be easily shared
-    function onEditQuery(newQuery) {
-      parameters.query = newQuery;
-      updateURL();
-    }
-    function onEditVariables(newVariables) {
-      parameters.variables = newVariables;
-      updateURL();
-    }
-    function onEditOperationName(newOperationName) {
-      parameters.operationName = newOperationName;
-      updateURL();
-    }
-    function updateURL() {
-      var newSearch = '?' + Object.keys(parameters).filter(function (key) {
-        return Boolean(parameters[key]);
-      }).map(function (key) {
-        return encodeURIComponent(key) + '=' +
-          encodeURIComponent(parameters[key]);
-      }).join('&');
-        history.replaceState(null, null, newSearch);
-    }
 
-    const graphQLFetcher = (graphQLParams, headers) =>
-        fetch('<DGS_GRAPHQL_PATH>', {
-            method: 'post',
-            headers: headers.headers || {},
-            body: JSON.stringify(graphQLParams),
-        })
-            .then(response => response.json())
-            .catch(() => response.text());
-    ReactDOM.render(
-        React.createElement(GraphiQL, { fetcher: graphQLFetcher, headerEditorEnabled: true, shouldPersistHeaders: true, headers: JSON.stringify({"Content-Type": "application/json"})}),
-        document.getElementById('graphiql'),
-    );
+      function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+      }
+
+      function onEditHeaders(newHeaders) {
+        parameters.headers = newHeaders;
+        updateURL();
+      }
+
+      function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+      }
+
+      function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+          return Boolean(parameters[key]);
+        }).map(function (key) {
+          return encodeURIComponent(key) + '=' +
+            encodeURIComponent(parameters[key]);
+        }).join('&');
+        history.replaceState(null, null, newSearch);
+      }
+      function graphQLFetcher(graphQLParams) {
+        var headers = {
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+        };
+
+        if (parameters.headers) {
+          var extraHeaders = JSON.parse(parameters.headers);
+          for (var headerName in extraHeaders) {
+            if (extraHeaders.hasOwnProperty(headerName)) {
+              headers[headerName] = extraHeaders[headerName];
+            }
+          }
+        }
+        return fetch('<DGS_GRAPHQL_PATH>', {
+          method: 'post',
+          headers: headers,
+          body: JSON.stringify(graphQLParams),
+        }).then(function (response) {
+          return response.text();
+        }).then(function (responseBody) {
+          try {
+            return JSON.parse(responseBody);
+          } catch (error) {
+            return responseBody;
+          }
+        });
+      }
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: graphQLFetcher,
+          query: parameters.query,
+          variables: parameters.variables,
+          headers: parameters.headers,
+          operationName: parameters.operationName,
+          onEditQuery: onEditQuery,
+          onEditVariables: onEditVariables,
+          onEditHeaders: onEditHeaders,
+          onEditOperationName: onEditOperationName,
+          defaultSecondaryEditorOpen: true,
+          headerEditorEnabled: true,
+          shouldPersistHeaders: true,
+          docExplorerOpen: true,
+        }),
+        document.getElementById('graphiql')
+      );
 </script>
 </body>
 </html>

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/static/graphiql/index.html
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/static/graphiql/index.html
@@ -36,6 +36,50 @@
 ></script>
 
 <script>
+    // Parse the search string to get url parameters.
+    var search = window.location.search;
+    var parameters = {};
+    search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+      try {
+        parameters.variables =
+          JSON.stringify(JSON.parse(parameters.variables), null, 2);
+      } catch (e) {
+        // Do nothing, we want to display the invalid JSON as a string, rather
+        // than present an error.
+      }
+    }
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
+    function onEditOperationName(newOperationName) {
+      parameters.operationName = newOperationName;
+      updateURL();
+    }
+    function updateURL() {
+      var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+        return Boolean(parameters[key]);
+      }).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(parameters[key]);
+      }).join('&');
+        history.replaceState(null, null, newSearch);
+    }
+
     const graphQLFetcher = (graphQLParams, headers) =>
         fetch('<DGS_GRAPHQL_PATH>', {
             method: 'post',

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/static/graphiql/index.html
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/static/graphiql/index.html
@@ -36,62 +36,103 @@
 ></script>
 
 <script>
-    // Parse the search string to get url parameters.
-    var search = window.location.search;
-    var parameters = {};
-    search.substr(1).split('&').forEach(function (entry) {
-      var eq = entry.indexOf('=');
-      if (eq >= 0) {
-        parameters[decodeURIComponent(entry.slice(0, eq))] =
-          decodeURIComponent(entry.slice(eq + 1));
+      // Parse the search string to get url parameters.
+      var search = window.location.search;
+      var parameters = {};
+      search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+          parameters[decodeURIComponent(entry.slice(0, eq))] =
+            decodeURIComponent(entry.slice(eq + 1));
+        }
+      });
+      // if variables was provided, try to format it.
+      if (parameters.variables) {
+        try {
+          parameters.variables =
+            JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+          // Do nothing, we want to display the invalid JSON as a string, rather
+          // than present an error.
+        }
       }
-    });
-    // if variables was provided, try to format it.
-    if (parameters.variables) {
-      try {
-        parameters.variables =
-          JSON.stringify(JSON.parse(parameters.variables), null, 2);
-      } catch (e) {
-        // Do nothing, we want to display the invalid JSON as a string, rather
-        // than present an error.
+      // When the query and variables string is edited, update the URL bar so
+      // that it can be easily shared
+      function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
       }
-    }
-    // When the query and variables string is edited, update the URL bar so
-    // that it can be easily shared
-    function onEditQuery(newQuery) {
-      parameters.query = newQuery;
-      updateURL();
-    }
-    function onEditVariables(newVariables) {
-      parameters.variables = newVariables;
-      updateURL();
-    }
-    function onEditOperationName(newOperationName) {
-      parameters.operationName = newOperationName;
-      updateURL();
-    }
-    function updateURL() {
-      var newSearch = '?' + Object.keys(parameters).filter(function (key) {
-        return Boolean(parameters[key]);
-      }).map(function (key) {
-        return encodeURIComponent(key) + '=' +
-          encodeURIComponent(parameters[key]);
-      }).join('&');
-        history.replaceState(null, null, newSearch);
-    }
 
-    const graphQLFetcher = (graphQLParams, headers) =>
-        fetch('<DGS_GRAPHQL_PATH>', {
-            method: 'post',
-            headers: headers.headers || {},
-            body: JSON.stringify(graphQLParams),
-        })
-            .then(response => response.json())
-            .catch(() => response.text());
-    ReactDOM.render(
-        React.createElement(GraphiQL, { fetcher: graphQLFetcher, headerEditorEnabled: true, shouldPersistHeaders: true, headers: JSON.stringify({"Content-Type": "application/json"})}),
-        document.getElementById('graphiql'),
-    );
+      function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+      }
+
+      function onEditHeaders(newHeaders) {
+        parameters.headers = newHeaders;
+        updateURL();
+      }
+
+      function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+      }
+
+      function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+          return Boolean(parameters[key]);
+        }).map(function (key) {
+          return encodeURIComponent(key) + '=' +
+            encodeURIComponent(parameters[key]);
+        }).join('&');
+        history.replaceState(null, null, newSearch);
+      }
+      function graphQLFetcher(graphQLParams) {
+        var headers = {
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+        };
+
+        if (parameters.headers) {
+          var extraHeaders = JSON.parse(parameters.headers);
+          for (var headerName in extraHeaders) {
+            if (extraHeaders.hasOwnProperty(headerName)) {
+              headers[headerName] = extraHeaders[headerName];
+            }
+          }
+        }
+        return fetch('<DGS_GRAPHQL_PATH>', {
+          method: 'post',
+          headers: headers,
+          body: JSON.stringify(graphQLParams),
+        }).then(function (response) {
+          return response.text();
+        }).then(function (responseBody) {
+          try {
+            return JSON.parse(responseBody);
+          } catch (error) {
+            return responseBody;
+          }
+        });
+      }
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: graphQLFetcher,
+          query: parameters.query,
+          variables: parameters.variables,
+          headers: parameters.headers,
+          operationName: parameters.operationName,
+          onEditQuery: onEditQuery,
+          onEditVariables: onEditVariables,
+          onEditHeaders: onEditHeaders,
+          onEditOperationName: onEditOperationName,
+          defaultSecondaryEditorOpen: true,
+          headerEditorEnabled: true,
+          shouldPersistHeaders: true,
+          docExplorerOpen: true,
+        }),
+        document.getElementById('graphiql')
+      );
 </script>
 </body>
 </html>

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/static/graphiql/index.html
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/static/graphiql/index.html
@@ -36,6 +36,50 @@
 ></script>
 
 <script>
+    // Parse the search string to get url parameters.
+    var search = window.location.search;
+    var parameters = {};
+    search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
+    // if variables was provided, try to format it.
+    if (parameters.variables) {
+      try {
+        parameters.variables =
+          JSON.stringify(JSON.parse(parameters.variables), null, 2);
+      } catch (e) {
+        // Do nothing, we want to display the invalid JSON as a string, rather
+        // than present an error.
+      }
+    }
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
+    function onEditOperationName(newOperationName) {
+      parameters.operationName = newOperationName;
+      updateURL();
+    }
+    function updateURL() {
+      var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+        return Boolean(parameters[key]);
+      }).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(parameters[key]);
+      }).join('&');
+        history.replaceState(null, null, newSearch);
+    }
+
     const graphQLFetcher = (graphQLParams, headers) =>
         fetch('<DGS_GRAPHQL_PATH>', {
             method: 'post',


### PR DESCRIPTION
Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [X] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
https://github.com/Netflix/dgs-framework/discussions/475
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Updates graphiql/index.html include script to trace user query in url parameters.
This makes query bookmarkable and shareble.
_Describe the new behavior from this PR, and why it's needed_
Issue #
Updates script to include generic solution used in all graphiql libraries to track user query
Alternatives considered

* Allowing user to set custom spring property for customizing graphiql/index.html
----

_Describe alternative implementation you have considered_

