### PR TITLE
Prevent calculating the stacktrace when calling ExecutionStrategyInstrumentationContext (rare case)

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -47,7 +47,7 @@ class DgsGraphQLMetricsInstrumentation(
             override fun onDispatched(result: CompletableFuture<ExecutionResult>) {
             }
 
-            override fun onCompleted(result: ExecutionResult, t: Throwable?) {
+            override fun onCompleted(result: ExecutionResult?, t: Throwable?) {
             }
         }
     }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This is a followup on #562. 

We are describing the `result: ExecutionResult` parameter as nullable.
This will prevent an unnecessary _null check_ on the `result` parameter in case the value is `null`.
If we don't do this the `NullPointerException` will go unnoticed but will increase the latency in the request since a stacktrace 
will be computed. Arguably this will be a rare case so the latency impact will not be as drastic as the change that #562 addresses.
