### PR TITLE
Support custom headers in executeQuery

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
@@ -101,6 +101,31 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
     }
 
     /**
+     * Executes a query and returns a GraphQLResponse.
+     * The actual HTTP request is done by an implementation of RequestExecutor, which is user provided.
+     * The RequestExecutor is typically provided as a lambda expression.
+     * Accepts custom headers to pass down to request executor
+     * @param query The Query as a String
+     * @param variables Query variables. May be empty
+     * @param operationName optional operation name
+     * @param headers The headers that get passed down to requestExecutor
+     * @param requestExecutor The code that does the actual HTTP request. Typically provided as a lambda expression.
+     * @return GraphQLResponse
+     * @throws GraphQLClientException when the HTTP response code is not 2xx.
+     */
+    override fun executeQuery(
+        query: String,
+        variables: Map<String, Any>,
+        operationName: String?,
+        headers: Map<String, List<String>>,
+        requestExecutor: RequestExecutor
+    ): GraphQLResponse {
+        val serializedRequest = objectMapper.writeValueAsString(Request(query, variables, operationName))
+        val response = requestExecutor.execute(url, headers, serializedRequest)
+        return handleResponse(response, serializedRequest)
+    }
+
+    /**
      * Executes a query and returns a reactive Mono<GraphQLResponse>.
      * The actual HTTP request is done by an implementation of RequestExecutor, which is user provided.
      * The RequestExecutor is typically provided as a lambda expression.

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -27,6 +27,13 @@ interface GraphQLClient {
         operationName: String?,
         requestExecutor: RequestExecutor
     ): GraphQLResponse
+    fun executeQuery(
+        query: String,
+        variables: Map<String, Any>,
+        operationName: String?,
+        headers: Map<String, List<String>>,
+        requestExecutor: RequestExecutor
+    ): GraphQLResponse
 }
 
 interface MonoGraphQLClient {

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
@@ -218,4 +218,39 @@ class GraphQLResponseTest {
 
         server.verify()
     }
+
+    @Test
+    fun useCustomHeaders() {
+
+        val jsonResponse = """
+            {
+              "data": {
+                "submitReview": {
+                  "edges": []
+                }
+              }
+            }
+        """.trimIndent()
+
+        server.expect(requestTo(url))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andRespond(withSuccess(jsonResponse, MediaType.APPLICATION_JSON))
+
+        val headers = mapOf(
+            "Accept" to listOf("application/json"),
+            "Content-type" to listOf("application/json")
+        )
+        val graphQLResponse = client.executeQuery(
+            """mutation SubmitUserReview {
+              submitReview(review:{movieId:1, starRating:5, description:""}) {}
+            }""",
+            emptyMap(),
+            null,
+            headers,
+            requestExecutor
+        )
+
+        server.verify()
+    }
 }


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Adds support for passing down custom headers to request executor
Issue #664 

Alternatives considered
----

_Describe alternative implementation you have considered_

