### PR TITLE
Add framework specific DgsNoOpPreparsedDocumentProvider

### DIFF
--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
@@ -22,7 +22,11 @@ import com.jayway.jsonpath.TypeRef
 import com.jayway.jsonpath.spi.mapper.MappingException
 import com.netflix.graphql.dgs.exceptions.DgsQueryExecutionDataExtractionException
 import com.netflix.graphql.dgs.exceptions.QueryException
-import com.netflix.graphql.dgs.internal.*
+import com.netflix.graphql.dgs.internal.BaseDgsQueryExecutor
+import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
+import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
+import com.netflix.graphql.dgs.internal.DgsNoOpPreparsedDocumentProvider
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import graphql.ExecutionResult
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy

--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
@@ -22,16 +22,12 @@ import com.jayway.jsonpath.TypeRef
 import com.jayway.jsonpath.spi.mapper.MappingException
 import com.netflix.graphql.dgs.exceptions.DgsQueryExecutionDataExtractionException
 import com.netflix.graphql.dgs.exceptions.QueryException
-import com.netflix.graphql.dgs.internal.BaseDgsQueryExecutor
-import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
-import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
-import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.*
 import graphql.ExecutionResult
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.NonNullableFieldWasNullError
 import graphql.execution.instrumentation.ChainedInstrumentation
-import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
 import org.slf4j.Logger
@@ -52,7 +48,7 @@ class DefaultDgsReactiveQueryExecutor(
     private val mutationExecutionStrategy: ExecutionStrategy,
     private val idProvider: Optional<ExecutionIdProvider>,
     private val reloadIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator = DefaultDgsQueryExecutor.ReloadSchemaIndicator { false },
-    private val preparsedDocumentProvider: PreparsedDocumentProvider = NoOpPreparsedDocumentProvider()
+    private val preparsedDocumentProvider: PreparsedDocumentProvider = DgsNoOpPreparsedDocumentProvider
 ) : com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor {
     private val logger: Logger = LoggerFactory.getLogger(DefaultDgsQueryExecutor::class.java)
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -28,7 +28,6 @@ import com.netflix.graphql.mocking.MockProvider
 import graphql.execution.*
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
-import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLSchema
@@ -99,7 +98,7 @@ open class DgsAutoConfiguration(
     @Bean
     @ConditionalOnMissingBean
     open fun preparsedDocumentProvider(): PreparsedDocumentProvider {
-        return NoOpPreparsedDocumentProvider()
+        return DgsNoOpPreparsedDocumentProvider
     }
 
     @Bean

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -35,7 +35,6 @@ import graphql.execution.ExecutionStrategy
 import graphql.execution.NonNullableFieldWasNullError
 import graphql.execution.SubscriptionExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
-import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
 import org.slf4j.Logger
@@ -59,7 +58,7 @@ class DefaultDgsQueryExecutor(
     private val mutationExecutionStrategy: ExecutionStrategy,
     private val idProvider: Optional<ExecutionIdProvider>,
     private val reloadIndicator: ReloadSchemaIndicator = ReloadSchemaIndicator { false },
-    private val preparsedDocumentProvider: PreparsedDocumentProvider = NoOpPreparsedDocumentProvider(),
+    private val preparsedDocumentProvider: PreparsedDocumentProvider = DgsNoOpPreparsedDocumentProvider,
 ) : DgsQueryExecutor {
 
     val logger: Logger = LoggerFactory.getLogger(DefaultDgsQueryExecutor::class.java)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsNoOpPreparsedDocumentProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsNoOpPreparsedDocumentProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import graphql.ExecutionInput
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.execution.preparsed.PreparsedDocumentProvider
+import java.util.function.Function
+
+object DgsNoOpPreparsedDocumentProvider : PreparsedDocumentProvider {
+
+    override fun getDocument(
+        executionInput: ExecutionInput,
+        parseAndValidateFunction: Function<ExecutionInput, PreparsedDocumentEntry>
+    ): PreparsedDocumentEntry {
+        return parseAndValidateFunction.apply(executionInput)
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DgsNoOpPreparsedDocumentProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DgsNoOpPreparsedDocumentProviderTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import graphql.ExecutionInput
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.language.Document
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class DgsNoOpPreparsedDocumentProviderTest {
+
+    @Test
+    fun `DgsNoOpPreparsedDocumentProvider returns result of parseAndValidateFunction`() {
+        val provider = DgsNoOpPreparsedDocumentProvider
+        val documentEntry = PreparsedDocumentEntry(Document.newDocument().build())
+
+        val computed = provider
+            .getDocument(ExecutionInput.newExecutionInput("{}").build()) { documentEntry }
+
+        Assertions.assertEquals(computed, documentEntry)
+    }
+}


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Replaces the graphql-java [`NoOpPreparsedDocumentProvider`](https://github.com/graphql-java/graphql-java/blob/d783ec7ee30369ca2fdecdfd0b74e8bf6d96baa8/src/main/java/graphql/execution/preparsed/NoOpPreparsedDocumentProvider.java) with a Kotlin `object DgsNoOpPreparsedDocumentProvider` because the graphql-java one is annotated with [@Internal](https://github.com/graphql-java/graphql-java/blob/8530366f24ba316075a63402473cb2a38ca36ab3/src/main/java/graphql/Internal.java):

> ```java
> /**
>  * This represents code that the graphql-java project considers internal code that MAY not be stable within
>  * major releases.
>  *
>  * In general unnecessary changes will be avoided but you should not depend on internal classes being stable
>  */
> ```

Test adopted from https://github.com/graphql-java/graphql-java/blob/8530366f24ba316075a63402473cb2a38ca36ab3/src/test/groovy/graphql/execution/preparsed/NoOpPreparsedDocumentProviderTest.groovy

Alternatives considered
----

N/A

