### PR TITLE
Convert fix

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
@@ -200,6 +200,8 @@ class DataFetcherInvoker(
                     ex
                 )
             }
+        } else if (parameterValue is Map<*, *> && parameter.type.isAssignableFrom(Map::class.java)) {
+            parameterValue
         } else {
             // Return the converted value mapped to the defined type
             convertValue(parameterValue, parameter, collectionType)


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
In some cases, an `@InputArgument` is of type `Map<String, Object>`. An example is using the `Object` or `JSON` scalar type from the extended scalars library.
Our code was assuming that a Map _always_ needs to be converted to a target object.

This fix makes sure that if both the `@InputArgument` value and target type are `Map`, the value is used as is, without further conversion.