### PR TITLE
Prevent the creation of Loggers in the Hotpath.

### DIFF
--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
@@ -19,8 +19,6 @@ package com.netflix.graphql.dgs.reactive.internal
 import com.netflix.graphql.dgs.context.DgsContext
 import com.netflix.graphql.dgs.internal.DgsRequestData
 import com.netflix.graphql.dgs.reactive.DgsReactiveCustomContextBuilderWithRequest
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.context.request.WebRequest
@@ -31,7 +29,6 @@ import java.util.*
 open class DefaultDgsReactiveGraphQLContextBuilder(
     private val dgsReactiveCustomContextBuilderWithRequest: Optional<DgsReactiveCustomContextBuilderWithRequest<*>> = Optional.empty()
 ) {
-    val logger: Logger = LoggerFactory.getLogger(DefaultDgsReactiveGraphQLContextBuilder::class.java)
 
     fun build(dgsRequestData: DgsReactiveRequestData?): Mono<DgsContext> {
         val customContext = if (dgsReactiveCustomContextBuilderWithRequest.isPresent) {

--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
@@ -54,7 +54,6 @@ class DefaultDgsReactiveQueryExecutor(
     private val reloadIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator = DefaultDgsQueryExecutor.ReloadSchemaIndicator { false },
     private val preparsedDocumentProvider: PreparsedDocumentProvider = DgsNoOpPreparsedDocumentProvider
 ) : com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor {
-    private val logger: Logger = LoggerFactory.getLogger(DefaultDgsQueryExecutor::class.java)
 
     private val schema = AtomicReference(defaultSchema)
 
@@ -155,5 +154,9 @@ class DefaultDgsReactiveQueryExecutor(
 
             BaseDgsQueryExecutor.objectMapper.writeValueAsString(executionResult.toSpecification())
         }
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DefaultDgsQueryExecutor::class.java)
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderInterceptor.kt
@@ -17,11 +17,6 @@ internal class BatchLoaderInterceptor(
     private val registry: MeterRegistry
 ) {
 
-    companion object {
-        private val ID = GqlMetric.DATA_LOADER.key
-        private val logger = LoggerFactory.getLogger(BatchLoaderInterceptor::class.java)
-    }
-
     fun load(@Pipe pipe: Forwarder<CompletionStage<List<*>>, BatchLoader<*, *>>): CompletionStage<List<*>> {
         logger.debug("Starting metered timer[{}] for BatchLoader.", ID)
         val timerSampler = Timer.start(registry)
@@ -42,5 +37,10 @@ internal class BatchLoaderInterceptor(
             logger.warn("Error creating BatchLoader metric interceptor '{}'", ID)
             pipe.to(batchLoader)
         }
+    }
+
+    companion object {
+        private val ID = GqlMetric.DATA_LOADER.key
+        private val logger = LoggerFactory.getLogger(BatchLoaderInterceptor::class.java)
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderWithContextInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderWithContextInterceptor.kt
@@ -16,10 +16,6 @@ internal class BatchLoaderWithContextInterceptor(
     private val name: String,
     private val registry: MeterRegistry
 ) {
-    companion object {
-        private val ID = GqlMetric.DATA_LOADER.key
-        private val logger = LoggerFactory.getLogger(BatchLoaderWithContextInterceptor::class.java)
-    }
 
     fun load(@Pipe pipe: Forwarder<CompletionStage<List<*>>, BatchLoaderWithContext<*, *>>): CompletionStage<List<*>> {
         logger.debug("Starting metered timer[{}] for {}.", ID, javaClass.simpleName)
@@ -41,5 +37,10 @@ internal class BatchLoaderWithContextInterceptor(
             logger.warn("Error creating timer interceptor '{}' for {}", ID, javaClass.simpleName)
             pipe.to(batchLoader)
         }
+    }
+
+    companion object {
+        private val ID = GqlMetric.DATA_LOADER.key
+        private val logger = LoggerFactory.getLogger(BatchLoaderWithContextInterceptor::class.java)
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/MappedBatchLoaderInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/MappedBatchLoaderInterceptor.kt
@@ -16,11 +16,6 @@ internal class MappedBatchLoaderInterceptor(
     private val name: String,
     private val registry: MeterRegistry
 ) {
-    companion object {
-        private val ID = GqlMetric.DATA_LOADER.key
-        private val logger = LoggerFactory.getLogger(MappedBatchLoaderInterceptor::class.java)
-    }
-
     fun load(@Pipe pipe: Forwarder<CompletionStage<Map<*, *>>, MappedBatchLoader<*, *>>): CompletionStage<Map<*, *>> {
         logger.debug("Starting metered timer[{}] for {}.", ID, javaClass.simpleName)
         val timerSampler = Timer.start(registry)
@@ -41,5 +36,10 @@ internal class MappedBatchLoaderInterceptor(
             logger.warn("Error creating timer interceptor '{}' for {}", ID, javaClass.simpleName)
             pipe.to(batchLoader)
         }
+    }
+
+    companion object {
+        private val ID = GqlMetric.DATA_LOADER.key
+        private val logger = LoggerFactory.getLogger(MappedBatchLoaderInterceptor::class.java)
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/MappedBatchLoaderWithContextInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/MappedBatchLoaderWithContextInterceptor.kt
@@ -17,11 +17,6 @@ internal class MappedBatchLoaderWithContextInterceptor(
     private val registry: MeterRegistry
 ) {
 
-    companion object {
-        private val ID = GqlMetric.DATA_LOADER.key
-        private val logger = LoggerFactory.getLogger(MappedBatchLoaderWithContextInterceptor::class.java)
-    }
-
     fun load(@Pipe pipe: Forwarder<CompletionStage<Map<*, *>>, MappedBatchLoaderWithContext<*, *>>): CompletionStage<Map<*, *>> {
         logger.debug("Starting metered timer[{}] for {}.", ID, javaClass.simpleName)
         val timerSampler = Timer.start(registry)
@@ -42,5 +37,10 @@ internal class MappedBatchLoaderWithContextInterceptor(
             logger.warn("Error creating timer interceptor '{}' for {}", ID, javaClass.simpleName)
             pipe.to(batchLoader)
         }
+    }
+
+    companion object {
+        private val ID = GqlMetric.DATA_LOADER.key
+        private val logger = LoggerFactory.getLogger(MappedBatchLoaderWithContextInterceptor::class.java)
     }
 }

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsReactiveWebsocketHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsReactiveWebsocketHandler.kt
@@ -37,22 +37,10 @@ import java.util.concurrent.ConcurrentHashMap
 
 class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReactiveQueryExecutor) : WebSocketHandler {
 
-    private val logger = LoggerFactory.getLogger(DgsReactiveQueryExecutor::class.java)
     private val resolvableType = ResolvableType.forType(OperationMessage::class.java)
     private val subscriptions = ConcurrentHashMap<String, MutableMap<String, Subscription>>()
     private val decoder = Jackson2JsonDecoder()
     private val encoder = Jackson2JsonEncoder(decoder.objectMapper)
-
-    companion object {
-        const val GQL_CONNECTION_INIT = "connection_init"
-        const val GQL_CONNECTION_ACK = "connection_ack"
-        const val GQL_START = "start"
-        const val GQL_STOP = "stop"
-        const val GQL_DATA = "data"
-        const val GQL_ERROR = "error"
-        const val GQL_COMPLETE = "complete"
-        const val GQL_CONNECTION_TERMINATE = "connection_terminate"
-    }
 
     override fun getSubProtocols(): List<String> = listOf("graphql-ws")
 
@@ -160,6 +148,19 @@ class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReact
                 null
             )
         )
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(DgsReactiveQueryExecutor::class.java)
+
+        const val GQL_CONNECTION_INIT = "connection_init"
+        const val GQL_CONNECTION_ACK = "connection_ack"
+        const val GQL_START = "start"
+        const val GQL_STOP = "stop"
+        const val GQL_DATA = "data"
+        const val GQL_ERROR = "error"
+        const val GQL_COMPLETE = "complete"
+        const val GQL_CONNECTION_TERMINATE = "connection_terminate"
     }
 }
 

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsWebfluxHttpHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsWebfluxHttpHandler.kt
@@ -27,8 +27,6 @@ import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 
 class DgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQueryExecutor) {
-    private val logger: Logger = LoggerFactory.getLogger(DgsWebfluxHttpHandler::class.java)
-    private val mapper = jacksonObjectMapper()
 
     fun graphql(request: ServerRequest): Mono<ServerResponse> {
         @Suppress("UNCHECKED_CAST") val executionResult: Mono<ExecutionResult> =
@@ -64,6 +62,11 @@ class DgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQueryExecut
             val graphQlOutput = result.toSpecification()
             ServerResponse.ok().bodyValue(graphQlOutput)
         }
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DgsWebfluxHttpHandler::class.java)
+        private val mapper = jacksonObjectMapper()
     }
 }
 

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLConfigurer.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLConfigurer.kt
@@ -43,12 +43,6 @@ open class GraphiQLConfigurer(
     private val servletContext: ServletContext
 ) : WebMvcConfigurer {
 
-    val logger: Logger = LoggerFactory.getLogger(GraphiQLConfigurer::class.java)
-
-    object Constants {
-        const val PATH_TO_GRAPHIQL_INDEX_HTML = "/graphiql/index.html"
-    }
-
     override fun addViewControllers(registry: ViewControllerRegistry) {
         registry.addViewController(configProps.graphiql.path).setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
         registry.addViewController("${configProps.graphiql.path}/").setViewName("forward:$PATH_TO_GRAPHIQL_INDEX_HTML")
@@ -81,5 +75,13 @@ open class GraphiQLConfigurer(
             }
             return resource
         }
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(GraphiQLConfigurer::class.java)
+    }
+
+    object Constants {
+        const val PATH_TO_GRAPHIQL_INDEX_HTML = "/graphiql/index.html"
     }
 }

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -62,9 +62,6 @@ import org.springframework.web.multipart.MultipartFile
 @RestController
 open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
 
-    open val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
-    private val mapper = jacksonObjectMapper()
-
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
     @RequestMapping(
         "#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.path}",
@@ -196,5 +193,10 @@ open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
         }
 
         return ResponseEntity.ok(result)
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
+        private val mapper = jacksonObjectMapper()
     }
 }

--- a/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
+++ b/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
@@ -25,6 +25,7 @@ import graphql.validation.ValidationError
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -41,7 +42,6 @@ import java.util.*
  */
 @RestController
 open class DgsSSESubscriptionHandler(open val dgsQueryExecutor: DgsQueryExecutor) {
-    open val logger = LoggerFactory.getLogger(DgsSSESubscriptionHandler::class.java)
     private val mapper = jacksonObjectMapper()
 
     @RequestMapping("/subscriptions", produces = ["text/event-stream"])
@@ -140,6 +140,21 @@ open class DgsSSESubscriptionHandler(open val dgsQueryExecutor: DgsQueryExecutor
         return ResponseEntity.ok(emitter)
     }
 
-    data class QueryPayload(@JsonProperty("variables") val variables: Map<String, Any> = emptyMap(), @JsonProperty("extensions") val extensions: Map<String, Any> = emptyMap(), @JsonProperty("operationName") val operationName: String?, @JsonProperty("query") val query: String)
-    data class SubscriptionData(val data: Any, val errors: List<GraphQLError>? = null, val subId: String, val type: String = "SUBSCRIPTION_DATA")
+    data class QueryPayload(
+        @JsonProperty("variables") val variables: Map<String, Any> = emptyMap(),
+        @JsonProperty("extensions") val extensions: Map<String, Any> = emptyMap(),
+        @JsonProperty("operationName") val operationName: String?,
+        @JsonProperty("query") val query: String
+    )
+
+    data class SubscriptionData(
+        val data: Any,
+        val errors: List<GraphQLError>? = null,
+        val subId: String,
+        val type: String = "SUBSCRIPTION_DATA"
+    )
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DgsSSESubscriptionHandler::class.java)
+    }
 }

--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketHandler.kt
@@ -33,8 +33,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import javax.annotation.PostConstruct
 
 class DgsWebSocketHandler(private val dgsQueryExecutor: DgsQueryExecutor) : TextWebSocketHandler() {
-    private val logger = LoggerFactory.getLogger(DgsWebSocketHandler::class.java)
-    private val objectMapper = jacksonObjectMapper()
+
     internal val subscriptions = ConcurrentHashMap<String, MutableMap<String, Subscription>>()
     internal val sessions = CopyOnWriteArrayList<WebSocketSession>()
 
@@ -138,5 +137,10 @@ class DgsWebSocketHandler(private val dgsQueryExecutor: DgsQueryExecutor) : Text
                 subscriptions[session.id]?.remove(id)
             }
         })
+    }
+
+    private companion object {
+        val logger = LoggerFactory.getLogger(DgsWebSocketHandler::class.java)
+        val objectMapper = jacksonObjectMapper()
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory
  * The default implementation uses the Common Errors library to return GraphQL errors.
  */
 class DefaultDataFetcherExceptionHandler : DataFetcherExceptionHandler {
-    private val logger: Logger = LoggerFactory.getLogger(DefaultDataFetcherExceptionHandler::class.java)
 
     override fun onException(handlerParameters: DataFetcherExceptionHandlerParameters?): DataFetcherExceptionHandlerResult {
 
@@ -60,5 +59,9 @@ class DefaultDataFetcherExceptionHandler : DataFetcherExceptionHandler {
         return DataFetcherExceptionHandlerResult.newResult()
             .error(graphqlError)
             .build()
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DefaultDataFetcherExceptionHandler::class.java)
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -61,8 +61,6 @@ open class DefaultDgsFederationResolver() :
     @Autowired
     lateinit var dgsExceptionHandler: Optional<DataFetcherExceptionHandler>
 
-    val logger: Logger = LoggerFactory.getLogger(DefaultDgsFederationResolver::class.java)
-
     override fun entitiesFetcher(): DataFetcher<Any?> {
         return DataFetcher { env ->
             dgsEntityFetchers(env)
@@ -155,5 +153,9 @@ open class DefaultDgsFederationResolver() :
 
             type
         }
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DefaultDgsFederationResolver::class.java)
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
@@ -51,7 +51,6 @@ class DataFetcherInvoker(
     private val method: Method
 ) {
 
-    private val logger = LoggerFactory.getLogger(DataFetcherInvoker::class.java)
     private val parameterNames = defaultParameterNameDiscoverer.getParameterNames(method) ?: emptyArray()
 
     fun invokeDataFetcher(): Any? {
@@ -269,4 +268,8 @@ class DataFetcherInvoker(
         } else {
             value
         }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(DataFetcherInvoker::class.java)
+    }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
@@ -31,7 +31,6 @@ open class DefaultDgsGraphQLContextBuilder(
     private val dgsCustomContextBuilder: Optional<DgsCustomContextBuilder<*>>,
     private val dgsCustomContextBuilderWithRequest: Optional<DgsCustomContextBuilderWithRequest<*>> = Optional.empty()
 ) {
-    val logger: Logger = LoggerFactory.getLogger(DefaultDgsGraphQLContextBuilder::class.java)
 
     fun build(dgsRequestData: DgsWebMvcRequestData): DgsContext {
         return TimeTracer.logTime({ buildDgsContext(dgsRequestData) }, logger, "Created DGS context in {}ms")
@@ -57,6 +56,10 @@ open class DefaultDgsGraphQLContextBuilder(
             customContext,
             dgsRequestData,
         )
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DefaultDgsGraphQLContextBuilder::class.java)
     }
 }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -61,8 +61,6 @@ class DefaultDgsQueryExecutor(
     private val preparsedDocumentProvider: PreparsedDocumentProvider = DgsNoOpPreparsedDocumentProvider,
 ) : DgsQueryExecutor {
 
-    val logger: Logger = LoggerFactory.getLogger(DefaultDgsQueryExecutor::class.java)
-
     val schema = AtomicReference(defaultSchema)
 
     override fun execute(
@@ -175,6 +173,10 @@ class DefaultDgsQueryExecutor(
     @FunctionalInterface
     fun interface ReloadSchemaIndicator {
         fun reloadSchema(): Boolean
+    }
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DefaultDgsQueryExecutor::class.java)
     }
 }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -36,7 +36,6 @@ import javax.annotation.PostConstruct
  * Framework implementation class responsible for finding and configuring data loaders.
  */
 class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) {
-    val logger: Logger = LoggerFactory.getLogger(DgsDataLoaderProvider::class.java)
 
     private val batchLoaders = mutableListOf<Pair<BatchLoader<*, *>, DgsDataLoader>>()
     private val batchLoadersWithContext = mutableListOf<Pair<BatchLoaderWithContext<*, *>, DgsDataLoader>>()
@@ -249,5 +248,9 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
             logger.debug("Unable to wrap the [{} : {}]", name, loader, ex)
         }
         return loader
+    }
+
+    private companion object {
+        private val logger: Logger = LoggerFactory.getLogger(DgsDataLoaderProvider::class.java)
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
@@ -34,7 +34,7 @@ import kotlin.reflect.jvm.jvmErasure
 
 @Suppress("UNCHECKED_CAST")
 object InputObjectMapper {
-    val logger: Logger = LoggerFactory.getLogger(InputObjectMapper::class.java)
+    private val logger: Logger = LoggerFactory.getLogger(InputObjectMapper::class.java)
 
     fun <T : Any> mapToKotlinObject(inputMap: Map<String, *>, targetClass: KClass<T>): T {
         val params = targetClass.primaryConstructor!!.parameters


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This PR moves all loggers to be available through a `companion object`.
This will prevent instances of loggers to be created as part of the _request execution_/_hotpath_.
Although this was initially identified in the `DataFetcherInvoker`, via a JFR analysis, we are also
favoring consistency and apply the same pattern across all components.

From the image below the time associated with creating the logger per DataFetcherInvoker is visible on the right.


![image](https://user-images.githubusercontent.com/134985/133486573-fed66923-8bae-403f-8ed0-322d9bb77499.png)
