### PR TITLE
Recommending Log4J versions >= 2.15

### DIFF
--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -436,6 +436,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "project": true
@@ -458,6 +459,9 @@
         "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure": {
             "project": true
         },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure": {
+            "project": true
+        },
         "com.netflix.graphql.dgs:graphql-error-types": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -466,7 +470,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
@@ -486,6 +490,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.5.21"
@@ -547,7 +552,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
             "locked": "2.12.3"
         },
@@ -586,7 +592,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
             "project": true
         },
@@ -606,6 +614,8 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "project": true
@@ -624,7 +634,8 @@
         },
         "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
             "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
             "project": true
         },
@@ -637,6 +648,15 @@
         "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure": {
             "project": true
         },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure": {
+            "project": true
+        },
         "com.netflix.graphql.dgs:graphql-error-types": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -645,7 +665,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
@@ -679,6 +699,8 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "1.5.21"
@@ -703,7 +725,9 @@
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
             "locked": "2.3.9.RELEASE"
         },
@@ -750,7 +774,8 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
             "locked": "5.2.13.RELEASE"
         },
@@ -762,6 +787,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure"
+            ],
+            "locked": "5.2.13.RELEASE"
+        },
+        "org.springframework:spring-websocket": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
             "locked": "5.2.13.RELEASE"
         }

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -530,6 +530,12 @@
             ],
             "project": true
         },
+        "io.projectreactor.netty:reactor-netty": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ],
+            "locked": "0.9.17.RELEASE"
+        },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
@@ -770,7 +776,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -986,7 +992,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
+        },
+        "io.projectreactor.netty:reactor-netty": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ],
+            "locked": "0.9.17.RELEASE"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -817,7 +817,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1049,7 +1049,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -569,7 +569,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
@@ -705,7 +705,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -534,7 +534,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -718,7 +718,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -316,7 +316,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
@@ -357,7 +357,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -470,7 +470,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
@@ -568,7 +568,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -69,6 +69,13 @@ dependencies {
         api("io.projectreactor:reactor-test"){
             version { require("3.4.10") }
         }
+        // CVEs
+        api("org.apache.logging.log4j:log4j-to-slf4j:2.15.0") {
+            because("Refer to CVE-2021-44228; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228")
+         }
+         api("org.apache.logging.log4j:log4j-api:2.15.0") {
+            because("Refer to CVE-2021-44228; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228")
+         }
     }
 }
 

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -501,7 +501,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"
@@ -627,7 +627,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -125,7 +125,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.3"
+            "locked": "1.0.9"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -437,7 +437,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.3"
+            "locked": "1.0.9"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -631,7 +631,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.3"
+            "locked": "1.0.9"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -640,7 +640,7 @@
             "locked": "1.5.11"
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -833,7 +833,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.3"
+            "locked": "1.0.9"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -842,7 +842,7 @@
             "locked": "1.5.11"
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -502,7 +502,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
@@ -616,7 +616,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -669,7 +669,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -839,7 +839,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -76,6 +76,9 @@
             ],
             "project": true
         },
+        "io.projectreactor.netty:reactor-netty": {
+            "locked": "0.9.17.RELEASE"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
         },
@@ -367,6 +370,9 @@
             ],
             "project": true
         },
+        "io.projectreactor.netty:reactor-netty": {
+            "locked": "0.9.17.RELEASE"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
         },
@@ -527,7 +533,10 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
+        },
+        "io.projectreactor.netty:reactor-netty": {
+            "locked": "0.9.17.RELEASE"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"
@@ -660,7 +669,10 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
+        },
+        "io.projectreactor.netty:reactor-netty": {
+            "locked": "0.9.17.RELEASE"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -519,7 +519,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
@@ -645,7 +645,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -479,7 +479,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
@@ -580,7 +580,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -313,7 +313,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
@@ -354,7 +354,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -516,7 +516,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
@@ -643,7 +643,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -514,7 +514,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"
@@ -630,7 +630,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -545,7 +545,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
@@ -670,7 +670,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -520,7 +520,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.0.3.RELEASE"
@@ -642,7 +642,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.0.3.RELEASE"

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -473,6 +473,12 @@
             ],
             "project": true
         },
+        "io.projectreactor.netty:reactor-netty": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ],
+            "locked": "0.9.17.RELEASE"
+        },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
@@ -680,7 +686,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -857,7 +863,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
+        },
+        "io.projectreactor.netty:reactor-netty": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ],
+            "locked": "0.9.17.RELEASE"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -435,7 +435,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
@@ -533,7 +533,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -304,7 +304,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"
@@ -339,7 +339,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.0"
+            "locked": "1.12.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.21"


### PR DESCRIPTION
Objective
========

Make sure that consumers of the DGS Starters don't get Log4J dependencies < 2.15

Ref. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228

### Example

With this change the `graphql-dgs-spring-boot-starter` will expose `org.apache.logging.log4j:log4j-to-slf4j` version `2.15.0` instead of `2.13.3`.

```
org.apache.logging.log4j:log4j-to-slf4j:2.13.3 -> 2.15.0
+--- org.springframework.boot:spring-boot-dependencies:2.3.12.RELEASE
|    \--- compileClasspath
\--- org.springframework.boot:spring-boot-starter-logging:2.3.12.RELEASE
     +--- org.springframework.boot:spring-boot-dependencies:2.3.12.RELEASE (*)
     \--- org.springframework.boot:spring-boot-starter:2.3.12.RELEASE
          +--- org.springframework.boot:spring-boot-dependencies:2.3.12.RELEASE (*)
          +--- org.springframework.boot:spring-boot-starter-web:2.3.12.RELEASE
          |    +--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
          |    +--- org.springframework.boot:spring-boot-dependencies:2.3.12.RELEASE (*)
          |    \--- org.springframework.boot:spring-boot-starter-websocket:2.3.12.RELEASE
          |         +--- compileClasspath (requested org.springframework.boot:spring-boot-starter-websocket)
          |         \--- org.springframework.boot:spring-boot-dependencies:2.3.12.RELEASE (*)
          \--- org.springframework.boot:spring-boot-starter-json:2.3.12.RELEASE
               +--- org.springframework.boot:spring-boot-dependencies:2.3.12.RELEASE (*)
               \--- org.springframework.boot:spring-boot-starter-web:2.3.12.RELEASE (*)
```