### PR TITLE
Only use USER_DECLARED_METHODS when looking for DataFetchers

### DIFF
--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -39,4 +39,5 @@ dependencies {
     testImplementation("io.projectreactor:reactor-core")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("com.graphql-java:graphql-java-extended-scalars")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherResultProcessor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherResultProcessor.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
+
+interface DataFetcherResultProcessor {
+
+    fun supportsType(originalResult: Any): Boolean
+
+    fun process(originalResult: Any, dfe: DgsDataFetchingEnvironment): Any = process(originalResult)
+
+    @Deprecated(
+        "Replaced with process(originalResult, dfe)",
+        replaceWith = ReplaceWith("process(originalResult: Any, dfe: DgsDataFetchingEnvironment)")
+    )
+    fun process(originalResult: Any): Any = originalResult
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DatafetcherReference.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DatafetcherReference.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import org.springframework.core.annotation.MergedAnnotations
+import java.lang.reflect.Method
+
+data class DatafetcherReference(
+    val instance: Any,
+    val method: Method,
+    val annotations: MergedAnnotations,
+    val parentType: String,
+    val field: String
+)

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
@@ -49,25 +49,18 @@ class CoroutineDataFetcherTest {
             suspend fun concurrent(@InputArgument from: Int, to: Int): Int = coroutineScope {
                 var sum = 0
                 withContext(executor.asCoroutineDispatcher()) {
-                    println("before $from")
                     repeat(from.rangeTo(to).count()) {
                         sum++
-
                         // Forcing a blocking call to demonstrate running with a thread pool
                         Thread.sleep(50)
                     }
-                    println("after $from")
-
                     sum
                 }
             }
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "concurrentFetcher",
-                fetcher
-            )
+            "concurrentFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -138,10 +131,7 @@ class CoroutineDataFetcherTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "exceptionWithMessageFetcher",
-                fetcher
-            )
+            "exceptionWithMessageFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Invoking `ReflectionUtils.getUniqueDeclaredMethods(javaClass)` will return all methods, including synthetic methods added by frameworks. We should only use methods that are explicitly declared by users, via `USER_DECLARED_METHODS`.

Fixes #834
