### PR TITLE
Modified to receive PreparsedDocumentProvider when DgsReactiveQueryExecutor Bean is created.

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -37,6 +37,7 @@ import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.introspection.IntrospectionQuery
 import graphql.schema.GraphQLSchema
 import org.springframework.beans.factory.annotation.Qualifier
@@ -79,7 +80,8 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
         @Qualifier("query") providedQueryExecutionStrategy: Optional<ExecutionStrategy>,
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
-        reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator
+        reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator,
+        preparsedDocumentProvider: PreparsedDocumentProvider
     ): DgsReactiveQueryExecutor {
 
         val queryExecutionStrategy =
@@ -95,7 +97,8 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             queryExecutionStrategy,
             mutationExecutionStrategy,
             idProvider,
-            reloadSchemaIndicator
+            reloadSchemaIndicator,
+            preparsedDocumentProvider
         )
     }
 

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/CustomPreparsedDocumentProvider.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/CustomPreparsedDocumentProvider.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webflux.autoconfiguration
+
+import com.ibm.icu.impl.Assert
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsQuery
+import com.netflix.graphql.dgs.DgsTypeDefinitionRegistry
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration
+import com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor
+import graphql.ExecutionInput
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.execution.preparsed.PreparsedDocumentProvider
+import graphql.language.FieldDefinition
+import graphql.language.ObjectTypeDefinition
+import graphql.language.TypeName
+import graphql.schema.idl.TypeDefinitionRegistry
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.web.reactive.config.EnableWebFlux
+import java.util.function.Function
+
+@AutoConfigureWebTestClient
+@EnableWebFlux
+@SpringBootTest(
+    classes = [CustomPreparsedDocumentProvider.TestConfig::class, DgsWebFluxAutoConfiguration::class, DgsAutoConfiguration::class, CustomPreparsedDocumentProvider.ExampleImplementation::class],
+)
+class CustomPreparsedDocumentProvider {
+
+    @Autowired
+    lateinit var executor: DgsReactiveQueryExecutor
+
+    @Test
+    fun customPreparsedInject() {
+        try {
+            executor.execute("""{"query": "{hello}"}""", mapOf()).block()
+            Assert.fail("do not inject CustomPreparsedDocumentProvider")
+        } catch (e: IllegalStateException) {
+        } catch (e: Exception) {
+            Assert.fail("do not inject CustomPreparsedDocumentProvider")
+        }
+    }
+
+    @DgsComponent
+    class ExampleImplementation {
+
+        @DgsTypeDefinitionRegistry
+        fun typeDefinitionRegistry(): TypeDefinitionRegistry {
+            val newRegistry = TypeDefinitionRegistry()
+
+            val query =
+                ObjectTypeDefinition
+                    .newObjectTypeDefinition()
+                    .name("Query")
+                    .fieldDefinition(
+                        FieldDefinition
+                            .newFieldDefinition()
+                            .name("hello")
+                            .type(TypeName("String"))
+                            .build()
+                    ).build()
+            newRegistry.add(query)
+
+            return newRegistry
+        }
+
+        @DgsQuery
+        fun hello(): String {
+            return "Hello, DGS"
+        }
+    }
+
+    @TestConfiguration
+    open class TestConfig {
+        @Bean
+        open fun customPreparsedDocumentProvider(): PreparsedDocumentProvider {
+            return CustomPreparsedDocumentProvider()
+        }
+
+        class CustomPreparsedDocumentProvider : PreparsedDocumentProvider {
+            override fun getDocument(
+                executionInput: ExecutionInput?,
+                parseAndValidateFunction: Function<ExecutionInput, PreparsedDocumentEntry>?
+            ): PreparsedDocumentEntry {
+                throw CustomException("custom")
+            }
+        }
+    }
+
+    class CustomException(message: String?) : RuntimeException(message)
+}


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe):

Changes in this PR
----
PreparsedDocumentProvider is always fixed as DgsNoOpPreparsedDocumentProvider.
So we can't use a custom "PreparsedDocumentProvider".

Alternatives considered
----

Modified to receive PreparsedDocumentProvider when DgsReactiveQueryExecutor Bean is created.