### PR TITLE
BOM now requires graphql-java-extended-validation:17.0-hibernate-validator-6.2.0.Final

### DIFF
--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -54,6 +54,11 @@ dependencies {
         api("com.apollographql.federation:federation-graphql-java-support") {
             version { require(Versions.GRAPHQL_JAVA_FEDERATION) }
         }
+        api("com.graphql-java:graphql-java-extended-validation"){
+            // The version below will work with Jakarta EE 8
+            // and use Hibernate Validator 6.2.
+            version { require("17.0-hibernate-validator-6.2.0.Final") }
+        }
         api("com.jayway.jsonpath:json-path") {
             version { require("2.6.0") }
         }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

The folks that maintain the graphql-java-extended-validation library were kind enough to provide a version of the library that is compatible with JEE 8 and Hibernate Validator 6.2 which are compatible with Spring Boot 2.x.

Note that Spring Boot 3.0 will move to JEE 9.

Ref:
https://github.com/graphql-java/graphql-java-extended-validation/issues/52