### PR TITLE
Added support for input arguments of type Any/Object. 

### DIFF
--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/inputobjects/JFilter.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/inputobjects/JFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.inputobjects;
+
+public class JFilter {
+    private Object query;
+
+    public Object getQuery() {
+        return query;
+    }
+
+    public void setQuery(Object query) {
+        this.query = query;
+    }
+}


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
In some cases, an input type might have a field of type Object/Any. This happens when for example using the Object/Json scalars. The target isn't actually Object/Any, but should be Map<String, Any>.