### PR TITLE
Call the ListableBeanFactory only once when fetching the MeterRegistry

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMicrometerAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMicrometerAutoConfiguration.kt
@@ -167,8 +167,12 @@ open class DgsGraphQLMicrometerAutoConfiguration {
             private val DEFAULT_METER_REGISTRY = SimpleMeterRegistry()
         }
 
+        private val registry: MeterRegistry by lazy {
+            meterRegistryProvider.ifAvailable ?: DEFAULT_METER_REGISTRY
+        }
+
         override fun get(): MeterRegistry {
-            return meterRegistryProvider.ifAvailable ?: DEFAULT_METER_REGISTRY
+            return registry
         }
     }
 }


### PR DESCRIPTION
As is the code will call the _BeanFactory_ every time the MeterRegistrySupplier attempts to resolve the MeterRegistry.
With this change we will call it once just once. This will remove the _BeanFactory_ call out of the _hot path_ of a request.