### PR TITLE
Upgrade to Log4J 2.16.0

### DIFF
--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -70,10 +70,10 @@ dependencies {
             version { require("3.4.10") }
         }
         // CVEs
-        api("org.apache.logging.log4j:log4j-to-slf4j:2.15.0") {
+        api("org.apache.logging.log4j:log4j-to-slf4j:2.16.0") {
             because("Refer to CVE-2021-44228; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228")
          }
-         api("org.apache.logging.log4j:log4j-api:2.15.0") {
+         api("org.apache.logging.log4j:log4j-api:2.16.0") {
             because("Refer to CVE-2021-44228; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228")
          }
     }

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -125,7 +125,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.9"
+            "locked": "1.0.10"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -437,7 +437,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.9"
+            "locked": "1.0.10"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -631,7 +631,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.9"
+            "locked": "1.0.10"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -833,7 +833,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.9"
+            "locked": "1.0.10"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"


### PR DESCRIPTION
Upgrades the recommendations to Log4J 2.16.0 to...

* Disable JNDI by default. Require log4j2.enableJndi to be set to true to allow JNDI. Fixes LOG4J2-3208.	rgoers
* Completely remove support for Message Lookups. Fixes LOG4J2-3211.

ref. https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0