### PR TITLE
Support custom deserializers in the GraphQLClient for deserializing the response.

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
@@ -21,7 +21,7 @@ package com.netflix.graphql.dgs.client
  * The user is responsible for doing the actual HTTP request, making this pluggable with any HTTP client.
  * For a more convenient option, use [WebClientGraphQLClient] instead.
  */
-class CustomGraphQLClient(private val url: String, private val requestExecutor: RequestExecutor) : GraphQLClient {
+class CustomGraphQLClient(private val url: String, private val requestExecutor: RequestExecutor, private val customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) : GraphQLClient {
     override fun executeQuery(query: String): GraphQLResponse {
         return executeQuery(query, emptyMap(), null)
     }
@@ -40,6 +40,6 @@ class CustomGraphQLClient(private val url: String, private val requestExecutor: 
         )
 
         val response = requestExecutor.execute(url, GraphQLClients.defaultHeaders, serializedRequest)
-        return GraphQLClients.handleResponse(response, serializedRequest, url)
+        return GraphQLClients.handleResponse(response, serializedRequest, url, customDeserializer)
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
@@ -16,12 +16,14 @@
 
 package com.netflix.graphql.dgs.client
 
+import graphql.schema.Coercing
+
 /**
  * Blocking implementation of a GraphQL client.
  * The user is responsible for doing the actual HTTP request, making this pluggable with any HTTP client.
  * For a more convenient option, use [WebClientGraphQLClient] instead.
  */
-class CustomGraphQLClient(private val url: String, private val requestExecutor: RequestExecutor, private val customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) : GraphQLClient {
+class CustomGraphQLClient(private val url: String, private val requestExecutor: RequestExecutor, private val customDeserializer: List<Coercing<*, String>>? = null) : GraphQLClient {
     override fun executeQuery(query: String): GraphQLResponse {
         return executeQuery(query, emptyMap(), null)
     }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomJsonDeserializer.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomJsonDeserializer.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+class CustomJsonDeserializer<T>(private val parse: (Any) -> Any?, vc: Class<*>) : StdDeserializer<T>(vc) {
+    override fun deserialize(jp: JsonParser, ctxt: DeserializationContext): T? {
+        val node: JsonNode = jp.codec.readTree(jp)
+        return parse(node.asText()) as T
+    }
+}

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomJsonDeserializer.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomJsonDeserializer.kt
@@ -20,10 +20,12 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import graphql.schema.Coercing
 
-class CustomJsonDeserializer<T>(private val parse: (Any) -> Any?, vc: Class<*>) : StdDeserializer<T>(vc) {
-    override fun deserialize(jp: JsonParser, ctxt: DeserializationContext): T? {
+class CustomJsonDeserializer<T>(private val deserializer: Coercing<*, String>, vc: Class<T>): StdDeserializer<T>(vc) {
+
+    override fun deserialize(jp: JsonParser, ctxt: DeserializationContext): T {
         val node: JsonNode = jp.codec.readTree(jp)
-        return parse(node.asText()) as T
+        return deserializer.parseValue(node.asText()) as T
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
@@ -23,7 +23,7 @@ import reactor.core.publisher.Mono
  * The user is responsible for doing the actual HTTP request, making this pluggable with any HTTP client.
  * For a more convenient option, use [WebClientGraphQLClient] instead.
  */
-class CustomMonoGraphQLClient(private val url: String, private val monoRequestExecutor: MonoRequestExecutor) : MonoGraphQLClient {
+class CustomMonoGraphQLClient(private val url: String, private val monoRequestExecutor: MonoRequestExecutor, private val customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) : MonoGraphQLClient {
     override fun reactiveExecuteQuery(query: String): Mono<GraphQLResponse> {
         return reactiveExecuteQuery(query, emptyMap(), null)
     }
@@ -45,7 +45,7 @@ class CustomMonoGraphQLClient(private val url: String, private val monoRequestEx
             )
         )
         return monoRequestExecutor.execute(url, GraphQLClients.defaultHeaders, serializedRequest).map { response ->
-            GraphQLClients.handleResponse(response, serializedRequest, url)
+            GraphQLClients.handleResponse(response, serializedRequest, url, customDeserializer)
         }
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.client
 
+import graphql.schema.Coercing
 import reactor.core.publisher.Mono
 
 /**
@@ -23,7 +24,7 @@ import reactor.core.publisher.Mono
  * The user is responsible for doing the actual HTTP request, making this pluggable with any HTTP client.
  * For a more convenient option, use [WebClientGraphQLClient] instead.
  */
-class CustomMonoGraphQLClient(private val url: String, private val monoRequestExecutor: MonoRequestExecutor, private val customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) : MonoGraphQLClient {
+class CustomMonoGraphQLClient(private val url: String, private val monoRequestExecutor: MonoRequestExecutor, private val customDeserializer: List<Coercing<*, String>>? = null) : MonoGraphQLClient {
     override fun reactiveExecuteQuery(query: String): Mono<GraphQLResponse> {
         return reactiveExecuteQuery(query, emptyMap(), null)
     }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.client
 
+import graphql.schema.Coercing
 import reactor.core.publisher.Mono
 
 /**
@@ -39,7 +40,7 @@ import reactor.core.publisher.Mono
  *    });
  */
 @Deprecated("This has been replaced by [CustomGraphQLClient], [CustomReactiveGraphQLClient] and [WebClientGraphQLClient]")
-class DefaultGraphQLClient(private val url: String, private val customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) : GraphQLClient, MonoGraphQLClient {
+class DefaultGraphQLClient(private val url: String, private val customDeserializer: List<Coercing<*, String>>? = null) : GraphQLClient, MonoGraphQLClient {
 
     /**
      * Executes a query and returns a GraphQLResponse.
@@ -61,7 +62,7 @@ class DefaultGraphQLClient(private val url: String, private val customDeserializ
     ): GraphQLResponse {
         val serializedRequest = GraphQLClients.objectMapper.writeValueAsString(Request(query, variables, operationName))
         val response = requestExecutor.execute(url, GraphQLClients.defaultHeaders, serializedRequest)
-        return GraphQLClients.handleResponse(response, serializedRequest, url, customDeserializer)
+        return GraphQLClients.handleResponse(response, serializedRequest, url)
     }
 
     override fun executeQuery(query: String): GraphQLResponse {

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/DefaultGraphQLClient.kt
@@ -39,7 +39,7 @@ import reactor.core.publisher.Mono
  *    });
  */
 @Deprecated("This has been replaced by [CustomGraphQLClient], [CustomReactiveGraphQLClient] and [WebClientGraphQLClient]")
-class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQLClient {
+class DefaultGraphQLClient(private val url: String, private val customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) : GraphQLClient, MonoGraphQLClient {
 
     /**
      * Executes a query and returns a GraphQLResponse.
@@ -61,7 +61,7 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
     ): GraphQLResponse {
         val serializedRequest = GraphQLClients.objectMapper.writeValueAsString(Request(query, variables, operationName))
         val response = requestExecutor.execute(url, GraphQLClients.defaultHeaders, serializedRequest)
-        return GraphQLClients.handleResponse(response, serializedRequest, url)
+        return GraphQLClients.handleResponse(response, serializedRequest, url, customDeserializer)
     }
 
     override fun executeQuery(query: String): GraphQLResponse {
@@ -151,7 +151,7 @@ class DefaultGraphQLClient(private val url: String) : GraphQLClient, MonoGraphQL
     ): Mono<GraphQLResponse> {
         val serializedRequest = GraphQLClients.objectMapper.writeValueAsString(Request(query, variables, operationName))
         return requestExecutor.execute(url, GraphQLClients.defaultHeaders, serializedRequest).map { response ->
-            GraphQLClients.handleResponse(response, serializedRequest, url)
+            GraphQLClients.handleResponse(response, serializedRequest, url, customDeserializer)
         }
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -67,7 +67,7 @@ interface GraphQLClient {
 
     companion object {
         @JvmStatic
-        fun createCustom(url: String, requestExecutor: RequestExecutor) = CustomGraphQLClient(url, requestExecutor)
+        fun createCustom(url: String, requestExecutor: RequestExecutor, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) = CustomGraphQLClient(url, requestExecutor, customDeserializer)
     }
 }
 
@@ -128,11 +128,11 @@ interface MonoGraphQLClient {
 
     companion object {
         @JvmStatic
-        fun createCustomReactive(url: String, requestExecutor: MonoRequestExecutor) = CustomMonoGraphQLClient(url, requestExecutor)
+        fun createCustomReactive(url: String, requestExecutor: MonoRequestExecutor, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) = CustomMonoGraphQLClient(url, requestExecutor, customDeserializer)
         @JvmStatic
-        fun createWithWebClient(webClient: WebClient) = WebClientGraphQLClient(webClient)
+        fun createWithWebClient(webClient: WebClient, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) = WebClientGraphQLClient(webClient, null, customDeserializer)
         @JvmStatic
-        fun createWithWebClient(webClient: WebClient, headersConsumer: Consumer<HttpHeaders>) = WebClientGraphQLClient(webClient, headersConsumer)
+        fun createWithWebClient(webClient: WebClient, headersConsumer: Consumer<HttpHeaders>, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) = WebClientGraphQLClient(webClient, headersConsumer, customDeserializer)
     }
 }
 
@@ -210,14 +210,14 @@ internal object GraphQLClients {
         "Content-type" to listOf("application/json")
     )
 
-    fun handleResponse(response: HttpResponse, requestBody: String, url: String): GraphQLResponse {
+    fun handleResponse(response: HttpResponse, requestBody: String, url: String, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null): GraphQLResponse {
         val (statusCode, body) = response
         val headers = response.headers
         if (statusCode !in 200..299) {
             throw GraphQLClientException(statusCode, url, body ?: "", requestBody)
         }
 
-        return GraphQLResponse(body ?: "", headers)
+        return GraphQLResponse(body ?: "", headers, customDeserializer)
     }
 }
 

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.client
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import graphql.schema.Coercing
 import org.springframework.http.HttpHeaders
 import org.springframework.util.ClassUtils
 import org.springframework.web.reactive.function.client.WebClient
@@ -67,7 +68,7 @@ interface GraphQLClient {
 
     companion object {
         @JvmStatic
-        fun createCustom(url: String, requestExecutor: RequestExecutor, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) = CustomGraphQLClient(url, requestExecutor, customDeserializer)
+        fun createCustom(url: String, requestExecutor: RequestExecutor, customDeserializer: List<Coercing<*, String>>? = null) = CustomGraphQLClient(url, requestExecutor, customDeserializer)
     }
 }
 
@@ -128,11 +129,11 @@ interface MonoGraphQLClient {
 
     companion object {
         @JvmStatic
-        fun createCustomReactive(url: String, requestExecutor: MonoRequestExecutor, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) = CustomMonoGraphQLClient(url, requestExecutor, customDeserializer)
+        fun createCustomReactive(url: String, requestExecutor: MonoRequestExecutor, customDeserializer: List<Coercing<*, String>>? = null) = CustomMonoGraphQLClient(url, requestExecutor, customDeserializer)
         @JvmStatic
-        fun createWithWebClient(webClient: WebClient, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) = WebClientGraphQLClient(webClient, null, customDeserializer)
+        fun createWithWebClient(webClient: WebClient, customDeserializer: List<Coercing<*, String>>? = null) = WebClientGraphQLClient(webClient, null, customDeserializer)
         @JvmStatic
-        fun createWithWebClient(webClient: WebClient, headersConsumer: Consumer<HttpHeaders>, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null) = WebClientGraphQLClient(webClient, headersConsumer, customDeserializer)
+        fun createWithWebClient(webClient: WebClient, headersConsumer: Consumer<HttpHeaders>, customDeserializer: List<Coercing<*, String>>? = null) = WebClientGraphQLClient(webClient, headersConsumer, customDeserializer)
     }
 }
 
@@ -210,7 +211,7 @@ internal object GraphQLClients {
         "Content-type" to listOf("application/json")
     )
 
-    fun handleResponse(response: HttpResponse, requestBody: String, url: String, customDeserializer: Map<Class<*>, (Any) -> Any?>? = null): GraphQLResponse {
+    fun handleResponse(response: HttpResponse, requestBody: String, url: String, customDeserializer: List<Coercing<*, String>>? = null): GraphQLResponse {
         val (statusCode, body) = response
         val headers = response.headers
         if (statusCode !in 200..299) {

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.client
 
+import graphql.schema.Coercing
 import org.springframework.http.HttpHeaders
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
@@ -31,7 +32,7 @@ import java.util.function.Consumer
  *      GraphQLResponse message = webClientGraphQLClient.reactiveExecuteQuery("{hello}").map(r -> r.extractValue<String>("hello"));
  *      message.subscribe();
  */
-class WebClientGraphQLClient(private val webclient: WebClient, private val headersConsumer: Consumer<HttpHeaders>?, private val customDeserializers: Map<Class<*>, (Any) -> Any?>? = null) : MonoGraphQLClient {
+class WebClientGraphQLClient(private val webclient: WebClient, private val headersConsumer: Consumer<HttpHeaders>?, private val customDeserializer: List<Coercing<*, String>>? = null) : MonoGraphQLClient {
 
     constructor(webclient: WebClient) : this(webclient, null, null)
     constructor(webclient: WebClient, headersConsumer: Consumer<HttpHeaders>?) : this(webclient, headersConsumer, null)
@@ -97,6 +98,6 @@ class WebClientGraphQLClient(private val webclient: WebClient, private val heade
             throw GraphQLClientException(statusCode, webclient.toString(), body ?: "", requestBody)
         }
 
-        return GraphQLResponse(body ?: "", headers, customDeserializers)
+        return GraphQLResponse(body ?: "", headers, customDeserializer)
     }
 }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
@@ -31,9 +31,11 @@ import java.util.function.Consumer
  *      GraphQLResponse message = webClientGraphQLClient.reactiveExecuteQuery("{hello}").map(r -> r.extractValue<String>("hello"));
  *      message.subscribe();
  */
-class WebClientGraphQLClient(private val webclient: WebClient, private val headersConsumer: Consumer<HttpHeaders>?) : MonoGraphQLClient {
+class WebClientGraphQLClient(private val webclient: WebClient, private val headersConsumer: Consumer<HttpHeaders>?, private val customDeserializers: Map<Class<*>, (Any) -> Any?>? = null) : MonoGraphQLClient {
 
-    constructor(webclient: WebClient) : this(webclient, null)
+    constructor(webclient: WebClient) : this(webclient, null, null)
+    constructor(webclient: WebClient, headersConsumer: Consumer<HttpHeaders>?) : this(webclient, headersConsumer, null)
+
     /**
      * @param query The query string. Note that you can use [code generation](https://netflix.github.io/dgs/generating-code-from-schema/#generating-query-apis-for-external-services) for a type safe query!
      * @return A [Mono] of [GraphQLResponse]. [GraphQLResponse] parses the response and gives easy access to data and errors.
@@ -95,6 +97,6 @@ class WebClientGraphQLClient(private val webclient: WebClient, private val heade
             throw GraphQLClientException(statusCode, webclient.toString(), body ?: "", requestBody)
         }
 
-        return GraphQLResponse(body ?: "", headers)
+        return GraphQLResponse(body ?: "", headers, customDeserializers)
     }
 }

--- a/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
+++ b/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
@@ -34,7 +34,7 @@ public class GraphQLResponseJavaTest {
     RestTemplate restTemplate = new RestTemplate();
     MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
     String url = "http://localhost:8080/graphql";
-    DefaultGraphQLClient client = new DefaultGraphQLClient(url);
+    DefaultGraphQLClient client = new DefaultGraphQLClient(url, null);
 
     RequestExecutor requestExecutor = (url, headers, body) -> {
         HttpHeaders httpHeaders = new HttpHeaders();

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClientTest.kt
@@ -51,13 +51,13 @@ class CustomGraphQLClientTest {
 
     @BeforeEach
     fun before() {
-        client = GraphQLClient.createCustom("http://localhost:$port/graphql") { url, headers, body ->
+        client = GraphQLClient.createCustom("http://localhost:$port/graphql", { url, headers, body ->
             val httpHeaders = HttpHeaders()
             headers.forEach { httpHeaders.addAll(it.key, it.value) }
 
             val exchange = restTemplate.exchange(url, HttpMethod.POST, HttpEntity(body, httpHeaders), String::class.java)
             HttpResponse(exchange.statusCodeValue, exchange.body)
-        }
+        })
     }
 
     @Test

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/CustomReactiveGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/CustomReactiveGraphQLClientTest.kt
@@ -45,7 +45,7 @@ class CustomReactiveGraphQLClientTest {
 
     @BeforeEach
     fun setup() {
-        client = MonoGraphQLClient.createCustomReactive("http://localhost:$port/graphql") { url, _, body ->
+        client = MonoGraphQLClient.createCustomReactive("http://localhost:$port/graphql", { url, _, body ->
             WebClient.create(url)
                 .post()
                 .bodyValue(body)
@@ -55,7 +55,7 @@ class CustomReactiveGraphQLClientTest {
                     r.bodyToMono(String::class.java)
                         .map { respBody -> HttpResponse(r.rawStatusCode(), respBody, r.headers().asHttpHeaders()) }
                 }
-        }
+        })
     }
 
     @Test

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ErrorsTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ErrorsTest.kt
@@ -44,7 +44,7 @@ class ErrorsTest {
     }
 
     private val url = "http://localhost:8080/graphql"
-    private val client = DefaultGraphQLClient(url)
+    private val client = DefaultGraphQLClient(url, null)
 
     @Test
     fun unknownErrorType() {

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
@@ -17,7 +17,6 @@
 package com.netflix.graphql.dgs.client
 
 import com.jayway.jsonpath.TypeRef
-import graphql.schema.CoercingParseValueException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
@@ -30,11 +29,8 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 import org.springframework.web.client.RestTemplate
-import java.time.DateTimeException
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
-import java.time.temporal.TemporalAccessor
 
 @Suppress("DEPRECATION")
 class GraphQLResponseTest {
@@ -59,10 +55,11 @@ class GraphQLResponseTest {
     }
 
     private val url = "http://localhost:8080/graphql"
-    private val client = DefaultGraphQLClient(url,
+    private val client = DefaultGraphQLClient(
+        url,
         mapOf(
             OffsetDateTime::class.java to { t -> OffsetDateTime.parse(t.toString(), DateTimeFormatter.ISO_OFFSET_DATE_TIME) },
-            Person::class.java to { t -> Person("Custom Person", 20)}
+            Person::class.java to { t -> Person("Custom Person", 20) }
         )
     )
 
@@ -336,7 +333,6 @@ class GraphQLResponseTest {
         assertThat(person.name).isEqualTo("Custom Person")
         server.verify()
     }
-
 }
 
 data class Person(val name: String, val age: Int)

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
@@ -47,7 +47,7 @@ class WebClientGraphQLClientTest {
 
     @BeforeEach
     fun setup() {
-        client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql"))
+        client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql"), null)
     }
 
     @Test
@@ -61,9 +61,9 @@ class WebClientGraphQLClientTest {
 
     @Test
     fun `Extra header can be provided`() {
-        client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql")) { headers ->
+        client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql"), { headers ->
             headers.add("myheader", "test")
-        }
+        })
         val result = client.reactiveExecuteQuery("{withHeader}").map { r -> r.extractValue<String>("withHeader") }
 
         StepVerifier.create(result)


### PR DESCRIPTION
Pull request checklist
----

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This feature allows the user to set custom deserializers for processing the GraphQLResponse. We have had many requests to allow custom mappers to be injected since users would like to add modules for processing custom types such as DateTime etc. Rather than exposing the jackson object mapper in the interface, we expose a more generic abstraction. The user can now provide the deserializer as a lambda that the framework configures in the internal jackson mapper. 

The same mechanism will work for any custom scalars that implement Coercing<*, *>. The parseValue method can be set as the custom deserializers in this scenario.

Here is a code snippet from the tests showing the usage where the second argument represents the map of custom deserializers:
```
private val client = DefaultGraphQLClient(url,
        mapOf(
            OffsetDateTime::class.java to { t -> OffsetDateTime.parse(t.toString(), DateTimeFormatter.ISO_OFFSET_DATE_TIME) },
            Person::class.java to { t -> Person("Custom Person", 20)}
        )
    )
```
Alternatives considered
----
We considered allowing the user to inject their own  jackson object mapper in the GraphQLClient interface for customization
. Since this would couple the framework tightly with the  Jackson mapper, we opted to expose a more generic abstraction.
