### PR TITLE
Tune Gradle to make our builds much faster

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,8 @@
 #
 systemProp.nebula.features.coreBomSupport=true
 kotlin.code.style=official
+
+org.gradle.caching = true
+org.gradle.parallel = true
+# org.gradle.configureondemand = true
+org.gradle.vfs.watch = true


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
* `org.gradle.parallel`: Enabling parallel builds makes the build considerably faster, that said, we need to make sure tests don't depend on each other, which should be already the case.

* `org.gradle.vfs.watch`: Since Gradle 6.5, avoids unnecessary I/O.

* `org.gradle.caching`: Shared caches can reduce the number of tasks we need to execute by reusing outputs already generated. This can significantly decrease build times but we need to make sure our tests do not depend on other external services, which is already the case.
