### PR TITLE
Pin graphiql to the latest known working version to avoid unexpected new issues.

### DIFF
--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/static/graphiql/index.html
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/static/graphiql/index.html
@@ -17,7 +17,7 @@
 <html>
 <head>
     <title>Simple GraphiQL Example</title>
-    <link href="https://unpkg.com/graphiql/graphiql.min.css" rel="stylesheet" />
+    <link href="https://unpkg.com/graphiql@1.5.12/graphiql.min.css" rel="stylesheet" />
 </head>
 <body style="margin: 0;">
 <div id="graphiql" style="height: 100vh;"></div>
@@ -32,7 +32,7 @@
 ></script>
 <script
         crossorigin
-        src="https://unpkg.com/graphiql/graphiql.min.js"
+        src="https://unpkg.com/graphiql@1.5.12/graphiql.min.js"
 ></script>
 
 <script>


### PR DESCRIPTION



Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ x] Other (please describe):

Changes in this PR
----
This PR addresses issue #770 caused by pulling in latest release that was incompatible for graphql versions < 16. By pinning we can control when we want to update the version.

_Describe the new behavior from this PR, and why it's needed_
Issue #770


