### PR TITLE
Some SSE Clients particular on having this constant upper-cased

### DIFF
--- a/graphql-dgs-subscription-types/src/main/kotlin/com/netflix/graphql/types/subscription/OperationMessage.kt
+++ b/graphql-dgs-subscription-types/src/main/kotlin/com/netflix/graphql/types/subscription/OperationMessage.kt
@@ -34,7 +34,7 @@ const val GQL_CONNECTION_TERMINATE = "connection_terminate"
 const val GQL_CONNECTION_KEEP_ALIVE = "ka"
 
 /** Used only when expressing the data type for SSE Subscriptions. */
-const val SSE_GQL_SUBSCRIPTION_DATA = "subscription_data"
+const val SSE_GQL_SUBSCRIPTION_DATA = "SUBSCRIPTION_DATA"
 
 data class OperationMessage(
     @JsonProperty("type")


### PR DESCRIPTION
Changing to `SUBSCRIPTION_DATA`, upper-cased, since some clients are matching the exact string.
