### PR TITLE
 moving private JacksonObjectMapper into companion object to establish compatibility with CGLIB proxying

### DIFF
--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
@@ -35,8 +35,6 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 open class DgsRestSchemaJsonController(open val schemaProvider: DgsSchemaProvider) {
 
-    private val mapper = jacksonObjectMapper()
-
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
     @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.schemaJson.path}", produces = ["application/json"])
     fun schema(): String {
@@ -48,5 +46,9 @@ open class DgsRestSchemaJsonController(open val schemaProvider: DgsSchemaProvide
         val execute: ExecutionResult = graphQL.execute(executionInput)
 
         return mapper.writeValueAsString(execute.toSpecification())
+    }
+
+    companion object {
+        private val mapper = jacksonObjectMapper()
     }
 }

--- a/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
+++ b/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
@@ -43,7 +43,6 @@ import java.util.*
  */
 @RestController
 open class DgsSSESubscriptionHandler(open val dgsQueryExecutor: DgsQueryExecutor) {
-    private val mapper = jacksonObjectMapper()
 
     @RequestMapping("/subscriptions", produces = ["text/event-stream"])
     fun subscriptionWithId(@RequestParam("query") queryBase64: String): ResponseEntity<SseEmitter> {
@@ -152,6 +151,7 @@ open class DgsSSESubscriptionHandler(open val dgsQueryExecutor: DgsQueryExecutor
     )
 
     companion object {
+        private val mapper = jacksonObjectMapper()
         private val logger: Logger = LoggerFactory.getLogger(DgsSSESubscriptionHandler::class.java)
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Follow-up on [PR#275](https://github.com/Netflix/dgs-framework/pull/275) and [PR#428](https://github.com/Netflix/dgs-framework/pull/428) which were opened by my colleague @lucatk.

Since with version [v4.5.1](https://github.com/Netflix/dgs-framework/releases/tag/v4.5.1) a [fix was introduced to `Avoid instantiating Jackson mappers per request`](https://github.com/Netflix/dgs-framework/pull/501) we are encountering again the issue that the `@RestController`s `DgsRestSchemaJsonController` and `DgsSSESubscriptionHandler` are not working when provided as a CGLIB proxied bean in our enterprise application since their `mapper`s are null as soon as they are provided as a CGLIB proxied bean.

This PR moves the mapper class fields into companion objects (thanks, @berngp). This should not affect any business logic or the like. Since these classes are already documented to actually be inner APIs and extending should not be performed, i don't see the need for any more communication regarding this issue on those classes.

This PR was opened with the understanding that this issue was addressed in the past as well as based on the [caring and understanding statement from @paulbakker](https://github.com/Netflix/dgs-framework/pull/275#issuecomment-821585665) on one of the related, previous PRs. 

Alternatives considered
----
What i could see in the future is the usage of the [`kotlin-allopen` plugin](https://kotlinlang.org/docs/all-open-plugin.html) especially its [`kotlin-spring` plugin that focuses on opening just the classes that are annotated with selected org.springframework annotations when compiling](https://kotlinlang.org/docs/all-open-plugin.html#spring-support). 

This might make it easier to follow the kotlin paradigms without interfering with compatibility regarding established java ecosystem frameworks and approaches. 

But this will not remove the need to communicate that openly provided classes should not be extended since they are open for CGLIB compatibility and not being actual public APIs of this framework.

I tried to incorporate the plugin into this project but i have not much expertise in kotlin, gradle and this projects build setup and i don't think me as a extern contributor would have a chance to incorporate it without breaking a lot of things. 

Acknowledgement
----
Thank you for considering this PR and thank you for this amazing framework which tremendously helps to provide a solid GraphQL API with minimal effort when utilized in a Spring Boot Application context!