### PR TITLE
An @InputArgument representing a complex type can be empty

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
@@ -137,7 +137,7 @@ object InputObjectMapper {
          This would happen if new schema fields are added, but the Java type wasn't updated yet.
          If none of the fields match however, it's a pretty good indication that the wrong type was used, hence this check.
          */
-        if (nrOfFieldErrors == inputMap.size) {
+        if (inputMap.isNotEmpty() && nrOfFieldErrors == inputMap.size) {
             throw DgsInvalidInputArgumentException("Input argument type '$targetClass' doesn't match input $inputMap")
         }
 

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JPerson.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JPerson.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
+
+import java.util.Objects;
+
+public class JPerson {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof JPerson)) return false;
+        JPerson jPerson = (JPerson) o;
+        return Objects.equals(getName(), jPerson.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
+    }
+
+    @Override
+    public String toString() {
+        return "JPerson{" +
+                "name='" + name + '\'' +
+                '}';
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -18,6 +18,8 @@ package com.netflix.graphql.dgs
 
 import com.netflix.graphql.dgs.exceptions.NoSchemaFoundException
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.kotlin.test.Show
+import com.netflix.graphql.dgs.internal.kotlin.test.Video
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.language.FieldDefinition
@@ -32,7 +34,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
-// import io.reactivex.rxjava3.subscribers.TestSubscriber
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -43,7 +44,6 @@ import org.reactivestreams.Publisher
 import org.springframework.context.ApplicationContext
 import reactor.core.publisher.Flux
 import reactor.test.StepVerifier
-import java.time.LocalDateTime
 import java.util.*
 import java.util.concurrent.CompletableFuture
 
@@ -841,11 +841,3 @@ internal class DgsSchemaProviderTest {
         assertEquals("hello", data["addMessage"])
     }
 }
-
-interface Video {
-    val title: String
-}
-
-data class Show(override val title: String) : Video
-data class Person(val name: String)
-data class DateTimeInput(val date: LocalDateTime)

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/kotlin/test/inputobjects.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/kotlin/test/inputobjects.kt
@@ -16,7 +16,17 @@
 
 package com.netflix.graphql.dgs.internal.kotlin.test
 
-import java.util.*
+import java.time.LocalDateTime
+
+interface Video {
+    val title: String
+}
+
+data class Show(override val title: String) : Video
+
+data class Person(val name: String)
+
+data class DateTimeInput(val date: LocalDateTime)
 
 enum class KGreetingType {
     FRIENDLY,


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Fixes #625

Given the following GraphQL Schema...

```
type Query {
    hello(person: Person): String
}

input Person {
    name:String
}
```

The following request should be valid.

```
{ hello(person: {}) }
```
