### PR TITLE
Support for proding a bean of type PreparsedDocumentProvider

### DIFF
--- a/graphql-dgs-example-java/build.gradle.kts
+++ b/graphql-dgs-example-java/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2021 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,4 +28,6 @@ dependencies {
     // Adding the DGS Micrometer integration that provides timers for gql.*
     // For additional information go to the link below:
     // https://netflix.github.io/dgs/advanced/instrumentation/
+
+    implementation("com.github.ben-manes.caffeine:caffeine:2.9.2")
 }

--- a/graphql-dgs-example-java/build.gradle.kts
+++ b/graphql-dgs-example-java/build.gradle.kts
@@ -29,5 +29,5 @@ dependencies {
     // For additional information go to the link below:
     // https://netflix.github.io/dgs/advanced/instrumentation/
 
-    implementation("com.github.ben-manes.caffeine:caffeine:2.9.2")
+    implementation("com.github.ben-manes.caffeine:caffeine")
 }

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -36,7 +36,7 @@
             "locked": "2.12.3"
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.2"
+            "locked": "2.8.8"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -404,7 +404,7 @@
             "locked": "2.12.3"
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.2"
+            "locked": "2.8.8"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
@@ -687,7 +687,7 @@
             "locked": "2.12.3"
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.2"
+            "locked": "2.8.8"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -869,7 +869,7 @@
             "locked": "2.12.3"
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.2"
+            "locked": "2.8.8"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -35,6 +35,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.9.2"
+        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -400,6 +403,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.9.2"
+        },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -680,6 +686,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.9.2"
+        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -858,6 +867,9 @@
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.9.2"
         },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/ExampleApp.java
+++ b/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/ExampleApp.java
@@ -16,12 +16,38 @@
 
 package com.netflix.graphql.dgs.example;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import graphql.execution.preparsed.PreparsedDocumentEntry;
+import graphql.execution.preparsed.PreparsedDocumentProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 @SpringBootApplication(scanBasePackages = {"com.netflix.graphql.dgs.example.shared", "com.netflix.graphql.dgs.example"})
 public class ExampleApp {
     public static void main(String[] args) {
         SpringApplication.run(ExampleApp.class, args);
     }
+
+    @Configuration
+    static class PreparsedDocumentProviderConfig {
+
+        private final Cache<String, PreparsedDocumentEntry> cache = Caffeine.newBuilder().maximumSize(250)
+                .expireAfterAccess(5,TimeUnit.MINUTES).recordStats().build();
+
+
+        @Bean
+        public PreparsedDocumentProvider preparsedDocumentProvider() {
+            return (executionInput, parseAndValidateFunction) -> {
+                Function<String, PreparsedDocumentEntry> mapCompute = key -> parseAndValidateFunction.apply(executionInput);
+                return cache.get(executionInput.getQuery(), mapCompute);
+            };
+        }
+    }
 }
+

--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
@@ -22,12 +22,17 @@ import com.jayway.jsonpath.TypeRef
 import com.jayway.jsonpath.spi.mapper.MappingException
 import com.netflix.graphql.dgs.exceptions.DgsQueryExecutionDataExtractionException
 import com.netflix.graphql.dgs.exceptions.QueryException
-import com.netflix.graphql.dgs.internal.*
+import com.netflix.graphql.dgs.internal.BaseDgsQueryExecutor
+import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
+import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import graphql.ExecutionResult
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.NonNullableFieldWasNullError
 import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
+import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -46,7 +51,8 @@ class DefaultDgsReactiveQueryExecutor(
     private val queryExecutionStrategy: ExecutionStrategy,
     private val mutationExecutionStrategy: ExecutionStrategy,
     private val idProvider: Optional<ExecutionIdProvider>,
-    private val reloadIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator = DefaultDgsQueryExecutor.ReloadSchemaIndicator { false }
+    private val reloadIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator = DefaultDgsQueryExecutor.ReloadSchemaIndicator { false },
+    private val preparsedDocumentProvider: PreparsedDocumentProvider = NoOpPreparsedDocumentProvider()
 ) : com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor {
     private val logger: Logger = LoggerFactory.getLogger(DefaultDgsQueryExecutor::class.java)
 
@@ -78,7 +84,8 @@ class DefaultDgsReactiveQueryExecutor(
                         chainedInstrumentation,
                         queryExecutionStrategy,
                         mutationExecutionStrategy,
-                        idProvider
+                        idProvider,
+                        preparsedDocumentProvider
                     )
                 ).doOnEach { result ->
                     if (result.hasValue()) {

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -28,6 +28,8 @@ import com.netflix.graphql.mocking.MockProvider
 import graphql.execution.*
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
+import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
+import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLSchema
 import graphql.schema.idl.TypeDefinitionRegistry
@@ -75,7 +77,8 @@ open class DgsAutoConfiguration(
         @Qualifier("query") providedQueryExecutionStrategy: Optional<ExecutionStrategy>,
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
-        reloadSchemaIndicator: ReloadSchemaIndicator
+        reloadSchemaIndicator: ReloadSchemaIndicator,
+        preparsedDocumentProvider: PreparsedDocumentProvider
     ): DgsQueryExecutor {
         val queryExecutionStrategy = providedQueryExecutionStrategy.orElse(AsyncExecutionStrategy(dataFetcherExceptionHandler))
         val mutationExecutionStrategy = providedMutationExecutionStrategy.orElse(AsyncSerialExecutionStrategy(dataFetcherExceptionHandler))
@@ -88,8 +91,15 @@ open class DgsAutoConfiguration(
             queryExecutionStrategy,
             mutationExecutionStrategy,
             idProvider,
-            reloadSchemaIndicator
+            reloadSchemaIndicator,
+            preparsedDocumentProvider
         )
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    open fun preparsedDocumentProvider(): PreparsedDocumentProvider {
+        return NoOpPreparsedDocumentProvider()
     }
 
     @Bean


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Finally, some support for `PreparsedDocumentProvider` as was requested a long time ago in issue #50.
With this PR you can provide a bean of type `PreparsedDocumentProvider` which will be used by the `DgsQueryExecutor`.
The developer is in control of how the cache is set up and configured.

An example based on Caffeine is added to the java example embedded in the repo.
