### PR TITLE
Avoid instantiating Jackson mappers per request

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsReactiveWebsocketHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsReactiveWebsocketHandler.kt
@@ -17,7 +17,7 @@
 package com.netflix.graphql.dgs.webflux.handlers
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscription
@@ -41,7 +41,7 @@ class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReact
     private val resolvableType = ResolvableType.forType(OperationMessage::class.java)
     private val subscriptions = ConcurrentHashMap<String, MutableMap<String, Subscription>>()
     private val decoder = Jackson2JsonDecoder()
-    private val encoder = Jackson2JsonEncoder()
+    private val encoder = Jackson2JsonEncoder(decoder.objectMapper)
 
     companion object {
         const val GQL_CONNECTION_INIT = "connection_init"
@@ -74,9 +74,10 @@ class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReact
                             )
                         )
                         GQL_START -> {
-                            val queryPayload =
-                                jacksonObjectMapper().convertValue(operationMessage.payload, QueryPayload::class.java)
-                            logger.debug("Starting subscription $queryPayload for session ${webSocketSession.id}")
+                            val queryPayload = decoder.objectMapper.convertValue<QueryPayload>(
+                                operationMessage.payload ?: error("payload == null")
+                            )
+                            logger.debug("Starting subscription {} for session {}", queryPayload, webSocketSession.id)
                             dgsReactiveQueryExecutor.execute(queryPayload.query, queryPayload.variables)
                                 .flatMapMany { executionResult ->
                                     val publisher: Publisher<Any> = executionResult.getData()
@@ -100,7 +101,10 @@ class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReact
                                         ).subscribe()
 
                                         subscriptions[webSocketSession.id]?.remove(operationMessage.id)
-                                        logger.debug("Completing subscription ${operationMessage.id} for subscription ${operationMessage.id} for connection ${webSocketSession.id}")
+                                        logger.debug(
+                                            "Completing subscription {} for connection {}",
+                                            operationMessage.id, webSocketSession.id
+                                        )
                                     }.doOnError {
                                         webSocketSession.send(
                                             Flux.just(
@@ -112,15 +116,20 @@ class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReact
                                         ).subscribe()
 
                                         subscriptions[webSocketSession.id]?.remove(operationMessage.id)
-                                        logger.debug("Subscription publisher error for input $queryPayload for subscription ${operationMessage.id} for connection ${webSocketSession.id}", it)
+                                        logger.debug(
+                                            "Subscription publisher error for input {} for subscription {} for connection {}",
+                                            queryPayload, operationMessage.id, webSocketSession.id, it
+                                        )
                                     }
                                 }
                         }
 
                         GQL_STOP -> {
-                            subscriptions[webSocketSession.id]?.get(operationMessage.id)?.cancel()
-                            subscriptions[webSocketSession.id]?.remove(operationMessage.id)
-                            logger.debug("Client stopped subscription ${operationMessage.id} for connection ${webSocketSession.id}")
+                            subscriptions[webSocketSession.id]?.remove(operationMessage.id)?.cancel()
+                            logger.debug(
+                                "Client stopped subscription {} for connection {}",
+                                operationMessage.id, webSocketSession.id
+                            )
                             Flux.empty()
                         }
 
@@ -128,7 +137,7 @@ class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReact
                             subscriptions[webSocketSession.id]?.values?.forEach { it.cancel() }
                             subscriptions.remove(webSocketSession.id)
                             webSocketSession.close()
-                            logger.debug("Connection ${webSocketSession.id} terminated")
+                            logger.debug("Connection {} terminated", webSocketSession.id)
                             Flux.empty()
                         }
 

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -63,6 +63,7 @@ import org.springframework.web.multipart.MultipartFile
 open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
 
     open val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
+    private val mapper = jacksonObjectMapper()
 
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
     @RequestMapping(
@@ -80,7 +81,6 @@ open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
 
         logger.debug("Starting /graphql handling")
 
-        val mapper = jacksonObjectMapper()
         val inputQuery: Map<String, Any>
         val queryVariables: Map<String, Any>
         val extensions: Map<String, Any>

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
@@ -35,11 +35,11 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 open class DgsRestSchemaJsonController(open val schemaProvider: DgsSchemaProvider) {
 
+    private val mapper = jacksonObjectMapper()
+
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
     @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.schemaJson.path}", produces = ["application/json"])
     fun schema(): String {
-        val mapper = jacksonObjectMapper()
-
         val graphQLSchema: GraphQLSchema = schemaProvider.schema()
         val graphQL = GraphQL.newGraphQL(graphQLSchema).build()
 


### PR DESCRIPTION
An ObjectMapper was being instantiated per request, which can be
expensive.