### PR TITLE
Avoid dependency ranges in platform to prevent SNAPSHOT versions.

### DIFF
--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -55,13 +55,13 @@ dependencies {
             version { require(Versions.GRAPHQL_JAVA_FEDERATION) }
         }
         api("com.jayway.jsonpath:json-path") {
-            version { require("[2.5,)") }
+            version { require("2.6.0") }
         }
         api("io.projectreactor:reactor-core") {
-            version { require("[3.4,)") }
+            version { require("3.4.10") }
         }
         api("io.projectreactor:reactor-test"){
-            version { require("[3.4,)") }
+            version { require("3.4.10") }
         }
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

We are being explicit on the versions we expose in the graphql-dgs-platform to avoid leaking any potential snapshot version as
a transitive or recommended dependency.

Fixes #642