### PR TITLE
Support content type that includes an encoding

### DIFF
--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -87,7 +87,7 @@ open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
         if (body != null) {
             logger.debug("Reading input value: '{}'", body)
 
-            if (headers.getFirst("Content-Type")?.contains("application/graphql" ) == true) {
+            if (headers.getFirst("Content-Type")?.contains("application/graphql") == true) {
                 inputQuery = mapOf(Pair("query", body))
                 queryVariables = emptyMap()
                 extensions = emptyMap()

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -87,7 +87,7 @@ open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
         if (body != null) {
             logger.debug("Reading input value: '{}'", body)
 
-            if ("application/graphql" == headers.getFirst("Content-Type")) {
+            if (headers.getFirst("Content-Type")?.contains("application/graphql" ) == true) {
                 inputQuery = mapOf(Pair("query", body))
                 queryVariables = emptyMap()
                 extensions = emptyMap()


### PR DESCRIPTION
E.g. if you run a `mockWebMVC` test and set the content type, Spring will append the character encoding to it. This would fail the exact match check.

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):
