### PR TITLE
Missing the typename in a federated query should return a BadRequest

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
@@ -40,13 +40,16 @@ class DefaultDataFetcherExceptionHandler : DataFetcherExceptionHandler {
                 .message("%s: %s", exception::class.java.name, exception.message)
                 .path(handlerParameters.path).build()
         } else if (exception is DgsEntityNotFoundException) {
-            TypedGraphQLError.newNotFoundBuilder().message("%s: %s", exception::class.java.name, exception.message)
+            TypedGraphQLError.newNotFoundBuilder()
+                .message("%s: %s", exception::class.java.name, exception.message)
                 .path(handlerParameters.path).build()
         } else if (exception is DgsBadRequestException) {
-            TypedGraphQLError.newBadRequestBuilder().message("%s: %s", exception::class.java.name, exception.message)
+            TypedGraphQLError.newBadRequestBuilder()
+                .message("%s: %s", exception::class.java.name, exception.message)
                 .path(handlerParameters.path).build()
         } else {
-            TypedGraphQLError.newInternalErrorBuilder().message("%s: %s", exception::class.java.name, exception.message)
+            TypedGraphQLError.newInternalErrorBuilder()
+                .message("%s: %s", exception::class.java.name, exception.message)
                 .path(handlerParameters.path).build()
         }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/MissingFederatedQueryArgument.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/MissingFederatedQueryArgument.kt
@@ -16,4 +16,4 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-open class DgsBadRequestException(override val message: String = "Malformed or incorrect request") : RuntimeException(message)
+class MissingFederatedQueryArgument(vararg fields: String) : DgsBadRequestException("The federated query is missing field(s) ${fields.joinToString()}")

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsFederationResolverTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsFederationResolverTest.kt
@@ -142,7 +142,8 @@ class DgsFederationResolverTest {
         assertThat(result).isNotNull
         assertThat(result.get().data.size).isEqualTo(1)
         assertThat(result.get().errors.size).isEqualTo(1)
-        assertThat(result.get().errors[0].message).contains("RuntimeException")
+        assertThat(result.get().errors.first().message)
+            .endsWith("MissingFederatedQueryArgument: The federated query is missing field(s) __typename")
     }
 
     @Test


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

When a _Federated Request_ is missing the `_typename` we should return an exception that can properly be matched to a _client generated bad request_. This is particularly relevant when the kind of error is used to identify, via metrics for example, if the error is associated with the client or internal to the server.