### PR TITLE
Improve handling of unexpected subscription requests on /graphql.

### DIFF
--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -26,12 +26,16 @@ import com.netflix.graphql.dgs.internal.utils.MultipartVariableMapper
 import com.netflix.graphql.dgs.internal.utils.TimeTracer
 import graphql.ExecutionResultImpl
 import graphql.GraphqlErrorBuilder
-import graphql.execution.reactive.CompletionStageMappingPublisher
+import graphql.execution.reactive.SubscriptionPublisher
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.multipart.MultipartFile
 
@@ -192,7 +196,7 @@ open class DgsRestController(
             executionResult.errors.size
         )
 
-        if (executionResult.isDataPresent && executionResult.getData<Any>() is CompletionStageMappingPublisher<*, *>) {
+        if (executionResult.isDataPresent && executionResult.getData<Any>() is SubscriptionPublisher) {
             return ResponseEntity.badRequest()
                 .body("Trying to execute subscription on /graphql. Use /subscriptions instead!")
         }

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsRestControllerTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsRestControllerTest.kt
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import graphql.ExecutionResultImpl
-import graphql.execution.reactive.CompletionStageMappingPublisher
+import graphql.execution.reactive.SubscriptionPublisher
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -149,7 +149,7 @@ class DgsRestControllerTest {
                 any()
             )
         } returns ExecutionResultImpl.newExecutionResult()
-            .data(CompletionStageMappingPublisher<String, String>(null, null)).build()
+            .data(SubscriptionPublisher(null, null)).build()
 
         val result =
             DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, HttpHeaders(), webRequest)


### PR DESCRIPTION


Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
When we receive subscription queries on /graphql, the framework needs to provide clear error messaging rather than returning data with no indication of error:
```
{
  "data": {
    "upstreamPublisher": {
      "scanAvailable": true,
      "prefetch": -1
    }
  }
}
```

