### PR TITLE
override equals method for TypedGraphQLError 

### DIFF
--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
@@ -244,6 +244,22 @@ public class TypedGraphQLError implements GraphQLError {
                 '}';
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null) return false;
+        if (obj.getClass() != this.getClass()) return false;
+
+        TypedGraphQLError e = (TypedGraphQLError)obj;
+
+        if (!message.equals(e.message)) return false;
+        if (!locations.equals(e.locations)) return false;
+        if (!path.equals(e.path)) return false;
+        if (!extensions.equals(e.extensions)) return false;
+
+        return true;
+    }
+
     public static class Builder {
         private String message;
         private List<Object> path;

--- a/graphql-error-types/src/test/java/com/netflix/graphql/types/errors/TypedGraphQLErrorTest.java
+++ b/graphql-error-types/src/test/java/com/netflix/graphql/types/errors/TypedGraphQLErrorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.types.errors;
+
+import graphql.execution.ResultPath;
+import graphql.language.SourceLocation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+public class TypedGraphQLErrorTest {
+    @Test
+    void equalsTest() {
+        TypedGraphQLError baseError = TypedGraphQLError.newPermissionDeniedBuilder()
+                .message("org.springframework.security.access.AccessDeniedException: Access is denied")
+                .path(ResultPath.parse("/graphqlEndpoint"))
+                .build();
+
+        TypedGraphQLError sameError = TypedGraphQLError.newPermissionDeniedBuilder()
+                .message("org.springframework.security.access.AccessDeniedException: Access is denied")
+                .path(ResultPath.parse("/graphqlEndpoint"))
+                .build();
+
+        Assertions.assertEquals(baseError, sameError);
+    }
+
+    @Test
+    void notEqualsTest() {
+        TypedGraphQLError baseError = TypedGraphQLError.newPermissionDeniedBuilder()
+                .message("org.springframework.security.access.AccessDeniedException: Access is denied")
+                .path(ResultPath.parse("/graphqlEndpoint"))
+                .build();
+
+        TypedGraphQLError differentMessageError = TypedGraphQLError.newPermissionDeniedBuilder()
+                .message("Different Error Message")
+                .path(ResultPath.parse("/graphqlEndpoint"))
+                .build();
+
+        Assertions.assertNotEquals(baseError, differentMessageError);
+
+        TypedGraphQLError differentLocationsError = TypedGraphQLError.newPermissionDeniedBuilder()
+                .message("Different Error Message")
+                .location(new SourceLocation(0, 0))
+                .path(ResultPath.parse("/graphqlEndpoint"))
+                .build();
+
+        Assertions.assertNotEquals(baseError, differentLocationsError);
+
+        TypedGraphQLError differentPathError = TypedGraphQLError.newPermissionDeniedBuilder()
+                .message("org.springframework.security.access.AccessDeniedException: Access is denied")
+                .path(ResultPath.parse("/differentGraphQlEndpoint"))
+                .build();
+
+        Assertions.assertNotEquals(baseError, differentPathError);
+
+        TypedGraphQLError differentExtensionsError = TypedGraphQLError.newPermissionDeniedBuilder()
+                .message("org.springframework.security.access.AccessDeniedException: Access is denied")
+                .path(ResultPath.parse("/differentGraphQlEndpoint"))
+                .extensions(new HashMap<String, Object>() {{
+                    put("key", "value");
+                }})
+                .build();
+
+        Assertions.assertNotEquals(baseError, differentExtensionsError);
+    }
+}


### PR DESCRIPTION
Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Closes https://github.com/Netflix/dgs-framework/issues/700
cc @srinivasankavitha 

Overrides the default equals method to compare `TypedGraphQLErrors` using the same fields outputted when `toString()` is called. This is helpful for users of the framework in their test environments and ensuring that error responses are semantically equal without needing to call `toString()` first. 
 
Alternatives considered
----

_Describe alternative implementation you have considered_

