### PR TITLE
Support custom input object mapper

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,24 @@ import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilder
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilderWithRequest
 import com.netflix.graphql.dgs.exceptions.DefaultDataFetcherExceptionHandler
-import com.netflix.graphql.dgs.internal.*
+import com.netflix.graphql.dgs.internal.CookieValueResolver
+import com.netflix.graphql.dgs.internal.DataFetcherResultProcessor
+import com.netflix.graphql.dgs.internal.DefaultDgsGraphQLContextBuilder
+import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
 import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor.ReloadSchemaIndicator
+import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
+import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
+import com.netflix.graphql.dgs.internal.DgsNoOpPreparsedDocumentProvider
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.InputObjectMapper
+import com.netflix.graphql.dgs.internal.QueryValueCustomizer
 import com.netflix.graphql.dgs.scalars.UploadScalar
 import com.netflix.graphql.mocking.MockProvider
-import graphql.execution.*
+import graphql.execution.AsyncExecutionStrategy
+import graphql.execution.AsyncSerialExecutionStrategy
+import graphql.execution.DataFetcherExceptionHandler
+import graphql.execution.ExecutionIdProvider
+import graphql.execution.ExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
@@ -151,7 +164,8 @@ open class DgsAutoConfiguration(
         mockProviders: Optional<Set<MockProvider>>,
         dataFetcherResultProcessors: List<DataFetcherResultProcessor>,
         dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler> = Optional.empty(),
-        cookieValueResolver: Optional<CookieValueResolver> = Optional.empty()
+        cookieValueResolver: Optional<CookieValueResolver> = Optional.empty(),
+        inputObjectMapper: Optional<InputObjectMapper> = Optional.empty()
     ): DgsSchemaProvider {
         return DgsSchemaProvider(
             applicationContext,
@@ -161,7 +175,8 @@ open class DgsAutoConfiguration(
             configProps.schemaLocations,
             dataFetcherResultProcessors,
             dataFetcherExceptionHandler,
-            cookieValueResolver
+            cookieValueResolver,
+            inputObjectMapper.orElse(DefaultInputObjectMapper())
         )
     }
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/CustomInputObjectComponents.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/CustomInputObjectComponents.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig.testcomponents
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsQuery
+import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
+import com.netflix.graphql.dgs.internal.InputObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import kotlin.reflect.KClass
+
+@Configuration
+open class CustomInputObjectMapperConfig {
+    @Bean
+    open fun inputObjectMapper(): InputObjectMapper {
+        return object : InputObjectMapper {
+            override fun <T : Any> mapToKotlinObject(inputMap: Map<String, *>, targetClass: KClass<T>): T {
+                val filteredInputMap = inputMap.filterKeys { !it.startsWith("ignore") }
+                return DefaultInputObjectMapper(this).mapToKotlinObject(filteredInputMap, targetClass)
+            }
+
+            override fun <T> mapToJavaObject(inputMap: Map<String, *>, targetClass: Class<T>): T {
+                val filteredInputMap = inputMap.filterKeys { !it.startsWith("ignore") }
+                return DefaultInputObjectMapper(this).mapToJavaObject(filteredInputMap, targetClass)
+            }
+        }
+    }
+
+    @Bean
+    open fun dataFetcher(): DataFetcherWithInputObject {
+        return DataFetcherWithInputObject()
+    }
+}
+
+@DgsComponent
+class DataFetcherWithInputObject {
+    @DgsQuery
+    fun withIgnoredField(@InputArgument input: Input): Input {
+        return input
+    }
+
+    @DgsQuery
+    fun withIgnoredFieldNested(@InputArgument nestedInput: NestedInput): Input {
+        return nestedInput.input
+    }
+
+    data class Input(val ignoredField: String?, val name: String)
+    data class NestedInput(val input: Input)
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/resources/schema/schema.graphqls
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/resources/schema/schema.graphqls
@@ -17,4 +17,22 @@ type Query {
     withNullableNull: String
 
     withNonNullableNull: String!
+
+    withIgnoredField(input: Input): Output
+
+    withIgnoredFieldNested(nestedInput: NestedInput): Output
+}
+
+input Input {
+    ignoredField: String
+    name: String
+}
+
+type Output {
+    ignoredField: String
+    name: String
+}
+
+input NestedInput {
+    input: Input
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,8 @@ class DataFetcherInvoker(
     defaultParameterNameDiscoverer: DefaultParameterNameDiscoverer,
     private val environment: DataFetchingEnvironment,
     private val dgsComponent: Any,
-    private val method: Method
+    private val method: Method,
+    private val inputObjectMapper: InputObjectMapper,
 ) {
 
     private val parameterNames = defaultParameterNameDiscoverer.getParameterNames(method) ?: emptyArray()
@@ -246,9 +247,9 @@ class DataFetcherInvoker(
                 }
 
             if (targetType.isKotlinClass()) {
-                InputObjectMapper.mapToKotlinObject(parameterValue as Map<String, *>, targetType.kotlin)
+                inputObjectMapper.mapToKotlinObject(parameterValue as Map<String, *>, targetType.kotlin)
             } else {
-                InputObjectMapper.mapToJavaObject(parameterValue as Map<String, *>, targetType)
+                inputObjectMapper.mapToJavaObject(parameterValue as Map<String, *>, targetType)
             }
         } else if ((parameter.type.isEnum || collectionType?.isEnum == true) && parameterValue != null) {
             val enumConstants: Array<Enum<*>> =

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,8 @@ class DgsSchemaProvider(
     private val schemaLocations: List<String> = listOf(DEFAULT_SCHEMA_LOCATION),
     private val dataFetcherResultProcessors: List<DataFetcherResultProcessor> = emptyList(),
     private val dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler> = Optional.empty(),
-    private val cookieValueResolver: Optional<CookieValueResolver> = Optional.empty()
+    private val cookieValueResolver: Optional<CookieValueResolver> = Optional.empty(),
+    private val inputObjectMapper: InputObjectMapper = DefaultInputObjectMapper(),
 ) {
 
     val dataFetcherInstrumentationEnabled = mutableMapOf<String, Boolean>()
@@ -317,13 +318,7 @@ class DgsSchemaProvider(
     private fun createBasicDataFetcher(method: Method, dgsComponent: Any, isSubscription: Boolean): DataFetcher<Any?> {
         return DataFetcher<Any?> { environment ->
             val dfe = DgsDataFetchingEnvironment(environment)
-            val result = DataFetcherInvoker(
-                cookieValueResolver,
-                defaultParameterNameDiscoverer,
-                dfe,
-                dgsComponent,
-                method
-            ).invokeDataFetcher()
+            val result = DataFetcherInvoker(cookieValueResolver, defaultParameterNameDiscoverer, dfe, dgsComponent, method, inputObjectMapper).invokeDataFetcher()
             when {
                 isSubscription -> {
                     result

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
@@ -33,6 +33,15 @@ import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.jvmErasure
 
 interface InputObjectMapper {
+    /**
+     * SPI intended for other frameworks/libraries that need to customize how input objects are mapped.
+     * Not intended to be used by most users.
+     *
+     * A custom mapper might call the DefaultInputObjectMapper, passing itself to the DefaultInputObjectMapper constructor.
+     * The DefaultInputObjectMapper will invoke the custom mapper each time it goes a level deeper into a nested object structure.
+     * This makes it possible to have a custom mapper that still mostly relies on the default one.
+     * Be careful to not create an infinite recursion calling back and forward though!
+     */
     fun <T : Any> mapToKotlinObject(inputMap: Map<String, *>, targetClass: KClass<T>): T
     fun <T> mapToJavaObject(inputMap: Map<String, *>, targetClass: Class<T>): T
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapper.kt
@@ -32,17 +32,34 @@ import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.jvm.jvmErasure
 
+/**
+ * SPI intended for other frameworks/libraries that need to customize how input objects are mapped.
+ * Not intended to be used by most users.
+ *
+ * A custom mapper might call the DefaultInputObjectMapper, passing itself to the DefaultInputObjectMapper constructor.
+ * The DefaultInputObjectMapper will invoke the custom mapper each time it goes a level deeper into a nested object structure.
+ * This makes it possible to have a custom mapper that still mostly relies on the default one.
+ * Be careful to not create an infinite recursion calling back and forward though!
+ *
+ * Kotlin and Java objects are converted differently. This is to deal with things like data classes.
+ * The input to the map methods is a map of values that are already converted by scalars.
+ * The input IS NOT JSON. Attempting to use a JSON mapper to converting these values will result in incorrect scalar values.
+ */
 interface InputObjectMapper {
     /**
-     * SPI intended for other frameworks/libraries that need to customize how input objects are mapped.
-     * Not intended to be used by most users.
-     *
-     * A custom mapper might call the DefaultInputObjectMapper, passing itself to the DefaultInputObjectMapper constructor.
-     * The DefaultInputObjectMapper will invoke the custom mapper each time it goes a level deeper into a nested object structure.
-     * This makes it possible to have a custom mapper that still mostly relies on the default one.
-     * Be careful to not create an infinite recursion calling back and forward though!
+     * Convert a map of input values to a Kotlin object. This must support Kotlin constructs such as data classes, and is typically handled differently from Java.
+     * @param inputMap The fields for an input object represented as a Map. This can be a nested map if nested types are used. Note that the values in this map are already converted by the scalars representing these types.
+     * @param targetClass The class to convert to.
+     * @return The converted object
      */
     fun <T : Any> mapToKotlinObject(inputMap: Map<String, *>, targetClass: KClass<T>): T
+
+    /**
+     * Convert a map of input values to a Java object.
+     * @param inputMap The fields for an input object represented as a Map. This can be a nested map if nested types are used. Note that the values in this map are already converted by the scalars representing these types.
+     * @param targetClass The class to convert to.
+     * @return The converted object
+     */
     fun <T> mapToJavaObject(inputMap: Map<String, *>, targetClass: Class<T>): T
 }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package com.netflix.graphql.dgs.internal
 
 import com.netflix.graphql.dgs.exceptions.DgsInvalidInputArgumentException
-import com.netflix.graphql.dgs.internal.InputObjectMapper.mapToJavaObject
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JGenericInputObjectTwoTypeParams
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JGenericSubInputObject
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObject
@@ -28,6 +27,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
+import kotlin.reflect.KClass
 
 internal class InputObjectMapperTest {
     private val currentDate = LocalDateTime.now()
@@ -48,9 +48,11 @@ internal class InputObjectMapperTest {
         "someObject" to mapOf("key1" to "value1", "key2" to currentDate, "key3" to null)
     )
 
+    private val inputObjectMapper: InputObjectMapper = DefaultInputObjectMapper()
+
     @Test
     fun mapToJavaClass() {
-        val mapToObject = mapToJavaObject(input, JInputObject::class.java)
+        val mapToObject = inputObjectMapper.mapToJavaObject(input, JInputObject::class.java)
         assertThat(mapToObject.simpleString).isEqualTo("hello")
         assertThat(mapToObject.someDate).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
@@ -60,7 +62,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToJavaClassWithKotlinProperty() {
-        val mapToObject = mapToJavaObject(inputKotlinJavaMix, JInputObjectWithKotlinProperty::class.java)
+        val mapToObject = inputObjectMapper.mapToJavaObject(inputKotlinJavaMix, JInputObjectWithKotlinProperty::class.java)
         assertThat(mapToObject.name).isEqualTo("dgs")
         assertThat(mapToObject.objectProperty.simpleString).isEqualTo("hello")
         assertThat(mapToObject.objectProperty.someObject.key1).isEqualTo("value1")
@@ -68,7 +70,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToKotlinDataClass() {
-        val mapToObject = InputObjectMapper.mapToKotlinObject(input, KotlinInputObject::class)
+        val mapToObject = inputObjectMapper.mapToKotlinObject(input, KotlinInputObject::class)
         assertThat(mapToObject.simpleString).isEqualTo("hello")
         assertThat(mapToObject.someDate).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
@@ -78,7 +80,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToKotlinDataClassWithJavaProperty() {
-        val mapToObject = InputObjectMapper.mapToKotlinObject(inputKotlinJavaMix, KotlinWithJavaProperty::class)
+        val mapToObject = inputObjectMapper.mapToKotlinObject(inputKotlinJavaMix, KotlinWithJavaProperty::class)
         assertThat(mapToObject.name).isEqualTo("dgs")
         assertThat(mapToObject.objectProperty.simpleString).isEqualTo("hello")
         assertThat(mapToObject.objectProperty.someObject.key1).isEqualTo("value1")
@@ -86,7 +88,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToJavaClassWithNull() {
-        val mapToObject = mapToJavaObject(inputWithNulls, JInputObject::class.java)
+        val mapToObject = inputObjectMapper.mapToJavaObject(inputWithNulls, JInputObject::class.java)
         assertThat(mapToObject.simpleString).isNull()
         assertThat(mapToObject.someDate).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
@@ -96,7 +98,7 @@ internal class InputObjectMapperTest {
 
     @Test
     fun mapToKotlinDataClassWithNull() {
-        val mapToObject = InputObjectMapper.mapToKotlinObject(inputWithNulls, KotlinInputObject::class)
+        val mapToObject = inputObjectMapper.mapToKotlinObject(inputWithNulls, KotlinInputObject::class)
         assertThat(mapToObject.simpleString).isNull()
         assertThat(mapToObject.someDate).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
@@ -107,7 +109,7 @@ internal class InputObjectMapperTest {
     @Test
     fun mapGenericJavaClassTwoTypeParams() {
         val input = mapOf("fieldA" to "value A", "fieldB" to listOf(1, 2, 3))
-        val mappedGeneric = mapToJavaObject(input, JGenericInputObjectTwoTypeParams::class.java)
+        val mappedGeneric = inputObjectMapper.mapToJavaObject(input, JGenericInputObjectTwoTypeParams::class.java)
 
         assertThat(mappedGeneric.fieldA).isEqualTo("value A")
         assertThat(mappedGeneric.fieldB).isEqualTo(listOf(1, 2, 3))
@@ -116,7 +118,7 @@ internal class InputObjectMapperTest {
     @Test
     fun mapGenericJavaClass() {
         val input = mapOf("someField" to "The String", "fieldA" to 1)
-        val mappedGeneric = mapToJavaObject(input, JGenericSubInputObject::class.java)
+        val mappedGeneric = inputObjectMapper.mapToJavaObject(input, JGenericSubInputObject::class.java)
 
         assertThat(mappedGeneric.fieldA).isEqualTo(1)
     }
@@ -128,7 +130,7 @@ internal class InputObjectMapperTest {
             "unknown" to "The String",
         )
 
-        val mapToObject = mapToJavaObject(input, JInputObject::class.java)
+        val mapToObject = inputObjectMapper.mapToJavaObject(input, JInputObject::class.java)
         assertThat(mapToObject).isNotNull
         assertThat(mapToObject.simpleString).isEqualTo("hello")
     }
@@ -139,7 +141,7 @@ internal class InputObjectMapperTest {
             "unknown" to "The String",
         )
 
-        assertThatThrownBy { mapToJavaObject(input, JInputObject::class.java) }.isInstanceOf(
+        assertThatThrownBy { inputObjectMapper.mapToJavaObject(input, JInputObject::class.java) }.isInstanceOf(
             DgsInvalidInputArgumentException::class.java
         )
     }
@@ -149,7 +151,7 @@ internal class InputObjectMapperTest {
         val inputWithNewProperty = input.toMutableMap()
         inputWithNewProperty["unkown"] = "something"
 
-        val mapToObject = InputObjectMapper.mapToKotlinObject(inputWithNewProperty, KotlinInputObject::class)
+        val mapToObject = inputObjectMapper.mapToKotlinObject(inputWithNewProperty, KotlinInputObject::class)
         assertThat(mapToObject).isNotNull
         assertThat(mapToObject.simpleString).isEqualTo("hello")
     }
@@ -160,7 +162,7 @@ internal class InputObjectMapperTest {
         // Use an Int as input where a String was expected
         newInput["simpleString"] = 1
 
-        assertThatThrownBy { mapToJavaObject(newInput, JInputObject::class.java) }.isInstanceOf(
+        assertThatThrownBy { inputObjectMapper.mapToJavaObject(newInput, JInputObject::class.java) }.isInstanceOf(
             DgsInvalidInputArgumentException::class.java
         ).hasMessageStartingWith("Invalid input argument `1` for field `simpleString` on type `com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObject`")
     }
@@ -171,7 +173,7 @@ internal class InputObjectMapperTest {
         // Use an Int as input where a String was expected
         newInput["simpleString"] = 1
 
-        assertThatThrownBy { InputObjectMapper.mapToKotlinObject(newInput, KotlinInputObject::class) }.isInstanceOf(
+        assertThatThrownBy { inputObjectMapper.mapToKotlinObject(newInput, KotlinInputObject::class) }.isInstanceOf(
             DgsInvalidInputArgumentException::class.java
         ).hasMessageStartingWith("Provided input arguments")
     }
@@ -179,21 +181,21 @@ internal class InputObjectMapperTest {
     @Test
     fun `A list argument should be able to convert to Set in Kotlin`() {
         val input = mapOf("items" to listOf(1, 2, 3))
-        val withSet = InputObjectMapper.mapToKotlinObject(input, KotlinObjectWithSet::class)
+        val withSet = inputObjectMapper.mapToKotlinObject(input, KotlinObjectWithSet::class)
         assertThat(withSet.items).isInstanceOf(Set::class.java)
     }
 
     @Test
     fun `A list argument should be able to convert to Set in Java`() {
         val input = mapOf("items" to listOf(1, 2, 3))
-        val withSet = mapToJavaObject(input, JInputObjectWithSet::class.java)
+        val withSet = inputObjectMapper.mapToJavaObject(input, JInputObjectWithSet::class.java)
         assertThat(withSet.items).isInstanceOf(Set::class.java)
     }
 
     @Test
     fun `A map argument should be able to convert to Map in Kotlin`() {
         val input = mapOf("json" to mapOf("key1" to "value1", "key2" to currentDate, "key3" to mapOf("subkey1" to "hi")))
-        val withMap = InputObjectMapper.mapToKotlinObject(input, KotlinObjectWithMap::class)
+        val withMap = inputObjectMapper.mapToKotlinObject(input, KotlinObjectWithMap::class)
         assertThat(withMap.json).isInstanceOf(Map::class.java)
         assertThat(withMap.json["key1"]).isEqualTo("value1")
     }
@@ -201,12 +203,54 @@ internal class InputObjectMapperTest {
     @Test
     fun `A map argument should be able to convert to Map in Java`() {
         val input = mapOf("json" to mapOf("key1" to "value1", "key2" to currentDate, "key3" to mapOf("subkey1" to "hi")))
-        val withMap = mapToJavaObject(input, JInputObjectWithMap::class.java)
+        val withMap = inputObjectMapper.mapToJavaObject(input, JInputObjectWithMap::class.java)
         assertThat(withMap.json).isInstanceOf(Map::class.java)
         assertThat(withMap.json["key1"]).isEqualTo("value1")
     }
 
+    @Test
+    fun `A custom object mapper should be used if available`() {
+
+        val customInputObjectMapper = object : InputObjectMapper {
+            override fun <T : Any> mapToKotlinObject(inputMap: Map<String, *>, targetClass: KClass<T>): T {
+                val filtered = inputMap.filterKeys { !it.startsWith("simple") }
+                return DefaultInputObjectMapper(this).mapToKotlinObject(filtered, targetClass)
+            }
+
+            override fun <T> mapToJavaObject(inputMap: Map<String, *>, targetClass: Class<T>): T {
+                TODO("Not yet implemented")
+            }
+        }
+
+        val rootObject = mapOf("input" to input)
+        val mapToObject = DefaultInputObjectMapper(customInputObjectMapper).mapToKotlinObject(rootObject, KotlinNestedInputObject::class)
+        assertThat(mapToObject.input.someObject).isNotNull
+        assertThat(mapToObject.input.simpleString).isNull()
+    }
+
+    @Test
+    fun `A custom object mapper should work recursively`() {
+
+        val customInputObjectMapper = object : InputObjectMapper {
+            override fun <T : Any> mapToKotlinObject(inputMap: Map<String, *>, targetClass: KClass<T>): T {
+                val filtered = inputMap.filterKeys { !it.startsWith("simple") }
+                return DefaultInputObjectMapper(this).mapToKotlinObject(filtered, targetClass)
+            }
+
+            override fun <T> mapToJavaObject(inputMap: Map<String, *>, targetClass: Class<T>): T {
+                TODO("Not yet implemented")
+            }
+        }
+
+        val rootObject = mapOf("inputL1" to mapOf("input" to input))
+        val mapToObject = DefaultInputObjectMapper(customInputObjectMapper).mapToKotlinObject(rootObject, KotlinDoubleNestedInputObject::class)
+        assertThat(mapToObject.inputL1.input.someObject).isNotNull
+        assertThat(mapToObject.inputL1.input.simpleString).isNull()
+    }
+
     data class KotlinInputObject(val simpleString: String?, val someDate: LocalDateTime, val someObject: KotlinSomeObject)
+    data class KotlinNestedInputObject(val input: KotlinInputObject)
+    data class KotlinDoubleNestedInputObject(val inputL1: KotlinNestedInputObject)
     data class KotlinSomeObject(val key1: String, val key2: LocalDateTime, val key3: KotlinSubObject?)
     data class KotlinSubObject(val subkey1: String)
     data class KotlinObjectWithSet(val items: Set<Int>)


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Issue #775
With this PR it's possible to provide your own `InputObjectMapper`. This can be useful for example to filter out fields from an input object, which is mostly to integrate with other frameworks/libraries, and is not intended to be used by most users.

Note that because `DefaultInputObjectMapper` calls itself recursively, for each field it goes a level deeper into an object structure it will call the custom mapper if available. The custom mapper in turn, might still call the `DefaultInputObjectMapper` after modifying the input map. It's easy to create a never ending recursion here, so be careful implementing this!

This extension does *not* make it possible to drop in a Jackson Object Mapper, since the input isn't JSON. 
