### PR TITLE
Fix Nebula Dependency Locks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     `java-library`
     id("nebula.netflixoss") version "10.1.0"
     id("nebula.dependency-recommender") version "10.0.1"
+    id("nebula.dependency-lock") version "11.3.2"
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
     kotlin("jvm") version Versions.KOTLIN_VERSION
     kotlin("kapt") version Versions.KOTLIN_VERSION
@@ -43,6 +44,7 @@ allprojects {
 
     apply(plugin = "nebula.netflixoss")
     apply(plugin = "nebula.dependency-recommender")
+    apply(plugin = "nebula.dependency-lock")
 
     dependencyRecommendations {
         mavenBom(mapOf("module" to "org.springframework:spring-framework-bom:${Versions.SPRING_VERSION}"))

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -116,7 +116,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.133.0"
+            "locked": "0.134.0"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -432,7 +432,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.133.0"
+            "locked": "0.134.0"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -623,7 +623,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.133.0"
+            "locked": "0.134.0"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -803,7 +803,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "0.133.0"
+            "locked": "0.134.0"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -26,6 +26,9 @@
         }
     },
     "compileClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
         },


### PR DESCRIPTION
This commit addresses a failure observed when attempting to generate the dependency locks.
The failure appears to be an inability to infer dependency versions from
a Maven BOM via Nebula. The current fix is to have an explicit reference to the
latest `nebula.dependency-lock` plugin.