### PR TITLE
DefaultDgsFederationResolver now handles failed completion stages ret…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ build
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
 .idea/**/dbnavigator.xml
+.idea/**/runConfigurations.xml
+.idea/**/aws.xml
 
 # Gradle
 .idea/**/gradle.xml

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -24,11 +24,14 @@ import com.netflix.graphql.dgs.exceptions.InvalidDgsEntityFetcher
 import com.netflix.graphql.dgs.exceptions.MissingDgsEntityFetcherException
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.types.errors.TypedGraphQLError
-import graphql.GraphQLError
-import graphql.execution.*
+import graphql.execution.DataFetcherExceptionHandler
+import graphql.execution.DataFetcherExceptionHandlerParameters
+import graphql.execution.DataFetcherResult
+import graphql.execution.ResultPath
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.TypeResolver
+import org.dataloader.Try
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -46,7 +49,10 @@ open class DefaultDgsFederationResolver() :
      * This is the most common use case.
      * The default constructor is used to extend the DefaultDgsFederationResolver. In that case injection is used to provide the schemaProvider.
      */
-    constructor(providedDgsSchemaProvider: DgsSchemaProvider, dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler>) : this() {
+    constructor(
+        providedDgsSchemaProvider: DgsSchemaProvider,
+        dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler>
+    ) : this() {
         dgsSchemaProvider = providedDgsSchemaProvider
         dgsExceptionHandler = dataFetcherExceptionHandler
     }
@@ -68,10 +74,9 @@ open class DefaultDgsFederationResolver() :
     }
 
     private fun dgsEntityFetchers(env: DataFetchingEnvironment): CompletableFuture<DataFetcherResult<List<Any?>>> {
-        val errorsList = mutableListOf<GraphQLError>()
         val resultList = env.getArgument<List<Map<String, Any>>>(_Entity.argumentName)
             .map { values ->
-                try {
+                Try.tryCall {
                     val typename = values["__typename"]
                         ?: throw RuntimeException("__typename missing from arguments in federated query")
                     val fetcher = dgsSchemaProvider.entityFetchers[typename]
@@ -96,39 +101,50 @@ open class DefaultDgsFederationResolver() :
                     } else {
                         CompletableFuture.completedFuture(result)
                     }
-                } catch (e: Exception) {
-                    if (e is InvocationTargetException && e.targetException != null) {
-                        if (dgsExceptionHandler.isPresent) {
-                            val res = dgsExceptionHandler.get().onException(
-                                DataFetcherExceptionHandlerParameters.newExceptionParameters()
-                                    .dataFetchingEnvironment(env).exception(e.targetException).build()
-                            )
-                            res.errors.forEach { errorsList.add(it) }
-                        } else {
-                            errorsList.add(
-                                TypedGraphQLError.newInternalErrorBuilder()
-                                    .message("%s: %s", e.targetException::class.java.name, e.targetException.message)
-                                    .path(ResultPath.parse("/_entities")).build()
-                            )
-                        }
-                    } else {
-                        errorsList.add(
-                            TypedGraphQLError.newInternalErrorBuilder().message("%s: %s", e::class.java.name, e.message)
-                                .path(ResultPath.parse("/_entities")).build()
-                        )
-                    }
-                    CompletableFuture.completedFuture(null)
                 }
+                    .map { tryFuture -> Try.tryFuture(tryFuture) }
+                    .recover { exception -> CompletableFuture.completedFuture(Try.failed(exception)) }
+                    .get()
             }
 
         return CompletableFuture.allOf(*resultList.toTypedArray()).thenApply {
-            DataFetcherResult.newResult<List<Any?>>().data(
-                resultList.asSequence()
-                    .map { cf -> cf.join() }
-                    .flatMap { r -> if (r is Collection<*>) r.asSequence() else sequenceOf(r) }
-                    .toList()
-            )
-                .errors(errorsList)
+            DataFetcherResult.newResult<List<Any?>>()
+                .data(
+                    resultList.asSequence()
+                        .map { cf -> cf.join() }
+                        .map { tryResult -> tryResult.orElse(null) }
+                        .flatMap { r -> if (r is Collection<*>) r.asSequence() else sequenceOf(r) }
+                        .toList()
+                )
+                .errors(
+                    resultList.asSequence()
+                        .map { cf -> cf.join() }
+                        .filter { tryResult -> tryResult.isFailure }
+                        .map { tryResult -> tryResult.throwable }
+                        .flatMap { e ->
+                            if (e is InvocationTargetException && e.targetException != null) {
+                                if (dgsExceptionHandler.isPresent) {
+                                    val res = dgsExceptionHandler.get().onException(
+                                        DataFetcherExceptionHandlerParameters.newExceptionParameters()
+                                            .dataFetchingEnvironment(env).exception(e.targetException).build()
+                                    )
+                                    res.errors.asSequence()
+                                } else {
+                                    sequenceOf(
+                                        TypedGraphQLError.newInternalErrorBuilder()
+                                            .message("%s: %s", e.targetException::class.java.name, e.targetException.message)
+                                            .path(ResultPath.parse("/_entities")).build()
+                                    )
+                                }
+                            } else {
+                                sequenceOf(
+                                    TypedGraphQLError.newInternalErrorBuilder().message("%s: %s", e::class.java.name, e.message)
+                                        .path(ResultPath.parse("/_entities")).build()
+                                )
+                            }
+                        }
+                        .toList()
+                )
                 .build()
         }
     }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsFederationResolverTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsFederationResolverTest.kt
@@ -238,6 +238,36 @@ class DgsFederationResolverTest {
     }
 
     @Test
+    fun dgsEntityFetcherWithFailedCompletableFuture() {
+
+        val movieEntityFetcher = object {
+            @DgsEntityFetcher(name = "Movie")
+            fun movieEntityFetcher(values: Map<String, Any>): CompletableFuture<Movie> {
+                return CompletableFuture.supplyAsync {
+                    if (values["movieId"] == "invalid") {
+                        throw DgsInvalidInputArgumentException("Invalid input argument exception")
+                    }
+
+                    Movie(values["movieId"].toString())
+                }
+            }
+        }
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(Pair("MovieEntityFetcher", movieEntityFetcher))
+        dgsSchemaProvider.schema("""type Query {}""")
+
+        val arguments = mapOf<String, Any>(Pair(_Entity.argumentName, listOf(mapOf(Pair("__typename", "Movie"), Pair("movieId", "invalid")))))
+        val executionStepInfo = ExecutionStepInfo.newExecutionStepInfo().path(ResultPath.parse("/_entities")).type(GraphQLList.list(GraphQLUnionType.newUnionType().name("Entity").possibleTypes(GraphQLObjectType.newObject().name("Movie").build()).build())).build()
+        val dataFetchingEnvironment = DgsDataFetchingEnvironment(DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).executionStepInfo(executionStepInfo).build())
+        val result = (DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler)).entitiesFetcher().get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>)
+        assertThat(result).isNotNull
+        assertThat(result.get().data.size).isEqualTo(1)
+        assertThat(result.get().errors.size).isEqualTo(1)
+        assertThat(result.get().errors[0].message).contains("DgsInvalidInputArgumentException")
+    }
+
+    @Test
     fun dgsEntityFetcherWithIllegalArgumentException() {
 
         val movieEntityFetcher = object {


### PR DESCRIPTION
…urned from entity fetchers properly

Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [X] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [X] Make sure the PR doesn't introduce backward compatibility issues
- [X] Make sure to have sufficient test cases

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #726 

It allows the DefaultDgsFederationResolver to properly handle exceptions thrown by failed completable futures.

I used the dataloader Try object to ease the handling of exception and to make sure to have a single path of execution for exceptions thrown in the entity fetcher body and also the exceptions thrown by failed completable futures. That's why the whole call to each entity fetchers are wrapped in Try.tryCallable (to handle exceptions thrown directly in the entity fetcher) and then unwrapped when combined with the result of the CompletableFuture (to handle exceptions thrown by a failed completable future).

I added a new tests to check that this use case now works.