### PR TITLE
Avoid chaining collection operations

### DIFF
--- a/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
+++ b/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
@@ -38,15 +38,15 @@ public class GraphQLResponseJavaTest {
 
     RequestExecutor requestExecutor = (url, headers, body) -> {
         HttpHeaders httpHeaders = new HttpHeaders();
-        headers.forEach( (k,v) -> { httpHeaders.addAll(k, v); });
-        ResponseEntity<String> exchange = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity(body, httpHeaders),String.class);
+        headers.forEach(httpHeaders::addAll);
+        ResponseEntity<String> exchange = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(body, httpHeaders),String.class);
         return new HttpResponse(exchange.getStatusCodeValue(), exchange.getBody());
     };
 
     RequestExecutor requestExecutorWithResponseHeaders = (url, headers, body) -> {
         HttpHeaders httpHeaders = new HttpHeaders();
-        headers.forEach( (k,v) -> { httpHeaders.addAll(k, v); });
-        ResponseEntity<String> exchange = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity(body, httpHeaders),String.class);
+        headers.forEach(httpHeaders::addAll);
+        ResponseEntity<String> exchange = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(body, httpHeaders),String.class);
         return new HttpResponse(exchange.getStatusCodeValue(), exchange.getBody(), exchange.getHeaders());
     };
 

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/MessagesDataLoaderWithException.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/MessagesDataLoaderWithException.java
@@ -35,7 +35,7 @@ public class MessagesDataLoaderWithException implements BatchLoaderWithContext<S
         MyContext context = DgsContext.getCustomContext(environment);
         return CompletableFuture.supplyAsync(() -> keys.stream()
                 .map(key -> Try.tryCall(() -> {
-                    if (key == "A") {
+                    if (key.equals("A")) {
                         throw new RuntimeException("Invalid key");
                     }
                     return  context.getCustomState() + " " + key;

--- a/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/DefaultDgsReactiveQueryExecutorTest.kt
+++ b/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/DefaultDgsReactiveQueryExecutorTest.kt
@@ -175,7 +175,7 @@ internal class DefaultDgsReactiveQueryExecutorTest {
 
     @Test
     fun extractJsonWithObjectListAsMap() {
-        val movies = dgsQueryExecutor!!.executeAndExtractJsonPath<List<Map<String, Any>>>(
+        val movies = dgsQueryExecutor.executeAndExtractJsonPath<List<Map<String, Any>>>(
             """
             {
                 movies { title releaseDate }
@@ -193,7 +193,7 @@ internal class DefaultDgsReactiveQueryExecutorTest {
 
     @Test
     fun extractJsonAsObjectAsMap() {
-        val movie = dgsQueryExecutor!!.executeAndExtractJsonPath<Map<String, Any>>(
+        val movie = dgsQueryExecutor.executeAndExtractJsonPath<Map<String, Any>>(
             """
             {
                 movies { title releaseDate }
@@ -210,7 +210,7 @@ internal class DefaultDgsReactiveQueryExecutorTest {
 
     @Test
     fun extractJsonAsObject() {
-        val movie = dgsQueryExecutor!!.executeAndExtractJsonPathAsObject(
+        val movie = dgsQueryExecutor.executeAndExtractJsonPathAsObject(
             """
             {
                 movies { title releaseDate }
@@ -227,7 +227,7 @@ internal class DefaultDgsReactiveQueryExecutorTest {
 
     @Test
     fun extractJsonAsObjectWithTypeRef() {
-        val person = dgsQueryExecutor!!.executeAndExtractJsonPathAsObject(
+        val person = dgsQueryExecutor.executeAndExtractJsonPathAsObject(
             """
             {
                 movies { title releaseDate }

--- a/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/ReactiveReturnTypesTest.kt
+++ b/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/ReactiveReturnTypesTest.kt
@@ -179,7 +179,7 @@ internal class ReactiveReturnTypesTest {
 
     @Test
     fun extractJsonWithMonoOfObjects() {
-        val movies = dgsQueryExecutor!!.executeAndExtractJsonPath<List<Map<String, Any>>>(
+        val movies = dgsQueryExecutor.executeAndExtractJsonPath<List<Map<String, Any>>>(
             """
             {
                 movies { title releaseDate }

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -617,13 +617,13 @@ class MicrometerServletSmokeTest {
             logger.info("No meters found.")
             return
         }
-        val meterData = meters?.map { it.id }?.map { id: Meter.Id ->
+        val meterData = meters?.map { it.id }?.joinToString(",\n", "{\n", "\n}") { id: Meter.Id ->
             """
             |Name: ${id.name}
             |Tags:
             |   ${id.tags.joinToString(",\n\t", "\t") { tag: Tag? -> "[${tag?.key} : ${tag?.value}]" }}
             """.trimMargin()
-        }?.joinToString(",\n", "{\n", "\n}")
+        }
         logger.info("Meters:\n{}", meterData)
     }
 
@@ -739,7 +739,7 @@ class MicrometerServletSmokeTest {
             ) : MappedBatchLoader<String, String> {
                 override fun load(keys: Set<String>): CompletionStage<Map<String, String>> {
                     return CompletableFuture.supplyAsync(
-                        { keys.map { it to it.reversed() }.toMap() },
+                        { keys.associateWith { it.reversed() } },
                         dataLoaderTaskExecutor
                     )
                 }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DefaultExceptionHandlerTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DefaultExceptionHandlerTest.kt
@@ -39,6 +39,6 @@ class DefaultExceptionHandlerTest {
         }
         assertThat(error.errors.size).isEqualTo(1)
 
-        assertThat(error.errors[0].extensions.get("errorType")).isEqualTo("INTERNAL")
+        assertThat(error.errors[0].extensions["errorType"]).isEqualTo("INTERNAL")
     }
 }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/TestDataLoader.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/TestDataLoader.kt
@@ -45,8 +45,8 @@ class FetcherUsingDataLoader {
 
 @DgsDataLoader(name = "testMappedLoader")
 class TestMappedDataLoader : MappedBatchLoader<String, String> {
-    override fun load(keys: MutableSet<String>?): CompletionStage<MutableMap<String, String>> {
-        return CompletableFuture.supplyAsync { keys?.map { it to it.toUpperCase() }?.toMap()?.toMutableMap() }
+    override fun load(keys: MutableSet<String>): CompletionStage<MutableMap<String, String>> {
+        return CompletableFuture.supplyAsync { keys.associateWith { it.toUpperCase() }.toMutableMap() }
     }
 }
 

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebRequestTestWithCustomEndpoint.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebRequestTestWithCustomEndpoint.kt
@@ -40,7 +40,7 @@ class WebRequestTestWithCustomEndpoint {
 
     @Test
     fun `A simple request should execute correctly when no custom context builder is available`() {
-        val exchange = webTestClient.post().uri("/api").bodyValue(
+        webTestClient.post().uri("/api").bodyValue(
             """
             {"query": "{hello}"}
             """.trimIndent()

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsTest.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsTest.kt
@@ -58,10 +58,7 @@ import java.time.Duration
     classes = [HttpHandlerAutoConfiguration::class, ReactiveWebServerFactoryAutoConfiguration::class, WebFluxAutoConfiguration::class, DgsWebFluxAutoConfiguration::class, DgsAutoConfiguration::class, WebsocketSubscriptionsTest.ExampleSubscriptionImplementation::class],
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
-open class WebsocketSubscriptionsTest {
-
-    @LocalServerPort
-    lateinit var port: Integer
+open class WebsocketSubscriptionsTest(@param:LocalServerPort val port: Int) {
 
     @Test
     fun `Basic subscription flow`() {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLPathConfigWithCustomGraphQLPathAndServletContextTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLPathConfigWithCustomGraphQLPathAndServletContextTest.kt
@@ -61,7 +61,7 @@ class GraphiQLPathConfigWithCustomGraphQLPathAndServletContextTest(
         assertThat(graphqlResponse.statusCodeValue).isEqualTo(HttpStatus.NOT_FOUND.value())
 
         // graphql is available with context path in uri (400 expected as we don't sent proper request)
-        val absPathWithContextPath = rootUri + "/zuzu"
+        val absPathWithContextPath = "$rootUri/zuzu"
         graphqlResponse = restTemplate.getForEntity(
             absPathWithContextPath,
             String::class.java

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/WebRequestTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/WebRequestTest.kt
@@ -293,7 +293,7 @@ class WebRequestTest {
 
         @DgsData(parentType = "Query", field = "usingWebRequest")
         fun usingWebRequest(dfe: DgsDataFetchingEnvironment): String {
-            return ((DgsContext.getRequestData(dfe) as DgsWebMvcRequestData)?.webRequest as ServletWebRequest).request.serverName
+            return ((DgsContext.getRequestData(dfe) as DgsWebMvcRequestData).webRequest as ServletWebRequest).request.serverName
         }
 
         @DgsData(parentType = "Query", field = "usingHeader")
@@ -309,7 +309,7 @@ class WebRequestTest {
             @RequestHeader(required = true) myheader: String,
             dataFetchingEnvironment: DgsDataFetchingEnvironment
         ): String {
-            return myheader ?: "empty"
+            return myheader
         }
 
         @DgsData(parentType = "Query", field = "usingOptionalHeader")

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -99,14 +99,14 @@ open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
                         .body(ex.message ?: "Error parsing query - no details found in the error message")
                 }
 
-                queryVariables = if (inputQuery.get("variables") != null) {
+                queryVariables = if (inputQuery["variables"] != null) {
                     @Suppress("UNCHECKED_CAST")
                     inputQuery["variables"] as Map<String, String>
                 } else {
                     emptyMap()
                 }
 
-                extensions = if (inputQuery.get("extensions") != null) {
+                extensions = if (inputQuery["extensions"] != null) {
                     @Suppress("UNCHECKED_CAST")
                     inputQuery["extensions"] as Map<String, Any>
                 } else {
@@ -118,14 +118,14 @@ open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
         } else if (fileParams != null && mapParam != null && operation != null) {
             inputQuery = operation.let { mapper.readValue(it) }
 
-            queryVariables = if (inputQuery.get("variables") != null) {
+            queryVariables = if (inputQuery["variables"] != null) {
                 @Suppress("UNCHECKED_CAST")
                 inputQuery["variables"] as Map<String, Any>
             } else {
                 emptyMap()
             }
 
-            extensions = if (inputQuery.get("extensions") != null) {
+            extensions = if (inputQuery["extensions"] != null) {
                 @Suppress("UNCHECKED_CAST")
                 inputQuery["extensions"] as Map<String, Any>
             } else {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -70,8 +70,7 @@ open class DefaultDgsFederationResolver() :
     }
 
     private fun dgsEntityFetchers(env: DataFetchingEnvironment): CompletableFuture<DataFetcherResult<List<Any?>>> {
-
-        var errorsList = mutableListOf<GraphQLError>()
+        val errorsList = mutableListOf<GraphQLError>()
         val resultList = env.getArgument<List<Map<String, Any>>>(_Entity.argumentName)
             .map { values ->
                 try {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -213,7 +213,7 @@ object BaseDgsQueryExecutor {
         }
         val graphQL = graphQLBuilder.build()
 
-        val dataLoaderRegistry = dataLoaderProvider.buildRegistryWithContextSupplier({ dgsContext })
+        val dataLoaderRegistry = dataLoaderProvider.buildRegistryWithContextSupplier { dgsContext }
         val executionInput: ExecutionInput = ExecutionInput.newExecutionInput()
             .query(query)
             .dataLoaderRegistry(dataLoaderRegistry)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/scalars/UploadScalar.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/scalars/UploadScalar.kt
@@ -35,7 +35,7 @@ class UploadScalar {
         }
 
         @Throws(CoercingParseValueException::class)
-        override fun parseValue(input: Any): MultipartFile? {
+        override fun parseValue(input: Any): MultipartFile {
             return if (input is MultipartFile) {
                 input
             } else run {


### PR DESCRIPTION
Avoid chaining collection operations in some places where intermediate
collections would be allocated and thrown away. Also, switch to Kotlin
idioms, remove unnecessary null assertions, etc.