### PR TITLE
fix: convert runtime to ResponseStatusException to get status

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -20,8 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.util.ClassUtils
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.function.Consumer
@@ -197,7 +199,7 @@ fun interface MonoRequestExecutor {
  * A transport level exception (e.g. a failed connection). This does *not* represent successful GraphQL responses that contain errors.
  */
 class GraphQLClientException(statusCode: Int, url: String, response: String, request: String) :
-    RuntimeException("GraphQL server $url responded with status code $statusCode: '$response'. The request sent to the server was \n$request")
+    ResponseStatusException(HttpStatus.valueOf(statusCode), "GraphQL server $url responded with status code $statusCode: '$response'. The request sent to the server was \n$request")
 
 internal object GraphQLClients {
     internal val objectMapper: ObjectMapper =


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
GraphQLClientException to extend ResponseStatusException instead of RuntimeException to solve for use cases which would require status code. (Some status codes need to have re-try implemented and some don't) 
----

_Describe the new behavior from this PR, and why it's needed_
Issue #
No breaking changes. Client would have explicit access to status Code now

Alternatives considered
----

_Describe alternative implementation you have considered_
We can parse the message from GraphQLClientException and interpret status code but that doesn't seem like a clean solution
