### PR TITLE
fix: DgsReactiveWebsocketHandler should override getSubProtocols

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsReactiveWebsocketHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsReactiveWebsocketHandler.kt
@@ -54,6 +54,8 @@ class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReact
         const val GQL_CONNECTION_TERMINATE = "connection_terminate"
     }
 
+    override fun getSubProtocols(): List<String> = listOf("graphql-ws")
+
     override fun handle(webSocketSession: WebSocketSession): Mono<Void> {
         return webSocketSession.send(
             webSocketSession.receive()


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

`WebSocketHandler` should return the list of sub-protocols supported by the handler.
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/reactive/socket/WebSocketHandler.html#getSubProtocols--
```java

	/**
	 * Return the list of sub-protocols supported by this handler.
	 * <p>By default an empty list is returned.
	 */
	default List<String> getSubProtocols() {
		return Collections.emptyList();
	}
```

`graphql-dgs-subscriptions-websockets-autoconfigure` configures supported protocols for `graphql-ws`.

https://github.com/Netflix/dgs-framework/blob/b48f8323c37f86659dda3e97e1071007aec9488f/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketAutoConfig.kt#L43

But `DgsReactiveWebsocketHandler` does not override `getSubProtocols()`, websocket subscriptions is not working properly.





_Describe the new behavior from this PR, and why it's needed_
Issue #401




