### PR TITLE
refactor: Added util function jsonTypeRef for simplification of TypeR…

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -49,7 +49,7 @@ data class GraphQLResponse(val json: String, val headers: Map<String, List<Strin
      */
 
     val data: Map<String, Any> = parsed.read("data") ?: emptyMap()
-    val errors: List<GraphQLError> = parsed.read("errors", object : TypeRef<List<GraphQLError>>() {}) ?: emptyList()
+    val errors: List<GraphQLError> = parsed.read("errors", jsonTypeRef<List<GraphQLError>>() ) ?: emptyList()
 
     constructor(json: String) : this(json, emptyMap())
 
@@ -136,3 +136,5 @@ data class GraphQLResponse(val json: String, val headers: Map<String, List<Strin
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class RequestDetails(val requestId: String?, val edgarLink: String?)
+
+inline fun <reified T> jsonTypeRef(): TypeRef<T> = object: TypeRef<T>() {}

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -49,7 +49,7 @@ data class GraphQLResponse(val json: String, val headers: Map<String, List<Strin
      */
 
     val data: Map<String, Any> = parsed.read("data") ?: emptyMap()
-    val errors: List<GraphQLError> = parsed.read("errors", jsonTypeRef<List<GraphQLError>>() ) ?: emptyList()
+    val errors: List<GraphQLError> = parsed.read("errors", jsonTypeRef<List<GraphQLError>>()) ?: emptyList()
 
     constructor(json: String) : this(json, emptyMap())
 
@@ -137,4 +137,4 @@ data class GraphQLResponse(val json: String, val headers: Map<String, List<Strin
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class RequestDetails(val requestId: String?, val edgarLink: String?)
 
-inline fun <reified T> jsonTypeRef(): TypeRef<T> = object: TypeRef<T>() {}
+inline fun <reified T> jsonTypeRef(): TypeRef<T> = object : TypeRef<T>() {}

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClient.kt
@@ -16,8 +16,8 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.netflix.graphql.types.subscription.*
 import graphql.GraphQLException
 import org.springframework.web.reactive.socket.WebSocketMessage
@@ -263,7 +263,7 @@ class OperationMessageWebSocketClient(
 
     private fun decodeMessage(message: WebSocketMessage): OperationMessage {
         val messageText = message.payloadAsText
-        val type = object : TypeReference<OperationMessage>() {}
+        val type = jacksonTypeRef<OperationMessage>()
 
         return MAPPER.readValue(messageText, type)
     }

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.jayway.jsonpath.TypeRef
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
@@ -184,9 +183,9 @@ class GraphQLResponseTest {
             emptyMap(), requestExecutor
         )
 
-        val listOfSubmittedBy: List<String> = graphQLResponse.extractValueAsObject(
+        val listOfSubmittedBy = graphQLResponse.extractValueAsObject(
             "submitReview.edges[*].node.submittedBy",
-            object : TypeRef<List<String>>() {}
+            jsonTypeRef<List<String>>()
         )
         assertThat(listOfSubmittedBy).isInstanceOf(ArrayList::class.java)
         assertThat(listOfSubmittedBy.size).isEqualTo(2)

--- a/graphql-dgs-subscription-types/src/test/kotlin/OperationMessageTest.kt
+++ b/graphql-dgs-subscription-types/src/test/kotlin/OperationMessageTest.kt
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.netflix.graphql.types.subscription.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -76,7 +76,7 @@ class OperationMessageTest {
     }
 
     private fun deserialize(message: String) =
-        MAPPER.readValue(message, object : TypeReference<OperationMessage>() {})
+        MAPPER.readValue(message, jacksonTypeRef<OperationMessage>())
 
     companion object {
         val MAPPER = jacksonObjectMapper()


### PR DESCRIPTION
…ef creation (added to examples as well)

Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [X] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [X] Make sure the PR doesn't introduce backward compatibility issues
- [X] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Before:
``` kotlin
dgsQueryExecutor.executeAndExtractJsonPathAsObject<List<User>>(
    graphQLQueryRequest.serialize(),
    "data.users[*]",
    object: TypeRef<List<User>>() {}
)
```

After
``` kotlin
dgsQueryExecutor.executeAndExtractJsonPathAsObject<List<User>>(
    graphQLQueryRequest.serialize(),
    "data.users[*]",
    jsonTypeRef()
)
```

Added util function `jsonTypeRef` (works the same as Jackson's `jacksonTypeRef`)

I know it's better suited to put it in `com.jayway.jsonpath` directly, but unfortunately it's Java project and they won't accept kotlin functions.

Anyway I think `jsonTypeRef()` is better than this   `object: TypeRef<List<User>>() {}`

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_

I can see some usages inside `graphql-dgs` module. Maybe it makes sense to create `graphql-dgs-common` to reuse it around.

