### PR TITLE
Process HTTP session data on websocket handshake and load SecurityContext into Subscriptions

### DIFF
--- a/graphql-dgs-subscriptions-websockets/build.gradle.kts
+++ b/graphql-dgs-subscriptions-websockets/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     implementation("org.springframework:spring-websocket")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
+    compileOnly("org.springframework.security:spring-security-core")
+
     testImplementation("io.projectreactor:reactor-core")
     testImplementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
 }

--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsHandshakeInterceptor.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsHandshakeInterceptor.kt
@@ -22,10 +22,10 @@ import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
 import org.springframework.web.socket.WebSocketHandler
 import org.springframework.web.socket.WebSocketHttpHeaders
-import org.springframework.web.socket.server.HandshakeInterceptor
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor
 import java.lang.Exception
 
-class DgsHandshakeInterceptor : HandshakeInterceptor {
+class DgsHandshakeInterceptor : HttpSessionHandshakeInterceptor() {
     private val logger = LoggerFactory.getLogger(DgsHandshakeInterceptor::class.java)
     override fun beforeHandshake(
         request: ServerHttpRequest,
@@ -36,7 +36,7 @@ class DgsHandshakeInterceptor : HandshakeInterceptor {
         if (request.headers[WebSocketHttpHeaders.SEC_WEBSOCKET_PROTOCOL].isNullOrEmpty()) {
             request.headers.set(WebSocketHttpHeaders.SEC_WEBSOCKET_PROTOCOL, GRAPHQL_SUBSCRIPTIONS_WS_PROTOCOL)
         }
-        return true
+        return super.beforeHandshake(request, response, wsHandler, attributes)
     }
 
     override fun afterHandshake(


### PR DESCRIPTION

Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This fixes a bug where we don't receive the correct SecurityContext in subscriptions, because the HTTP session etc. is only available during the handshake, meaning Spring Security logic (annotations, etc.) does not work.
The `HttpSessionHandshakeInterceptor` handles the extraction of HTTP headers during the handshake and makes it available as attributes on the `WebSocketSession`.
Then the correct SecurityContext is loaded prior to handling any WebSocket message.

Alternatives considered
----


- Create own WebSocket controller, but the DgsWebSocketHandler class needs to be `open` so we can extend it and add the loading of the SecurityContext for ourselves.