### PR TITLE
Update compile only dependency on webclient to implementation.

### DIFF
--- a/dependencies.lock
+++ b/dependencies.lock
@@ -195,11 +195,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations")
     api(project(":graphql-dgs-subscription-types"))
 
-    compileOnly("org.springframework:spring-webflux")
+    implementation("org.springframework:spring-webflux")
 
     implementation("org.springframework:spring-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -32,10 +32,16 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.12.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.12.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -257,11 +263,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
@@ -289,10 +290,16 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.12.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.12.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -342,6 +349,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "5.2.13.RELEASE"
         }
     },
     "testAnnotationProcessor": {
@@ -371,10 +381,16 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.12.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.12.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -500,6 +516,9 @@
         },
         "org.springframework:spring-web": {
             "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "5.2.13.RELEASE"
         }
     },
     "testRuntimeClasspath": {
@@ -515,6 +534,9 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -527,6 +549,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.12.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -727,6 +752,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure"
             ],
+            "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
             "locked": "5.2.13.RELEASE"
         },
         "org.springframework:spring-webmvc": {

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -344,11 +344,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
@@ -389,6 +384,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -403,6 +404,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -627,6 +634,7 @@
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
@@ -831,6 +839,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -845,6 +859,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -1075,6 +1095,7 @@
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -350,11 +350,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
@@ -395,6 +390,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -408,6 +409,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -653,6 +660,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+            ],
+            "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "5.2.13.RELEASE"
         },
@@ -880,6 +893,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -893,6 +912,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -1151,6 +1176,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+            ],
+            "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "5.2.13.RELEASE"
         },

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -292,11 +292,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -263,11 +263,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
@@ -597,6 +592,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -609,6 +610,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -816,6 +823,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "5.2.13.RELEASE"
         },

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -227,11 +227,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -260,11 +260,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -269,11 +269,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -125,7 +125,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.2"
+            "locked": "1.0.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -348,11 +348,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
@@ -442,7 +437,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.2"
+            "locked": "1.0.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -636,7 +631,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.2"
+            "locked": "1.0.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -712,6 +707,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -724,6 +725,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -826,7 +833,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.2"
+            "locked": "1.0.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -946,6 +953,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "5.2.13.RELEASE"
         },

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -272,11 +272,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -316,11 +316,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
@@ -355,6 +350,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -367,6 +368,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -542,6 +549,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "5.2.13.RELEASE"
         },
@@ -716,6 +729,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -728,6 +747,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -909,6 +934,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-webflux": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "5.2.13.RELEASE"
         },

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -274,11 +274,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -275,11 +275,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -269,11 +269,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -224,11 +224,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -271,11 +271,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -278,11 +278,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -283,11 +283,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -281,11 +281,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -321,11 +321,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"
@@ -360,6 +355,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -374,6 +375,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -555,6 +562,7 @@
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
@@ -730,6 +738,12 @@
             ],
             "locked": "2.12.3"
         },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
+            ],
+            "locked": "2.12.3"
+        },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -744,6 +758,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ],
+            "locked": "2.12.3"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "2.12.3"
         },
@@ -931,6 +951,7 @@
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -269,11 +269,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -224,11 +224,6 @@
             "locked": "5.2.13.RELEASE"
         }
     },
-    "ktlint": {
-        "com.pinterest:ktlint": {
-            "locked": "0.40.0"
-        }
-    },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.3"


### PR DESCRIPTION
Pull Request type
----

- [x ] Bugfix


Changes in this PR
----
With the introduction of the GraphQlClients to create graphql client instances, we have references to the WebClient. Since this was previously a compile only dependency, the user had to add webclient explicitly to their dependencies. This PR fixes that by adding it to the graphql client module instead.


