### PR TITLE
Avoid unnecessarily calculating the stacktrace when callint ExecutionStrategyInstrumentationContext

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -42,6 +42,14 @@ class DgsGraphQLMetricsInstrumentation(
 
     companion object {
         private val log: Logger = LoggerFactory.getLogger(DgsGraphQLMetricsInstrumentation::class.java)
+
+        private object DefaultExecutionStrategyInstrumentationContext : ExecutionStrategyInstrumentationContext {
+            override fun onDispatched(result: CompletableFuture<ExecutionResult>) {
+            }
+
+            override fun onCompleted(result: ExecutionResult, t: Throwable?) {
+            }
+        }
     }
 
     override fun createState(): InstrumentationState {
@@ -166,18 +174,12 @@ class DgsGraphQLMetricsInstrumentation(
     ): ExecutionStrategyInstrumentationContext {
         val state: MetricsInstrumentationState = parameters.getInstrumentationState()
         if (parameters.executionContext.getRoot<Any>() == null) {
-            state.operation = of(parameters.executionContext.operationDefinition.operation.name.toUpperCase())
+            state.operation = of(parameters.executionContext.operationDefinition.operation.name.uppercase())
             if (!state.operationName.isPresent) {
                 state.operationName = ofNullable(parameters.executionContext.operationDefinition?.name)
             }
         }
-        return object : ExecutionStrategyInstrumentationContext {
-            override fun onDispatched(result: CompletableFuture<ExecutionResult>) {
-            }
-
-            override fun onCompleted(result: ExecutionResult, t: Throwable) {
-            }
-        }
+        return DefaultExecutionStrategyInstrumentationContext
     }
 
     private fun recordDataFetcherMetrics(


### PR DESCRIPTION
Since DGS is complied via Kotlin, the bytecode will include a non-null
check on arguments which type is _none nullable_. In the case of `ExecutionStrategyInstrumentationContext`
this meant that on every call of any _resolver_ there will be a check of
nullability on the _throwable_. Although the exception was ignored it
incurred a heavy cost since calculating the exception includes
calculating the stack trace.