### PR TITLE
Only look for generic type if the field is generic

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
@@ -116,7 +116,7 @@ object InputObjectMapper {
         val type: Type = field.genericType
         return if (type is ParameterizedType) {
             Class.forName(type.actualTypeArguments[0].typeName)
-        } else if (genericSuperclass is ParameterizedType) {
+        } else if (genericSuperclass is ParameterizedType && field.type != field.genericType) {
             val typeParameters = (genericSuperclass.rawType as Class<*>).typeParameters
             val indexOfTypeParameter = typeParameters.indexOfFirst { it.name == type.typeName }
             Class.forName(genericSuperclass.actualTypeArguments[indexOfTypeParameter].typeName)

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JGenericBaseInputObject.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JGenericBaseInputObject.java
@@ -16,24 +16,24 @@
 
 package com.netflix.graphql.dgs.internal.java.test.inputobjects;
 
-public class JGenericInputObject<A, B> {
+public class JGenericBaseInputObject<T> {
 
-    private A fieldA;
-    private B fieldB;
+    private String someField;
+    private T fieldA;
 
-    public A getFieldA() {
+    public String getSomeField() {
+        return someField;
+    }
+
+    public void setSomeField(String someField) {
+        this.someField = someField;
+    }
+
+    public T getFieldA() {
         return fieldA;
     }
 
-    public void setFieldA(A fieldA) {
+    public void setFieldA(T fieldA) {
         this.fieldA = fieldA;
-    }
-
-    public B getFieldB() {
-        return fieldB;
-    }
-
-    public void setFieldB(B fieldB) {
-        this.fieldB = fieldB;
     }
 }

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JGenericInputObjectTwoTypeParams.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JGenericInputObjectTwoTypeParams.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
+
+public class JGenericInputObjectTwoTypeParams<A, B> {
+
+    private A fieldA;
+    private B fieldB;
+
+    public A getFieldA() {
+        return fieldA;
+    }
+
+    public void setFieldA(A fieldA) {
+        this.fieldA = fieldA;
+    }
+
+    public B getFieldB() {
+        return fieldB;
+    }
+
+    public void setFieldB(B fieldB) {
+        this.fieldB = fieldB;
+    }
+}

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JGenericSubInputObject.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JGenericSubInputObject.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
+
+public class JGenericSubInputObject extends JGenericBaseInputObject<Integer>{
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
@@ -16,7 +16,8 @@
 
 package com.netflix.graphql.dgs.internal
 
-import com.netflix.graphql.dgs.internal.java.test.inputobjects.JGenericInputObject
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.JGenericInputObjectTwoTypeParams
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.JGenericSubInputObject
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObject
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithKotlinProperty
 import org.assertj.core.api.Assertions.assertThat
@@ -99,12 +100,20 @@ internal class InputObjectMapperTest {
     }
 
     @Test
-    fun mapGenericJavaClass() {
+    fun mapGenericJavaClassTwoTypeParams() {
         val input = mapOf("fieldA" to "value A", "fieldB" to listOf(1, 2, 3))
-        val mappedGeneric = InputObjectMapper.mapToJavaObject(input, JGenericInputObject::class.java)
+        val mappedGeneric = InputObjectMapper.mapToJavaObject(input, JGenericInputObjectTwoTypeParams::class.java)
 
         assertThat(mappedGeneric.fieldA).isEqualTo("value A")
         assertThat(mappedGeneric.fieldB).isEqualTo(listOf(1, 2, 3))
+    }
+
+    @Test
+    fun mapGenericJavaClass() {
+        val input = mapOf("someField" to "The String", "fieldA" to 1)
+        val mappedGeneric = InputObjectMapper.mapToJavaObject(input, JGenericSubInputObject::class.java)
+
+        assertThat(mappedGeneric.fieldA).isEqualTo(1)
     }
 
     data class KotlinInputObject(val simpleString: String?, val someDate: LocalDateTime, val someObject: KotlinSomeObject)


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

When using a generic class, the type of a field should only try to resolve the type parameter when the field is actually using the type parameter.
This was reproducible by having a "normal", non generic field in a generic class.