### PR TITLE
Introduce a CONFLICT error detail catered for mutations.

### DIFF
--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/ErrorDetail.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/ErrorDetail.java
@@ -121,6 +121,17 @@ public interface ErrorDetail extends ErrorClassification {
          */
         MISSING_RESOURCE(FAILED_PRECONDITION),
 
+        /**
+         * Indicates the operation conflicts with the current state of the target resource.
+         * Conflicts are most likely to occur in the context of a mutation.
+         * <p>
+         * For example, you may get a CONFLICT when writing a field with a reference value that is
+         * older than the one already on the server, resulting in a version control conflict.
+         * <p>
+         * HTTP Mapping: 409 Conflict.
+         * Error Type: FAILED_PRECONDITION
+         */
+        CONFLICT(FAILED_PRECONDITION),
 
         /**
          * Service Error.

--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
@@ -226,6 +226,13 @@ public class TypedGraphQLError implements GraphQLError {
         return new Builder().errorType(ErrorType.BAD_REQUEST);
     }
 
+    /**
+     * Create new Builder instance to further customize an error that results in a {@link ErrorDetail.Common#CONFLICT conflict}.
+     * @return A new TypedGraphQLError.Builder instance to further customize the error. Pre-sets {@link ErrorDetail.Common#CONFLICT}.
+     */
+    public static Builder newConflictBuilder() {
+        return new Builder().errorDetail(ErrorDetail.Common.CONFLICT);
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Indicates the operation conflicts with the current state of the target resource.
Conflicts are most likely to occur in the context of a mutation.

For example, you may get a CONFLICT when writing a field with a reference value that is
older than the one already on the server, resulting in a version control conflict.

HTTP Mapping: 409 Conflict.
Error Type: FAILED_PRECONDITION
