### PR TITLE
fix : enable to set dgs.graphql.graphiql.path in webflux

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -36,6 +36,7 @@ import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.introspection.IntrospectionQuery
 import graphql.schema.GraphQLSchema
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -43,6 +44,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
+import org.springframework.core.io.Resource
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.server.RequestPredicates.accept
 import org.springframework.web.reactive.function.server.RouterFunction
@@ -111,10 +113,15 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
 
     @Bean
     @ConditionalOnProperty(name = ["dgs.graphql.graphiql.enabled"], havingValue = "true", matchIfMissing = true)
-    open fun graphiQlIndexRedirect(): RouterFunction<ServerResponse> {
-        return RouterFunctions.route().GET("/graphiql") {
-            permanentRedirect(URI.create("/graphiql/index.html")).build()
-        }.build()
+    open fun graphiQlIndexRedirect(@Value("classpath:/static/graphiql/index.html") indexHtml: Resource): RouterFunction<ServerResponse> {
+        return RouterFunctions.route()
+            .GET(configProps.graphiql.path) {
+                permanentRedirect(URI.create(configProps.graphiql.path + "/index.html")).build()
+            }
+            .GET(configProps.graphiql.path + "/index.html") {
+                ok().bodyValue(indexHtml)
+            }
+            .build()
     }
 
     @Bean

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebfluxConfigurationProperties.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebfluxConfigurationProperties.kt
@@ -28,8 +28,16 @@ import javax.annotation.PostConstruct
 class DgsWebfluxConfigurationProperties(
     /** Path to the endpoint that will serve GraphQL requests. */
     @DefaultValue("/graphql") var path: String = "/graphql",
+    @NestedConfigurationProperty var graphiql: DgsGraphiQLConfigurationProperties = DgsGraphiQLConfigurationProperties(),
     @NestedConfigurationProperty var schemaJson: DgsSchemaJsonConfigurationProperties = DgsSchemaJsonConfigurationProperties()
 ) {
+    /**
+     * Configuration properties for the GraphiQL endpoint.
+     */
+    data class DgsGraphiQLConfigurationProperties(
+        /** Path to the GraphiQL endpoint without trailing slash. */
+        @DefaultValue("/graphiql") var path: String = "/graphiql"
+    )
     /**
      * Configuration properties for the schema-json endpoint.
      */
@@ -41,6 +49,7 @@ class DgsWebfluxConfigurationProperties(
     @PostConstruct
     fun validatePaths() {
         validatePath(this.path, "dgs.graphql.path")
+        validatePath(this.graphiql.path, "dgs.graphql.graphiql.path")
         validatePath(this.schemaJson.path, "dgs.graphql.schema-json.path")
     }
 

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphiQlCustomEndpoint.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphiQlCustomEndpoint.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webflux.autoconfiguration
+
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.config.EnableWebFlux
+
+@AutoConfigureWebTestClient
+@EnableWebFlux
+@SpringBootTest(
+    classes = [DgsWebFluxAutoConfiguration::class, DgsAutoConfiguration::class, WebRequestTestWithCustomEndpoint.ExampleImplementation::class],
+    properties = ["dgs.graphql.graphiql.path=/coustomEndpoint"]
+)
+class GraphiQlCustomEndpoint {
+    @Autowired
+    lateinit var webTestClient: WebTestClient
+
+    @Test
+    fun customGraphiQlPathRedirect() {
+        webTestClient.get().uri("/coustomEndpoint")
+            .exchange()
+            .expectStatus()
+            .is3xxRedirection
+    }
+
+    @Test
+    fun customGraphiQlPath() {
+        webTestClient.get().uri("/coustomEndpoint/index.html")
+            .exchange()
+            .expectStatus()
+            .is2xxSuccessful
+    }
+}

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
@@ -35,7 +35,7 @@ data class DgsWebMvcConfigurationProperties(
     @NestedConfigurationProperty var schemaJson: DgsSchemaJsonConfigurationProperties = DgsSchemaJsonConfigurationProperties()
 ) {
     /**
-     * Configuration properties for the schema-json endpoint.
+     * Configuration properties for the GraphiQL endpoint.
      */
     data class DgsGraphiQLConfigurationProperties(
         /** Path to the GraphiQL endpoint without trailing slash. */


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
`dgs.graphql.graphiql.path`(https://netflix.github.io/dgs/configuration/) configuration does not work in webflux 


Alternatives considered
----
- add graphiql path property in DgsWebfluxConfigurationProperties
- change the redirect path to 'dgs.graphql.graphiql.path' + /index.html
- 'dgs.graphql.graphiql.path'+/index.html path request is return the "classpath:/static/graphiql/index.html" resource
- add custom path test case
