### PR TITLE
Fix assertSubscription helper method

### DIFF
--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -807,8 +807,9 @@ internal class DgsSchemaProviderTest {
             .create(data)
             .expectSubscription().assertNext { result ->
                 assertThat(result.getData<Map<String, String>>())
-                    .hasEntrySatisfying("message") { value -> assertThat(value).isEqualTo("hello") }
+                    .hasEntrySatisfying("messages") { value -> assertThat(value).isEqualTo("hello") }
             }
+            .verifyComplete()
     }
 
     private fun assertInputMessage(build: GraphQL) {


### PR DESCRIPTION
Verification was never being triggered on the StepVerifier instance, and
the assertion was looking for the wrong map key.