### PR TITLE
Allow input arguments or fields of input objects as Set for list values

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
@@ -243,7 +243,11 @@ class DataFetcherInvoker(
             (parameter.type.enumConstants as Array<Enum<*>>).find { it.name == parameterValue }
                 ?: throw DgsInvalidInputArgumentException("Invalid enum value '$parameterValue for enum type ${parameter.type.name}")
         } else {
-            parameterValue
+            if (parameterValue is List<*> && parameter.type == Set::class.java) {
+                parameterValue.toSet()
+            } else {
+                parameterValue
+            }
         }
 
     private fun getValueAsOptional(value: Any?, parameter: Parameter) =

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JInputObjectWithSet.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JInputObjectWithSet.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
+
+import java.util.Set;
+
+public class JInputObjectWithSet {
+    private Set<Integer> items;
+
+    public Set<Integer> getItems() {
+        return items;
+    }
+
+    public void setItems(Set<Integer> items) {
+        this.items = items;
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.dgs.internal.java.test.inputobjects.JGenericInputObje
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JGenericSubInputObject
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObject
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithKotlinProperty
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithSet
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -48,7 +49,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToJavaClass() {
-        val mapToObject = InputObjectMapper.mapToJavaObject(input, JInputObject::class.java)
+        val mapToObject = mapToJavaObject(input, JInputObject::class.java)
         assertThat(mapToObject.simpleString).isEqualTo("hello")
         assertThat(mapToObject.someDate).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
@@ -58,7 +59,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToJavaClassWithKotlinProperty() {
-        val mapToObject = InputObjectMapper.mapToJavaObject(inputKotlinJavaMix, JInputObjectWithKotlinProperty::class.java)
+        val mapToObject = mapToJavaObject(inputKotlinJavaMix, JInputObjectWithKotlinProperty::class.java)
         assertThat(mapToObject.name).isEqualTo("dgs")
         assertThat(mapToObject.objectProperty.simpleString).isEqualTo("hello")
         assertThat(mapToObject.objectProperty.someObject.key1).isEqualTo("value1")
@@ -84,7 +85,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToJavaClassWithNull() {
-        val mapToObject = InputObjectMapper.mapToJavaObject(inputWithNulls, JInputObject::class.java)
+        val mapToObject = mapToJavaObject(inputWithNulls, JInputObject::class.java)
         assertThat(mapToObject.simpleString).isNull()
         assertThat(mapToObject.someDate).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
@@ -105,7 +106,7 @@ internal class InputObjectMapperTest {
     @Test
     fun mapGenericJavaClassTwoTypeParams() {
         val input = mapOf("fieldA" to "value A", "fieldB" to listOf(1, 2, 3))
-        val mappedGeneric = InputObjectMapper.mapToJavaObject(input, JGenericInputObjectTwoTypeParams::class.java)
+        val mappedGeneric = mapToJavaObject(input, JGenericInputObjectTwoTypeParams::class.java)
 
         assertThat(mappedGeneric.fieldA).isEqualTo("value A")
         assertThat(mappedGeneric.fieldB).isEqualTo(listOf(1, 2, 3))
@@ -114,7 +115,7 @@ internal class InputObjectMapperTest {
     @Test
     fun mapGenericJavaClass() {
         val input = mapOf("someField" to "The String", "fieldA" to 1)
-        val mappedGeneric = InputObjectMapper.mapToJavaObject(input, JGenericSubInputObject::class.java)
+        val mappedGeneric = mapToJavaObject(input, JGenericSubInputObject::class.java)
 
         assertThat(mappedGeneric.fieldA).isEqualTo(1)
     }
@@ -126,7 +127,7 @@ internal class InputObjectMapperTest {
             "unknown" to "The String",
         )
 
-        val mapToObject = InputObjectMapper.mapToJavaObject(input, JInputObject::class.java)
+        val mapToObject = mapToJavaObject(input, JInputObject::class.java)
         assertThat(mapToObject).isNotNull
         assertThat(mapToObject.simpleString).isEqualTo("hello")
     }
@@ -174,9 +175,24 @@ internal class InputObjectMapperTest {
         ).hasMessageStartingWith("Provided input arguments")
     }
 
+    @Test
+    fun `A list argument should be able to convert to Set in Kotlin`() {
+        val input = mapOf("items" to listOf(1, 2, 3))
+        val withSet = InputObjectMapper.mapToKotlinObject(input, KotlinObjectWithSet::class)
+        assertThat(withSet.items).isInstanceOf(Set::class.java)
+    }
+
+    @Test
+    fun `A list argument should be able to convert to Set in Java`() {
+        val input = mapOf("items" to listOf(1, 2, 3))
+        val withSet = mapToJavaObject(input, JInputObjectWithSet::class.java)
+        assertThat(withSet.items).isInstanceOf(Set::class.java)
+    }
+
     data class KotlinInputObject(val simpleString: String?, val someDate: LocalDateTime, val someObject: KotlinSomeObject)
     data class KotlinSomeObject(val key1: String, val key2: LocalDateTime, val key3: KotlinSubObject?)
     data class KotlinSubObject(val subkey1: String)
+    data class KotlinObjectWithSet(val items: Set<Int>)
 
     data class KotlinWithJavaProperty(val name: String, val objectProperty: JInputObject)
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Datafetcher input arguments and fields of input arguments should support `Set` as well as `List`.
Without this change, only `List` is supported. While in most cases `List` semantics make more sense from a GraphQL perspective, there is not reason we couldn't also support Set.

Issue #621 

