### PR TITLE
Fix serialization of List of Enums as Input Arguments

### DIFF
--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/enums/JGreetingType.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/enums/JGreetingType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.java.test.enums;
+
+public enum JGreetingType {
+    FRIENDLY,
+    POLITE
+}

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/enums/JInputMessage.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/enums/JInputMessage.java
@@ -14,16 +14,27 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.internal.testenums;
+package com.netflix.graphql.dgs.internal.java.test.enums;
 
-public class InputMessage {
-    private GreetingType type;
+import java.util.List;
 
-    public GreetingType getType() {
+public class JInputMessage {
+    private JGreetingType type;
+    private List<JGreetingType> typeList;
+
+    public JGreetingType getType() {
         return type;
     }
 
-    public void setType(GreetingType type) {
+    public void setType(JGreetingType type) {
         this.type = type;
+    }
+
+    public List<JGreetingType> getTypeList() {
+        return typeList;
+    }
+
+    public void setTypeList(List<JGreetingType> typeList) {
+        this.typeList = typeList;
     }
 }

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JBarInput.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JBarInput.java
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.inputobjects;
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
 
-import com.netflix.graphql.dgs.internal.InputObjectMapperTest;
-
-public class InputObjectWithKotlinProperty {
+public class JBarInput {
     private String name;
-    private InputObjectMapperTest.KotlinInputObject objectProperty;
+    private Object value;
 
     public String getName() {
         return name;
@@ -30,11 +28,11 @@ public class InputObjectWithKotlinProperty {
         this.name = name;
     }
 
-    public InputObjectMapperTest.KotlinInputObject getObjectProperty() {
-        return objectProperty;
+    public Object getValue() {
+        return value;
     }
 
-    public void setObjectProperty(InputObjectMapperTest.KotlinInputObject objectProperty) {
-        this.objectProperty = objectProperty;
+    public void setValue(Object value) {
+        this.value = value;
     }
 }

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JFilter.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JFilter.java
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.internal.testenums;
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
 
-public enum GreetingType {
-    FRIENDLY,
-    POLITE
+public class JFilter {
+    private Object query;
+
+    public Object getQuery() {
+        return query;
+    }
+
+    public void setQuery(Object query) {
+        this.query = query;
+    }
 }

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JFooInput.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JFooInput.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.inputobjects;
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
 
 import java.util.List;
 

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JInputObject.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JInputObject.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.inputobjects;
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
 
 import java.time.LocalDateTime;
 
-public class InputObject {
+public class JInputObject {
+
     private String simpleString;
     private LocalDateTime someDate;
     private SomeObject someObject;

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JInputObjectWithKotlinProperty.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JInputObjectWithKotlinProperty.java
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.inputobjects;
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
 
-public class JBarInput {
+import com.netflix.graphql.dgs.internal.InputObjectMapperTest;
+
+public class JInputObjectWithKotlinProperty {
     private String name;
-    private Object value;
+    private InputObjectMapperTest.KotlinInputObject objectProperty;
 
     public String getName() {
         return name;
@@ -28,11 +30,11 @@ public class JBarInput {
         this.name = name;
     }
 
-    public Object getValue() {
-        return value;
+    public InputObjectMapperTest.KotlinInputObject getObjectProperty() {
+        return objectProperty;
     }
 
-    public void setValue(Object value) {
-        this.value = value;
+    public void setObjectProperty(InputObjectMapperTest.KotlinInputObject objectProperty) {
+        this.objectProperty = objectProperty;
     }
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -19,10 +19,11 @@ package com.netflix.graphql.dgs.internal
 import com.netflix.graphql.dgs.*
 import com.netflix.graphql.dgs.context.DgsContext
 import com.netflix.graphql.dgs.exceptions.DgsInvalidInputArgumentException
-import com.netflix.graphql.dgs.inputobjects.JFilter
-import com.netflix.graphql.dgs.inputobjects.JFooInput
-import com.netflix.graphql.dgs.internal.testenums.GreetingType
-import com.netflix.graphql.dgs.internal.testenums.InputMessage
+import com.netflix.graphql.dgs.internal.java.test.enums.JGreetingType
+import com.netflix.graphql.dgs.internal.java.test.enums.JInputMessage
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.JFilter
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.JFooInput
+import com.netflix.graphql.dgs.internal.kotlin.test.*
 import com.netflix.graphql.dgs.scalars.UploadScalar
 import graphql.ExceptionWhileDataFetching
 import graphql.ExecutionInput
@@ -299,8 +300,6 @@ internal class InputArgumentTest {
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
-    data class MovieFilter(val movieIds: List<Any>)
-
     @Test
     fun `List of scalar in a nested input type`() {
         val schema = """
@@ -317,7 +316,7 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "titles")
-            fun someFetcher(@InputArgument("filter") filter: MovieFilter): String {
+            fun someFetcher(@InputArgument("filter") filter: KMovieFilter): String {
                 return filter.movieIds.joinToString { "Title for $it" }
             }
 
@@ -347,9 +346,6 @@ internal class InputArgumentTest {
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
-    data class FooInput(val bars: List<BarInput>)
-    data class BarInput(val name: String, val value: Any)
-
     @Test
     fun `Use scalar property inside a List of complex input type`() {
         val schema = """
@@ -371,7 +367,7 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "titles")
-            fun someFetcher(@InputArgument input: FooInput): String {
+            fun someFetcher(@InputArgument input: KFooInput): String {
                 return input.bars.joinToString { "${it.name}: ${it.value}" }
             }
 
@@ -817,13 +813,8 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf(Pair("DateTime", LocalDateTimeScalar()))
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf("DateTime" to LocalDateTimeScalar())
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
         val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
@@ -856,13 +847,8 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf(Pair("DateTime", LocalDateTimeScalar()))
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf("DateTime" to LocalDateTimeScalar())
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
         val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
@@ -891,13 +877,8 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf(Pair("DateTime", LocalDateTimeScalar()))
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf("DateTime" to LocalDateTimeScalar())
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
         val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
 
@@ -929,13 +910,8 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
-        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf(Pair("DateTime", LocalDateTimeScalar()))
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns mapOf("DateTime" to LocalDateTimeScalar())
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
         val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
@@ -964,12 +940,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1038,10 +1009,7 @@ internal class InputArgumentTest {
         val build = GraphQL.newGraphQL(schema).build()
         val httpHeaders = HttpHeaders()
         httpHeaders.add("Referer", "localhost")
-        val executionResult = build.execute(
-            ExecutionInput.newExecutionInput("""{hello}""")
-                .context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders)))
-        )
+        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
         Assertions.assertEquals("From, localhost", data["hello"])
@@ -1264,6 +1232,7 @@ internal class InputArgumentTest {
 
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
+
     @Test
     fun `An @InputArgument of type Optional should fail when no type is specified`() {
         val schema = """
@@ -1296,8 +1265,9 @@ internal class InputArgumentTest {
 
         val build = GraphQL.newGraphQL(provider.schema(schema)).build()
         val executionResult = build.execute("""{hello(person: {name: "tester"})}""")
-        Assertions.assertEquals(1, executionResult.errors.size)
-        Assertions.assertEquals("Exception while fetching data (/hello) : When Optional<T> is used, the type must be specified using the collectionType argument of the @InputArgument annotation.", executionResult.errors[0].message)
+        assertThat(executionResult.errors).hasSize(1)
+        assertThat(executionResult.errors[0].message)
+            .isEqualTo("Exception while fetching data (/hello) : When Optional<T> is used, the type must be specified using the collectionType argument of the @InputArgument annotation.")
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
@@ -1332,11 +1302,6 @@ internal class InputArgumentTest {
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
-    enum class GreetingType {
-        FRIENDLY,
-        POLITE
-    }
-
     @Test
     fun `Kotlin enum @InputArgument`() {
         val schema = """
@@ -1352,7 +1317,7 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(@InputArgument type: GreetingType): String {
+            fun someFetcher(@InputArgument type: KGreetingType): String {
                 return "Hello, this is a $type greeting"
             }
         }
@@ -1391,7 +1356,7 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(@InputArgument type: GreetingType?): String {
+            fun someFetcher(@InputArgument type: KGreetingType?): String {
                 return "Hello, this is a ${type ?: "SAD"} greeting"
             }
         }
@@ -1430,7 +1395,7 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(@InputArgument type: com.netflix.graphql.dgs.internal.testenums.GreetingType): String {
+            fun someFetcher(@InputArgument type: JGreetingType): String {
                 return "Hello, this is a $type greeting"
             }
         }
@@ -1454,17 +1419,16 @@ internal class InputArgumentTest {
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
-    data class InputMessage(val type: GreetingType?)
-
     @Test
-    fun `Nested enum @InputArgument`() {
+    fun `Nested Kotlin enum @InputArgument`() {
         val schema = """
             type Query {
-                hello(someInput:InputMessage): String
+                hello(input:InputMessage): String
             }
 
             input InputMessage {
                 type: GreetingType
+                typeList:  [GreetingType!]
             }
             
             enum GreetingType {
@@ -1475,27 +1439,34 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(@InputArgument someInput: InputMessage): String {
-                return "Hello, this is a ${someInput.type} greeting"
+            fun hello(@InputArgument input: KInputMessage): String {
+                assertThat(input.type).isInstanceOf(KGreetingType::class.java)
+                assertThat(input.type).isEqualTo(KGreetingType.FRIENDLY)
+                assertThat(input.typeList).hasOnlyElementsOfType(KGreetingType::class.java)
+                assertThat(input.typeList).contains(KGreetingType.FRIENDLY, KGreetingType.POLITE)
+                return "Hello, this is a ${input.type} greeting with ${input.typeList}"
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
         val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
 
         val build = GraphQL.newGraphQL(provider.schema(schema)).build()
-        val executionResult = build.execute("""{hello(someInput: {type: FRIENDLY})}""")
-        assertThat(executionResult.errors.isEmpty()).isTrue
-        val data = executionResult.getData<Map<String, *>>()
-        Assertions.assertEquals("Hello, this is a FRIENDLY greeting", data["hello"])
+        val executionResult = build.execute(
+            """
+                { hello(input: { type: FRIENDLY, typeList: [POLITE, FRIENDLY] }) }
+            """.trimIndent()
+        )
+
+        assertThat(executionResult.errors).isEmpty()
+        assertThat(executionResult)
+            .extracting { it.getData<Map<String, *>>() }
+            .extracting { it["hello"] }
+            .isEqualTo("Hello, this is a FRIENDLY greeting with [POLITE, FRIENDLY]")
+
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
@@ -1518,7 +1489,7 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(@InputArgument someInput: InputMessage): String {
+            fun someFetcher(@InputArgument someInput: JInputMessage): String {
                 return "Hello, this is a ${someInput.type ?: "SAD"} greeting"
             }
         }
@@ -1546,11 +1517,12 @@ internal class InputArgumentTest {
     fun `Nested Java enum @InputArgument`() {
         val schema = """
             type Query {
-                hello(someInput:InputMessage): String
+                hello(input:InputMessage): String
             }
             
             input InputMessage {
                 type: GreetingType
+                typeList:  [GreetingType!]
             }
             
             enum GreetingType {          
@@ -1561,27 +1533,33 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(@InputArgument someInput: com.netflix.graphql.dgs.internal.testenums.InputMessage): String {
-                return "Hello, this is a ${someInput.type} greeting"
+            fun hello(@InputArgument input: JInputMessage): String {
+                assertThat(input.type).isInstanceOf(JGreetingType::class.java)
+                assertThat(input.type).isEqualTo(JGreetingType.FRIENDLY)
+                assertThat(input.typeList).hasOnlyElementsOfType(JGreetingType::class.java)
+                assertThat(input.typeList).contains(JGreetingType.FRIENDLY, JGreetingType.POLITE)
+                return "Hello, this is a ${input.type} greeting with ${input.typeList}"
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
         val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
-
         val build = GraphQL.newGraphQL(provider.schema(schema)).build()
-        val executionResult = build.execute("""{hello(someInput: {type: FRIENDLY})}""")
-        assertThat(executionResult.errors.isEmpty()).isTrue
-        val data = executionResult.getData<Map<String, *>>()
-        Assertions.assertEquals("Hello, this is a FRIENDLY greeting", data["hello"])
+        val executionResult = build.execute(
+            """
+                { hello(input: { type: FRIENDLY, typeList: [POLITE, FRIENDLY] }) }
+            """.trimIndent()
+        )
+
+        assertThat(executionResult.errors).isEmpty()
+        assertThat(executionResult)
+            .extracting { it.getData<Map<String, *>>() }
+            .extracting { it["hello"] }
+            .isEqualTo("Hello, this is a FRIENDLY greeting with [POLITE, FRIENDLY]")
+
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
@@ -1633,7 +1611,7 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(@InputArgument(collectionType = BarInput::class) objects: List<BarInput>): String {
+            fun someFetcher(@InputArgument(collectionType = KBarInput::class) objects: List<KBarInput>): String {
                 return objects.joinToString { "${it.name}: ${it.value}" }
             }
 
@@ -1704,8 +1682,6 @@ internal class InputArgumentTest {
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
 
-    data class Filter(val query: Any)
-
     @Test
     fun `A field of an input type of type Any should be assigned the actual value and skip converting`() {
 
@@ -1723,7 +1699,7 @@ internal class InputArgumentTest {
 
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(@InputArgument filter: Filter): String {
+            fun someFetcher(@InputArgument filter: KFilter): String {
                 return filter.toString()
             }
 
@@ -1747,7 +1723,7 @@ internal class InputArgumentTest {
         val executionResult = build.execute("""{hello(filter: {query: {and: ["title", "genre"]}})}""")
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
-        Assertions.assertEquals("Filter(query={and=[title, genre]})", data["hello"])
+        Assertions.assertEquals("KFilter(query={and=[title, genre]})", data["hello"])
 
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
@@ -16,8 +16,8 @@
 
 package com.netflix.graphql.dgs.internal
 
-import com.netflix.graphql.dgs.inputobjects.InputObject
-import com.netflix.graphql.dgs.inputobjects.InputObjectWithKotlinProperty
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObject
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithKotlinProperty
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -43,7 +43,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToJavaClass() {
-        val mapToObject = InputObjectMapper.mapToJavaObject(input, InputObject::class.java)
+        val mapToObject = InputObjectMapper.mapToJavaObject(input, JInputObject::class.java)
         assertThat(mapToObject.simpleString).isEqualTo("hello")
         assertThat(mapToObject.someDate).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
@@ -53,7 +53,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToJavaClassWithKotlinProperty() {
-        val mapToObject = InputObjectMapper.mapToJavaObject(inputKotlinJavaMix, InputObjectWithKotlinProperty::class.java)
+        val mapToObject = InputObjectMapper.mapToJavaObject(inputKotlinJavaMix, JInputObjectWithKotlinProperty::class.java)
         assertThat(mapToObject.name).isEqualTo("dgs")
         assertThat(mapToObject.objectProperty.simpleString).isEqualTo("hello")
         assertThat(mapToObject.objectProperty.someObject.key1).isEqualTo("value1")
@@ -79,7 +79,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToJavaClassWithNull() {
-        val mapToObject = InputObjectMapper.mapToJavaObject(inputWithNulls, InputObject::class.java)
+        val mapToObject = InputObjectMapper.mapToJavaObject(inputWithNulls, JInputObject::class.java)
         assertThat(mapToObject.simpleString).isNull()
         assertThat(mapToObject.someDate).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
@@ -101,5 +101,5 @@ internal class InputObjectMapperTest {
     data class KotlinSomeObject(val key1: String, val key2: LocalDateTime, val key3: KotlinSubObject?)
     data class KotlinSubObject(val subkey1: String)
 
-    data class KotlinWithJavaProperty(val name: String, val objectProperty: InputObject)
+    data class KotlinWithJavaProperty(val name: String, val objectProperty: JInputObject)
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/kotlin/test/inputobjects.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/kotlin/test/inputobjects.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.kotlin.test
+
+enum class KGreetingType {
+    FRIENDLY,
+    POLITE
+}
+
+data class KInputMessage(val type: KGreetingType, val typeList: List<KGreetingType>)
+
+data class KMovieFilter(val movieIds: List<Any>)
+
+data class KFooInput(val bars: List<KBarInput>)
+
+data class KBarInput(val name: String, val value: Any)
+
+data class KFilter(val query: Any)


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

When the target type of an input argument is a list of enumerations we need to transform the
list item to the enum type. Previously the value was left as a string causing unexpected errors.

As part of this change we are moving all the support classes for the  Input Argument serialization tests:

* If Java, to `com/netflix/graphql/dgs/internal/java/test/` and the name will have a `J` prefix. e.g. `JGreetingType`.
* If Kotlin, to `com/netflix/graphql/dgs/internal/kotlin/test/inputobjects.kt` and the name will have a 'K'  prefix. e.g. `KGreeingType`