### PR TITLE
Support of PreparsedDocumentProvider in  DgsWebFluxAutoConfguration

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -39,6 +39,7 @@ import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.introspection.IntrospectionQuery
 import graphql.schema.GraphQLSchema
 import org.springframework.beans.factory.annotation.Qualifier
@@ -84,7 +85,8 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
         @Qualifier("query") providedQueryExecutionStrategy: Optional<ExecutionStrategy>,
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
-        reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator
+        reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator,
+        preparsedDocumentProvider: PreparsedDocumentProvider
     ): DgsReactiveQueryExecutor {
 
         val queryExecutionStrategy =
@@ -100,7 +102,8 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             queryExecutionStrategy,
             mutationExecutionStrategy,
             idProvider,
-            reloadSchemaIndicator
+            reloadSchemaIndicator,
+            preparsedDocumentProvider
         )
     }
 


### PR DESCRIPTION

Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [X] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Please refer to https://github.com/Netflix/dgs-framework/issues/50. Support of PreparsedDocumentProvider was added through PR https://github.com/Netflix/dgs-framework/pull/583.
Above PR added it to DefaultDgsReactiveQueryExecutor but missed changes in DgsWebFluxAutoConfiguration.
In this PR, we are fixing that so that WebFlux application can define own implementation PreparsedDocumentProvider.

Alternatives considered
----
