### PR TITLE
Compile javac with -parameters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,6 +115,10 @@ configure(subprojects.filterNot { it in internalBomModules }) {
         }
     }
 
+    tasks.withType<JavaCompile>().configureEach {
+        options.compilerArgs + "-parameters"
+    }
+
     tasks.withType<KotlinCompile>().configureEach {
         kotlinOptions {
             freeCompilerArgs += "-Xjvm-default=enable"


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Configure the Java Compiler to compile with `-parameters` to gain access to parameter names.
Ref https://openjdk.java.net/jeps/118