### PR TITLE
Support Apollo APQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,11 @@ GW_CMD = $(GW) $(GFLAGS)
 # GW_OPT_DISABLE_LOCAL=-x autoLintGradle
 GW_OPT_DISABLE_LOCAL=
 
-
 format: ## Formats source code
 	$(GW_CMD) formatKotlin
 
-
 publish-local: ## Clans, bulds, and publishes the Codegen artifacts to mavenLocal, as a SNAPSHOT.
 	$(GW_CMD) $(GW_OPT_DISABLE_LOCAL) clean build publishToMavenLocal
-
 
 test-examples_py: ## Modify the examples to use the latest Codegen SNAPSHOT, publishes the snapshot locally, and builds the examples.
 	scripts/test-examples.py -v -g -k --path=build/examples
@@ -28,17 +25,16 @@ test-examples: /usr/local/bin/python3 ## Modify the examples to use the latest C
 	$(MAKE) install-py-libs
 	$(MAKE) test-examples_py
 
-
 install-py-libs: ## Installs the Python Modules required by the scripts.
 	 pip3 install -r scripts/requirements.txt
-
 
 /usr/local/bin/python3: ## Installs Python3 via brew.
 	brew install python3
 
-
 all: format test-examples ## Cleans, checks/tests, publishes the plugin locally and runs the examples.
-
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+%: ## Runs a given gradle task. e.g. check
+	$(GW_CMD) $(@F)

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -470,7 +470,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
@@ -665,7 +665,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
@@ -678,6 +678,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "4.0.4"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -530,6 +530,12 @@
             ],
             "project": true
         },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.0.3.RELEASE"
+        },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
@@ -542,6 +548,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
             "locked": "3.4.10"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -776,7 +788,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -992,7 +1004,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
+        },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
@@ -1006,6 +1024,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
             "locked": "3.4.10"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -557,6 +557,12 @@
             ],
             "locked": "4.0.4"
         },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
         },
@@ -817,7 +823,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1049,7 +1055,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1066,6 +1072,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "4.0.4"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -406,6 +406,12 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
         },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
         },
@@ -569,7 +575,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
@@ -705,13 +711,19 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/ConcurrentDataFetcherTest.java
+++ b/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/ConcurrentDataFetcherTest.java
@@ -21,7 +21,7 @@ import com.netflix.graphql.dgs.DgsQueryExecutor;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ExampleSpringBootTest
 class ConcurrentDataFetcherTest {
@@ -36,6 +36,6 @@ class ConcurrentDataFetcherTest {
         int ts1 = documentContext.read("data.concurrent1");
         int ts2 = documentContext.read("data.concurrent2");
 
-        assertTrue(ts1 > ts2);
+        assertThat(ts1).isGreaterThanOrEqualTo(ts2);
     }
 }

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -534,7 +534,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -718,7 +718,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -731,6 +731,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "4.0.4"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -534,7 +534,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -718,7 +718,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -731,6 +731,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "4.0.4"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -316,7 +316,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -357,7 +357,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -470,7 +470,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -568,7 +568,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-reactive/build.gradle.kts
+++ b/graphql-dgs-reactive/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("org.springframework:spring-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     testImplementation(project(":graphql-dgs-spring-boot-oss-autoconfigure"))
     testImplementation("io.projectreactor:reactor-test")
 }

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -69,6 +69,9 @@
             ],
             "project": true
         },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "locked": "1.0.3.RELEASE"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
         },
@@ -354,6 +357,9 @@
             ],
             "project": true
         },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "locked": "1.0.3.RELEASE"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
         },
@@ -501,7 +507,10 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
+        },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"
@@ -627,10 +636,19 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
+        },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
@@ -21,7 +21,6 @@ import com.netflix.graphql.dgs.internal.DgsRequestData
 import com.netflix.graphql.dgs.reactive.DgsReactiveCustomContextBuilderWithRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.server.reactive.ServerHttpRequest
-import org.springframework.web.context.request.WebRequest
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.core.publisher.Mono
 import java.util.*
@@ -60,8 +59,7 @@ open class DefaultDgsReactiveGraphQLContextBuilder(
 /**
  * @param extensions Optional map of extensions - useful for customized GraphQL interactions between for example a gateway and dgs.
  * @param headers Http Headers
- * @param webRequest Spring [WebRequest]. This will only be available when deployed in a WebMVC (Servlet based) environment. See [serverRequest] for the WebFlux version.
- * @param serverRequest Spring reactive [ServerHttpRequest]. This will only be available when deployed in a WebFlux (non-Servlet) environment. See [webRequest] for the WebMVC version.
+ * @param serverRequest Spring reactive [ServerHttpRequest]. This will only be available when deployed in a WebFlux (non-Servlet) environment.
  */
 data class DgsReactiveRequestData(
     override val extensions: Map<String, Any>? = emptyMap(),

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -125,7 +125,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.10"
+            "locked": "1.0.14"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -437,7 +437,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.10"
+            "locked": "1.0.14"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -631,7 +631,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.10"
+            "locked": "1.0.14"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -640,7 +640,7 @@
             "locked": "1.5.14"
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -833,7 +833,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.0.10"
+            "locked": "1.0.14"
         },
         "commons-codec:commons-codec": {
             "locked": "1.14"
@@ -842,7 +842,7 @@
             "locked": "1.5.14"
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -857,7 +857,13 @@
             "locked": "4.0.4"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.11.5"
+            "locked": "1.12.5"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/utils/CacheableQuerySignatureRepository.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/utils/CacheableQuerySignatureRepository.kt
@@ -73,7 +73,7 @@ open class CacheableQuerySignatureRepository(
     ): QuerySignatureRepository.QuerySignature {
         val key = CacheKey(queryHash, queryName)
         log.debug("Computing query signature for query with cache key: {}.", key)
-        return cache.get(key) { super.computeQuerySignature(queryHash, queryName, document) }
+        return cache.get(key) { super.computeQuerySignature(queryHash, queryName, document) }!!
     }
 
     override fun afterPropertiesSet() {

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -29,6 +29,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.8.8"
+        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -73,6 +76,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
             "project": true
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.5.14"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -366,6 +375,9 @@
             ],
             "project": true
         },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.10"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
         },
@@ -456,6 +468,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.8.8"
+        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -502,7 +517,10 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -564,6 +582,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.8.8"
+        },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -616,7 +637,10 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/AutomatedPersistedQueryCacheAdapter.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/AutomatedPersistedQueryCacheAdapter.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.apq
+
+import graphql.ExecutionInput
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.execution.preparsed.persisted.PersistedQueryCache
+import graphql.execution.preparsed.persisted.PersistedQueryCacheMiss
+import graphql.execution.preparsed.persisted.PersistedQueryNotFound
+import graphql.execution.preparsed.persisted.PersistedQuerySupport
+import org.apache.commons.lang3.StringUtils
+import java.util.function.Supplier
+
+/**
+ * Adapter that is intended to facilitate the implementation of a [PersistedQueryCache] that can be used to
+ * store _Automated Persisted Queries_. Refer to [AutomatedPersistedQueryCaffeineCache] for an example.
+ *
+ * @see DgsAPQSupportAutoConfiguration
+ */
+abstract class AutomatedPersistedQueryCacheAdapter : PersistedQueryCache {
+
+    override fun getPersistedQueryDocument(
+        persistedQueryId: Any,
+        executionInput: ExecutionInput,
+        onCacheMiss: PersistedQueryCacheMiss
+    ): PreparsedDocumentEntry? {
+        val key = when (persistedQueryId) {
+            is String -> persistedQueryId
+            else -> persistedQueryId.toString()
+        }
+        return getFromCache(key) {
+            // Get the query from the execution input. Make sure it's not null, empty or the APQ marker.
+            val queryText = executionInput.query
+            if (StringUtils.isBlank(queryText) || queryText.equals(PersistedQuerySupport.PERSISTED_QUERY_MARKER)) {
+                throw PersistedQueryNotFound(persistedQueryId)
+            }
+            return@getFromCache onCacheMiss.apply(queryText)
+        }
+    }
+
+    /**
+     * Obtains the [PreparsedDocumentEntry] associated with the [key] from the cache that backs the implementation.
+     * If the document is missing from the [documentEntrySupplier] will provide one, it should be added to the cache
+     * then.
+     *
+     * @param key The hash of the requested query.
+     * @param documentEntrySupplier function that will supply the document in case there is a cache miss.
+     */
+    protected abstract fun getFromCache(
+        key: String,
+        documentEntrySupplier: Supplier<PreparsedDocumentEntry>
+    ): PreparsedDocumentEntry?
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/AutomatedPersistedQueryCaffeineCache.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/AutomatedPersistedQueryCaffeineCache.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.apq
+
+import com.github.benmanes.caffeine.cache.Cache
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.execution.preparsed.persisted.PersistedQueryCache
+import java.util.function.Supplier
+
+/**
+ * Implementation of [PersistedQueryCache] backed by a Caffeine Cache.
+ */
+class AutomatedPersistedQueryCaffeineCache(val cache: Cache<String, PreparsedDocumentEntry>) :
+    AutomatedPersistedQueryCacheAdapter() {
+
+    override fun getFromCache(
+        key: String,
+        documentEntrySupplier: Supplier<PreparsedDocumentEntry>
+    ): PreparsedDocumentEntry? {
+        return cache.get(key) { documentEntrySupplier.get() }
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/DgsAPQSupportAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/DgsAPQSupportAutoConfiguration.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.apq
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.CaffeineSpec
+import com.netflix.graphql.dgs.internal.QueryValueCustomizer
+import graphql.execution.preparsed.PreparsedDocumentEntry
+import graphql.execution.preparsed.persisted.ApolloPersistedQuerySupport
+import graphql.execution.preparsed.persisted.PersistedQueryCache
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics
+import org.apache.commons.lang3.StringUtils
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+@Configuration
+@ConditionalOnProperty(
+    prefix = DgsAPQSupportProperties.PREFIX,
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = DgsAPQSupportProperties.DEFAULT_ENABLED
+)
+@EnableConfigurationProperties(DgsAPQSupportProperties::class)
+open class DgsAPQSupportAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(PersistedQueryCache::class)
+    open fun apolloPersistedQuerySupport(persistedQueryCache: PersistedQueryCache): ApolloPersistedQuerySupport {
+        return ApolloPersistedQuerySupport(persistedQueryCache)
+    }
+
+    @Bean
+    @ConditionalOnBean(ApolloPersistedQuerySupport::class)
+    open fun apolloAPQQueryValueCustomizer(): QueryValueCustomizer {
+        return QueryValueCustomizer { query ->
+            if (StringUtils.isBlank(query)) {
+                ApolloPersistedQuerySupport.PERSISTED_QUERY_MARKER
+            } else {
+                query
+            }
+        }
+    }
+
+    @Configuration
+    @ConditionalOnClass(name = ["com.github.benmanes.caffeine.cache.Cache"])
+    @ConditionalOnProperty(
+        prefix = DgsAPQSupportProperties.CACHE_PREFIX,
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = DgsAPQSupportProperties.DEFAULT_CACHE_CAFFEINE_ENABLED
+    )
+    open class APQCaffeineCacheConfiguration {
+
+        @Bean(name = [BEAN_APQ_CAFFEINE_CACHE_NAME])
+        @ConditionalOnMissingBean(name = [BEAN_APQ_CAFFEINE_CACHE_NAME])
+        @Suppress("UNCHECKED_CAST")
+        open fun apqCaffeineCache(properties: DgsAPQSupportProperties): Cache<String, PreparsedDocumentEntry> {
+            return if (StringUtils.isNotBlank(properties.defaultCache.caffeineSpec)) {
+                Caffeine.from(CaffeineSpec.parse(properties.defaultCache.caffeineSpec)).build()
+            } else {
+                Caffeine.newBuilder()
+                    .maximumSize(1000)
+                    .expireAfterAccess(Duration.ofHours(1))
+                    .build()
+            }
+        }
+    }
+
+    @Configuration
+    @ConditionalOnClass(
+        name = ["io.micrometer.core.instrument.MeterRegistry", "com.github.benmanes.caffeine.cache.Cache"]
+    )
+    open class APQMicrometerMeteredCaffeineCacheConfiguration {
+
+        @Bean
+        @ConditionalOnBean(io.micrometer.core.instrument.MeterRegistry::class)
+        @ConditionalOnMissingBean(PersistedQueryCache::class)
+        open fun meteredPersistedQueryCache(
+            @Qualifier(BEAN_APQ_CAFFEINE_CACHE_NAME) appCaffeine: Cache<String, PreparsedDocumentEntry>,
+            meterRegistry: MeterRegistry
+        ): PersistedQueryCache {
+            val monitoredCache: Cache<String, PreparsedDocumentEntry> =
+                CaffeineCacheMetrics.monitor(meterRegistry, appCaffeine, BEAN_APQ_CAFFEINE_CACHE_NAME)
+            return AutomatedPersistedQueryCaffeineCache(monitoredCache)
+        }
+    }
+
+    @Configuration
+    @ConditionalOnMissingBean(APQMicrometerMeteredCaffeineCacheConfiguration::class)
+    @ConditionalOnClass(name = ["com.github.benmanes.caffeine.cache.Cache"])
+    open class APQBasicCaffeineCacheConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(PersistedQueryCache::class)
+        open fun meteredPersistedQueryCache(
+            @Qualifier(BEAN_APQ_CAFFEINE_CACHE_NAME) cache: Cache<String, PreparsedDocumentEntry>
+        ): PersistedQueryCache {
+            return AutomatedPersistedQueryCaffeineCache(cache)
+        }
+    }
+
+    companion object {
+        const val BEAN_APQ_CAFFEINE_CACHE_NAME = "apqCaffeineCache"
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/DgsAPQSupportProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/DgsAPQSupportProperties.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.apq
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.NestedConfigurationProperty
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+@ConfigurationProperties(prefix = DgsAPQSupportProperties.PREFIX)
+@ConstructorBinding
+@Suppress("ConfigurationProperties")
+data class DgsAPQSupportProperties(
+    /** Enables/Disables support for Automated Persisted Queries (APQ). */
+    @DefaultValue("$DEFAULT_ENABLED")
+    var enabled: Boolean = DEFAULT_ENABLED,
+    @NestedConfigurationProperty
+    var defaultCache: DgsAPQDefaultCaffeineCacheProperties = DgsAPQDefaultCaffeineCacheProperties()
+) {
+    data class DgsAPQDefaultCaffeineCacheProperties(
+        /** Enables/Disables the APQ default cache, backed by a Caffeine Cache.*/
+        @DefaultValue("$DEFAULT_CACHE_CAFFEINE_ENABLED")
+        var enabled: Boolean = DEFAULT_CACHE_CAFFEINE_ENABLED,
+        /** Defines the Caffeine Spec used by the default cache.*/
+        @DefaultValue(DEFAULT_CACHE_CAFFEINE_SPEC)
+        var caffeineSpec: String = DEFAULT_CACHE_CAFFEINE_SPEC
+    )
+
+    companion object {
+        const val DEFAULT_ENABLED = false
+        const val DEFAULT_CACHE_CAFFEINE_ENABLED = true
+        const val DEFAULT_CACHE_CAFFEINE_SPEC = "maximumSize=100,expireAfterWrite=1h,recordStats"
+
+        const val PREFIX: String = "dgs.graphql.apq"
+        const val CACHE_PREFIX: String = "$PREFIX.default-cache"
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -77,7 +77,8 @@ open class DgsAutoConfiguration(
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
         reloadSchemaIndicator: ReloadSchemaIndicator,
-        preparsedDocumentProvider: PreparsedDocumentProvider
+        preparsedDocumentProvider: PreparsedDocumentProvider,
+        queryValueCustomizer: QueryValueCustomizer
     ): DgsQueryExecutor {
         val queryExecutionStrategy = providedQueryExecutionStrategy.orElse(AsyncExecutionStrategy(dataFetcherExceptionHandler))
         val mutationExecutionStrategy = providedMutationExecutionStrategy.orElse(AsyncSerialExecutionStrategy(dataFetcherExceptionHandler))
@@ -91,8 +92,15 @@ open class DgsAutoConfiguration(
             mutationExecutionStrategy,
             idProvider,
             reloadSchemaIndicator,
-            preparsedDocumentProvider
+            preparsedDocumentProvider,
+            queryValueCustomizer
         )
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    open fun defaultQueryValueCustomizer(): QueryValueCustomizer {
+        return QueryValueCustomizer { a -> a }
     }
 
     @Bean

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -25,9 +25,14 @@ import org.springframework.boot.context.properties.bind.DefaultValue
  * Configuration properties for DGS framework.
  */
 @ConstructorBinding
-@ConfigurationProperties(prefix = "dgs.graphql")
+@ConfigurationProperties(prefix = DgsConfigurationProperties.PREFIX)
 @Suppress("ConfigurationProperties")
 data class DgsConfigurationProperties(
     /** Location of the GraphQL schema files. */
-    @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>
-)
+    @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>,
+
+) {
+    companion object {
+        const val PREFIX: String = "dgs.graphql"
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration
+  com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration, \
+  com.netflix.graphql.dgs.apq.DgsAPQSupportAutoConfiguration
 
 org.springframework.boot.diagnostics.FailureAnalyzer=\
   com.netflix.graphql.dgs.diagnostics.SchemaFailureAnalyzer

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -471,6 +471,12 @@
             ],
             "locked": "4.0.4"
         },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
         },
@@ -669,7 +675,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -839,7 +845,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -852,6 +858,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "4.0.4"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-spring-webflux-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-webflux-autoconfigure/build.gradle.kts
@@ -17,11 +17,14 @@
 dependencies {
     api(project(":graphql-dgs"))
     api(project(":graphql-dgs-reactive"))
+
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework:spring-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.projectreactor.netty:reactor-netty")
+
     testImplementation(project(":graphql-dgs-spring-boot-oss-autoconfigure"))
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("io.projectreactor:reactor-test")
+    testImplementation("com.github.ben-manes.caffeine:caffeine")
 }

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -370,6 +370,12 @@
             ],
             "project": true
         },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.0.3.RELEASE"
+        },
         "io.projectreactor.netty:reactor-netty": {
             "locked": "0.9.20.RELEASE"
         },
@@ -474,6 +480,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.8.8"
+        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -533,7 +542,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor.netty:reactor-netty": {
             "locked": "0.9.20.RELEASE"
@@ -604,6 +613,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.8.8"
+        },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -669,13 +681,25 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
+        },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor.netty:reactor-netty": {
             "locked": "0.9.20.RELEASE"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -20,6 +20,7 @@ import com.netflix.graphql.dgs.internal.CookieValueResolver
 import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.QueryValueCustomizer
 import com.netflix.graphql.dgs.reactive.DgsReactiveCustomContextBuilderWithRequest
 import com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveGraphQLContextBuilder
@@ -86,7 +87,8 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
         reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator,
-        preparsedDocumentProvider: PreparsedDocumentProvider
+        preparsedDocumentProvider: PreparsedDocumentProvider,
+        queryValueCustomizer: QueryValueCustomizer
     ): DgsReactiveQueryExecutor {
 
         val queryExecutionStrategy =
@@ -103,7 +105,8 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             mutationExecutionStrategy,
             idProvider,
             reloadSchemaIndicator,
-            preparsedDocumentProvider
+            preparsedDocumentProvider,
+            queryValueCustomizer
         )
     }
 

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DefaultDgsWebfluxHttpHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DefaultDgsWebfluxHttpHandler.kt
@@ -37,9 +37,12 @@ class DefaultDgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQuer
                         QueryInput(it)
                     } else {
                         val readValue = mapper.readValue<Map<String, Any>>(it)
+                        val query: String? = when (val iq = readValue["query"]) {
+                            is String -> iq
+                            else -> null
+                        }
                         QueryInput(
-                            readValue["query"] as String,
-
+                            query,
                             (readValue["variables"] ?: emptyMap<String, Any>()) as Map<String, Any>,
                             (readValue["extensions"] ?: emptyMap<String, Any>()) as Map<String, Any>,
                         )
@@ -71,7 +74,7 @@ class DefaultDgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQuer
 }
 
 private data class QueryInput(
-    val query: String,
+    val query: String?,
     val queryVariables: Map<String, Any> = emptyMap(),
     val extensions: Map<String, Any> = emptyMap()
 )

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/apq/DgsWebFluxAutomatedPersistedQueriesSmokeTest.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/apq/DgsWebFluxAutomatedPersistedQueriesSmokeTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webflux.apq
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsTypeDefinitionRegistry
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TypeDefinitionRegistry
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.reactive.config.EnableWebFlux
+
+@SpringBootTest(
+    properties = [
+        "debug:true",
+        "dgs.graphql.apq.enabled:true"
+    ]
+)
+@EnableWebFlux
+@AutoConfigureWebTestClient
+@EnableAutoConfiguration
+@Execution(ExecutionMode.SAME_THREAD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class DgsWebFluxAutomatedPersistedQueriesSmokeTest {
+
+    @Autowired
+    lateinit var webTestClient: WebTestClient
+
+    @Test
+    @Order(0)
+    fun `The demo app is able to start`() {
+    }
+
+    @Test
+    @Order(1)
+    fun `Attempt to execute a POST Request with a known hash`() {
+        webTestClient
+            .post()
+            .uri("/graphql")
+            .bodyValue(
+                """
+                  |{
+                  |    "extensions":{
+                  |        "persistedQuery":{
+                  |            "version":1,
+                  |            "sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"
+                  |        }
+                  |    }
+                  | }
+                  |""".trimMargin()
+            )
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody().json(
+                """
+                  |{
+                  |   "errors":[
+                  |     {
+                  |       "message":"PersistedQueryNotFound",
+                  |       "locations":[],
+                  |       "extensions":{
+                  |         "persistedQueryId":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38",
+                  |         "generatedBy":"graphql-java",
+                  |         "classification":"PersistedQueryNotFound"
+                  |       }
+                  |     }
+                  |   ]
+                  | }
+                  |""".trimMargin()
+            )
+    }
+
+    @Test
+    @Order(2)
+    fun `Execute a POST Request with a known hash and query`() {
+        webTestClient
+            .post()
+            .uri("/graphql")
+            .bodyValue(
+                """
+                  |{
+                  |    "query": "{__typename}",
+                  |    "extensions":{
+                  |        "persistedQuery":{
+                  |            "version":1,
+                  |            "sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"
+                  |        }
+                  |    }
+                  | }
+                  |""".trimMargin()
+            )
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().json(
+                """
+                  | {
+                  |    "data": {
+                  |        "__typename":"Query"
+                  |    }
+                  | }
+                  |""".trimMargin()
+            )
+    }
+
+    @Test
+    @Order(3)
+    fun `Execute a POST Request with a known hash once the query was registered`() {
+        webTestClient
+            .post()
+            .uri("/graphql")
+            .bodyValue(
+                """
+                   |{
+                   |    "extensions":{
+                   |        "persistedQuery":{
+                   |            "version":1,
+                   |            "sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"
+                   |        }
+                   |    }
+                   | }
+                   |""".trimMargin()
+            )
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().json(
+                """
+                  | {
+                  |    "data": {
+                  |        "__typename":"Query"
+                  |    }
+                  | }
+                  |""".trimMargin()
+            )
+    }
+
+    @SpringBootApplication(proxyBeanMethods = false, scanBasePackages = [])
+    @ComponentScan(
+        useDefaultFilters = false,
+        includeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [])]
+    )
+    @SuppressWarnings("unused")
+    open class LocalApp {
+
+        @DgsComponent
+        class ExampleImplementation {
+
+            @DgsTypeDefinitionRegistry
+            fun typeDefinitionRegistry(): TypeDefinitionRegistry {
+                val schemaParser = SchemaParser()
+
+                val gqlSchema = """
+                |type Query{
+                |}
+                """.trimMargin()
+                return schemaParser.parse(gqlSchema)
+            }
+        }
+    }
+}

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebRequestTestWithCustomContext.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebRequestTestWithCustomContext.kt
@@ -38,7 +38,14 @@ import reactor.core.publisher.Mono
 
 @AutoConfigureWebTestClient
 @EnableWebFlux
-@SpringBootTest(classes = [DgsWebFluxAutoConfiguration::class, DgsAutoConfiguration::class, WebRequestTestWithCustomContext.ExampleImplementation::class, WebRequestTestWithCustomContext.MyContextBuilder::class])
+@SpringBootTest(
+    classes = [
+        DgsWebFluxAutoConfiguration::class,
+        DgsAutoConfiguration::class,
+        WebRequestTestWithCustomContext.ExampleImplementation::class,
+        WebRequestTestWithCustomContext.MyContextBuilder::class
+    ]
+)
 class WebRequestTestWithCustomContext {
     @Autowired
     lateinit var webTestClient: WebTestClient

--- a/graphql-dgs-spring-webmvc-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-webmvc-autoconfigure/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("org.springframework:spring-webmvc")
     implementation("jakarta.servlet:jakarta.servlet-api")
 
-    testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation(project(":graphql-dgs-spring-boot-oss-autoconfigure"))
+    testImplementation("org.springframework.boot:spring-boot-starter-web")
+    testImplementation("com.github.ben-manes.caffeine:caffeine")
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -465,6 +465,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.8.8"
+        },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -519,7 +522,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
@@ -585,6 +588,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "2.8.8"
+        },
         "com.github.javafaker:javafaker": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -645,10 +651,16 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/apq/DgsWebMVCAutomatedPersistedQueriesSmokeTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/apq/DgsWebMVCAutomatedPersistedQueriesSmokeTest.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.apq
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsTypeDefinitionRegistry
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TypeDefinitionRegistry
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest(
+    properties = [
+        "debug:true",
+        "dgs.graphql.apq.enabled:true"
+    ]
+)
+@AutoConfigureMockMvc
+@EnableAutoConfiguration
+@Execution(ExecutionMode.SAME_THREAD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class DgsWebMVCAutomatedPersistedQueriesSmokeTest {
+
+    @Autowired
+    lateinit var mvc: MockMvc
+
+    @Test
+    @Order(0)
+    fun `The demo app is able to start`() {
+    }
+
+    @Test
+    @Order(1)
+    fun `Attempt to execute a POST Request with a known hash`() {
+        val uriBuilder =
+            MockMvcRequestBuilders
+                .post("/graphql")
+                .content(
+                    """
+                       |{
+                       |    "extensions":{
+                       |        "persistedQuery":{
+                       |            "version":1,
+                       |            "sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"
+                       |        }
+                       |    }
+                       | }
+                       |""".trimMargin()
+                )
+        mvc.perform(uriBuilder)
+            .andExpect(status().isOk)
+            .andExpect(
+                content().json(
+                    """
+                    |{
+                    |   "errors":[
+                    |     {
+                    |       "message":"PersistedQueryNotFound",
+                    |       "locations":[],
+                    |       "extensions":{
+                    |         "persistedQueryId":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38",
+                    |         "generatedBy":"graphql-java",
+                    |         "classification":"PersistedQueryNotFound"
+                    |       }
+                    |     }
+                    |   ]
+                    | }
+                    |""".trimMargin()
+                )
+            )
+    }
+
+    @Test
+    @Order(2)
+    fun `Execute a POST Request with a known hash and query`() {
+        val uriBuilder =
+            MockMvcRequestBuilders
+                .post("/graphql")
+                .content(
+                    """
+                       |{
+                       |    "query": "{__typename}",
+                       |    "extensions":{
+                       |        "persistedQuery":{
+                       |            "version":1,
+                       |            "sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"
+                       |        }
+                       |    }
+                       | }
+                       |""".trimMargin()
+                )
+        mvc.perform(uriBuilder)
+            .andExpect(status().isOk)
+            .andExpect(
+                content().json(
+                    """
+                    | {
+                    |    "data": {
+                    |        "__typename":"Query"
+                    |    }
+                    | }
+                    |""".trimMargin()
+                )
+            )
+    }
+
+    @Test
+    @Order(3)
+    fun `Execute a POST Request with a known hash once the query was registered`() {
+        val uriBuilder =
+            MockMvcRequestBuilders
+                .post("/graphql")
+                .content(
+                    """
+                       |{
+                       |    "extensions":{
+                       |        "persistedQuery":{
+                       |            "version":1,
+                       |            "sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"
+                       |        }
+                       |    }
+                       | }
+                       |""".trimMargin()
+                )
+        mvc.perform(uriBuilder)
+            .andExpect(status().isOk)
+            .andExpect(
+                content().json(
+                    """
+                    | {
+                    |    "data": {
+                    |        "__typename":"Query"
+                    |    }
+                    | }
+                    |""".trimMargin()
+                )
+            )
+    }
+
+    @SpringBootApplication(proxyBeanMethods = false, scanBasePackages = [])
+    @ComponentScan(
+        useDefaultFilters = false,
+        includeFilters = [ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = [])]
+    )
+    @SuppressWarnings("unused")
+    open class LocalApp {
+
+        @DgsComponent
+        class ExampleImplementation {
+
+            @DgsTypeDefinitionRegistry
+            fun typeDefinitionRegistry(): TypeDefinitionRegistry {
+                val schemaParser = SchemaParser()
+
+                val gqlSchema = """
+                |type Query{
+                |}
+                """.trimMargin()
+                return schemaParser.parse(gqlSchema)
+            }
+        }
+    }
+}

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -479,7 +479,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -580,7 +580,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -60,7 +60,9 @@ import org.springframework.web.multipart.MultipartFile
  */
 
 @RestController
-open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
+open class DgsRestController(
+    open val dgsQueryExecutor: DgsQueryExecutor
+) {
 
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
     @RequestMapping(
@@ -155,10 +157,15 @@ open class DgsRestController(open val dgsQueryExecutor: DgsQueryExecutor) {
             return ResponseEntity.badRequest().body("Invalid GraphQL request - operationName must be a String")
         }
 
+        val query: String? = when (val iq = inputQuery["query"]) {
+            is String -> iq
+            else -> null
+        }
+
         val executionResult = TimeTracer.logTime(
             {
                 dgsQueryExecutor.execute(
-                    inputQuery["query"] as String,
+                    query,
                     queryVariables,
                     extensions,
                     headers,

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsMultipartPostControllerTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsMultipartPostControllerTest.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.mvc
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import graphql.ExecutionResultImpl
@@ -203,4 +204,9 @@ class DgsMultipartPostControllerTest {
             DgsRestController(dgsQueryExecutor).graphql(null, mapOf("0" to file), operation, map, HttpHeaders(), webRequest)
         }
     }
+
+    data class GraphQLResponse(val data: Map<String, Any> = emptyMap(), val errors: List<GraphQLError> = emptyList())
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class GraphQLError(val message: String)
 }

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsRestControllerTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsRestControllerTest.kt
@@ -50,9 +50,20 @@ class DgsRestControllerTest {
             }
         """.trimIndent()
 
-        every { dgsQueryExecutor.execute(queryString, emptyMap(), any(), any(), any(), any()) } returns ExecutionResultImpl.newExecutionResult().data(CompletionStageMappingPublisher<String, String>(null, null)).build()
+        every {
+            dgsQueryExecutor.execute(
+                queryString,
+                emptyMap(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns ExecutionResultImpl.newExecutionResult()
+            .data(CompletionStageMappingPublisher<String, String>(null, null)).build()
 
-        val result = DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, HttpHeaders(), webRequest)
+        val result =
+            DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, HttpHeaders(), webRequest)
         assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
         assertThat(result.body).isEqualTo("Trying to execute subscription on /graphql. Use /subscriptions instead!")
     }
@@ -66,7 +77,16 @@ class DgsRestControllerTest {
             }
         """.trimIndent()
 
-        every { dgsQueryExecutor.execute(queryString, emptyMap(), any(), any(), any(), any()) } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("hello", "hello"))).build()
+        every {
+            dgsQueryExecutor.execute(
+                queryString,
+                emptyMap(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("hello", "hello"))).build()
 
         val result = DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, HttpHeaders(), webRequest)
         val mapper = jacksonObjectMapper()
@@ -134,9 +154,9 @@ class DgsRestControllerTest {
         assertThat(errors.size).isEqualTo(0)
         assertThat(data["hello"]).isEqualTo("hello")
     }
+
+    data class GraphQLResponse(val data: Map<String, Any> = emptyMap(), val errors: List<GraphQLError> = emptyList())
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class GraphQLError(val message: String)
 }
-
-data class GraphQLResponse(val data: Map<String, Any> = emptyMap(), val errors: List<GraphQLError> = emptyList())
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class GraphQLError(val message: String)

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -313,7 +313,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -354,7 +354,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -516,7 +516,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -643,7 +643,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -514,7 +514,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"
@@ -630,7 +630,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.4.10"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -545,7 +545,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -670,7 +670,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -104,6 +104,9 @@
         "org.springframework.security:spring-security-bom": {
             "locked": "5.3.12.RELEASE"
         },
+        "org.springframework.security:spring-security-core": {
+            "locked": "5.3.12.RELEASE"
+        },
         "org.springframework:spring-framework-bom": {
             "locked": "5.2.18.RELEASE"
         },
@@ -520,7 +523,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.0.3.RELEASE"
@@ -642,7 +645,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.0.3.RELEASE"

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -473,6 +473,12 @@
             ],
             "project": true
         },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.0.3.RELEASE"
+        },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
@@ -484,6 +490,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "3.4.10"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -686,7 +698,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -863,7 +875,13 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
+        },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ],
+            "locked": "1.0.3.RELEASE"
         },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
@@ -876,6 +894,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
             "locked": "3.4.10"
+        },
+        "org.apache.commons:commons-lang3": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ],
+            "locked": "3.10"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -435,7 +435,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"
@@ -533,7 +533,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.10"

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/QueryValueCustomizer.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/QueryValueCustomizer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,8 @@
  * limitations under the License.
  */
 
-dependencies {
-    api(project(":graphql-dgs"))
-    api(project(":graphql-dgs-spring-webmvc"))
-    implementation("org.springframework:spring-web")
-    implementation("org.springframework.boot:spring-boot-starter")
-    implementation("org.apache.commons:commons-lang3")
+package com.netflix.graphql.dgs.internal
 
-    compileOnly("com.github.ben-manes.caffeine:caffeine")
-    compileOnly("io.micrometer:micrometer-core")
-
-    testImplementation("org.springframework.boot:spring-boot-starter-web")
-    testImplementation("com.github.ben-manes.caffeine:caffeine")
+fun interface QueryValueCustomizer {
+    fun apply(query: String?): String?
 }

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -304,7 +304,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
@@ -339,7 +339,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.1"
+            "locked": "1.12.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

## Summary

This commit adds support for Apollos Automated Persisted Queries or APQ.
To enable this feature you will have to set the `dgs.graphql.apq.enabled` property to `true`.

You can see a demo of APQ in the following tests:
* SpringMVC with DgsWebMVCAutomatedPersistedQueriesSmokeTest.kt
* WebFlux with DgsWebFluxAutomatedPersistedQueriesSmokeTest.kt

### Configuration

| Property Name | Type | Default | Description |
|----------------|-------|--------------|------------|
| dgs.graphql.apq.enabled | boolean | false |  Enables Apollo's APQ (as implemented in graphql-java) on the DGS Service |
| dgs.graphql.apq.default-cache.enabled |  boolean | true | Can be used to disable the default Caffeine Cache | 
| dgs.graphql.apq.default-cache.caffeine-spec |  String | maximumSize=100,expireAfterWrite=1h,recordStats | Specifies the [CaffeineSpec] used by the default Caffeine Cache | 

[CaffeineSpec]: https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/latest/com.github.benmanes.caffeine/com/github/benmanes/caffeine/cache/CaffeineSpec.html

### Bean Overrides

* You can implement your own _Caffeine Cache Bean_ if you name it as `apqCaffeineCache`.
* You can implement your own _PersistedQueryCache_, se below for details.

## Details.

The `PersistedQueryCache` that backs the default  implementation leverages a Caffeine Cache. You can provide your own `PersistedQueryCache` if the default doesn't suffice, please review the `PersistedQueryCaffeineCache` if you decide to do so. It is important that the cache can handle the case where the query text matches the value defined by the `PersistedQuerySupport.PERSISTED_QUERY_MARKER` property.
In the future we could provide an _adapter_ that facilitates this.

The Caffeine Cache used by the default `PersistedQueryCaffeineCache` is a named bean, `apqCaffeineCache`, that can be replaced. You can also specify the _Caffeine Spec_, encoded as a String value, via the `dgs.graphql.apq.cache.caffeine-spec` property. By default the `dgs.graphql.apq.cache.caffeine-spec` has `maximumSize=100,expireAfterWrite=1h,recordStats` but as mentioned you can define yours as needed.

Future Actions
----

* Revisit how we are splitting the modules on the project. We could coalesce some to simplify development and testing and leverage `ConditionalOnClass` to enable or disable features. 

