### PR TITLE
Added createWithWebClient factory method that takes header consumer

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -19,10 +19,12 @@ package com.netflix.graphql.dgs.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.http.HttpHeaders
 import org.springframework.util.ClassUtils
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.util.function.Consumer
 
 /**
  * GraphQL client interface for blocking clients.
@@ -129,6 +131,8 @@ interface MonoGraphQLClient {
         fun createCustomReactive(url: String, requestExecutor: MonoRequestExecutor) = CustomMonoGraphQLClient(url, requestExecutor)
         @JvmStatic
         fun createWithWebClient(webClient: WebClient) = WebClientGraphQLClient(webClient)
+        @JvmStatic
+        fun createWithWebClient(webClient: WebClient, headersConsumer: Consumer<HttpHeaders>) = WebClientGraphQLClient(webClient, headersConsumer)
     }
 }
 

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
@@ -47,7 +47,7 @@ class WebClientGraphQLClientTest {
 
     @BeforeEach
     fun setup() {
-        client = WebClientGraphQLClient(WebClient.create("http://localhost:$port/graphql"))
+        client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql"))
     }
 
     @Test
@@ -61,8 +61,7 @@ class WebClientGraphQLClientTest {
 
     @Test
     fun `Extra header can be provided`() {
-        client = WebClientGraphQLClient(WebClient.create("http://localhost:$port/graphql")) { headers ->
-            println("extra")
+        client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql")) { headers ->
             headers.add("myheader", "test")
         }
         val result = client.reactiveExecuteQuery("{withHeader}").map { r -> r.extractValue<String>("withHeader") }


### PR DESCRIPTION
Previously added this to the `WebClientGraphQLClient`, but it should have a corresponding factory method in `MonoGraphQLClient`.