### PR TITLE
Move result processors for Flux/Mono to graphql-dgs

### DIFF
--- a/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/ReactiveReturnTypesTest.kt
+++ b/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/ReactiveReturnTypesTest.kt
@@ -23,10 +23,10 @@ import com.netflix.graphql.dgs.DgsScalar
 import com.netflix.graphql.dgs.exceptions.QueryException
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.FluxDataFetcherResultProcessor
+import com.netflix.graphql.dgs.internal.MonoDataFetcherResultProcessor
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveGraphQLContextBuilder
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveQueryExecutor
-import com.netflix.graphql.dgs.reactive.internal.FluxDataFetcherResultProcessor
-import com.netflix.graphql.dgs.reactive.internal.MonoDataFetcherResultProcessor
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation

--- a/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     compileOnly("com.github.ben-manes.caffeine:caffeine")
     compileOnly("io.micrometer:micrometer-core")
+    compileOnly("io.projectreactor:reactor-core")
 
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("com.github.ben-manes.caffeine:caffeine")

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -80,6 +80,9 @@
         "io.micrometer:micrometer-core": {
             "locked": "1.5.14"
         },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.4.10"
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -30,7 +30,9 @@ import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsNoOpPreparsedDocumentProvider
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.FluxDataFetcherResultProcessor
 import com.netflix.graphql.dgs.internal.InputObjectMapper
+import com.netflix.graphql.dgs.internal.MonoDataFetcherResultProcessor
 import com.netflix.graphql.dgs.internal.QueryValueCustomizer
 import com.netflix.graphql.dgs.scalars.UploadScalar
 import com.netflix.graphql.mocking.MockProvider
@@ -50,6 +52,7 @@ import graphql.schema.visibility.GraphqlFieldVisibility
 import graphql.schema.visibility.NoIntrospectionGraphqlFieldVisibility.NO_INTROSPECTION_FIELD_VISIBILITY
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
@@ -219,5 +222,19 @@ open class DgsAutoConfiguration(
     @Bean
     open fun uploadScalar(): UploadScalar {
         return UploadScalar()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnClass(name = ["reactor.core.publisher.Mono"])
+    open fun monoReactiveDataFetcherResultProcessor(): MonoDataFetcherResultProcessor {
+        return MonoDataFetcherResultProcessor()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnClass(name = ["reactor.core.publisher.Flux"])
+    open fun fluxReactiveDataFetcherResultProcessor(): FluxDataFetcherResultProcessor {
+        return FluxDataFetcherResultProcessor()
     }
 }

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -20,13 +20,13 @@ import com.netflix.graphql.dgs.internal.CookieValueResolver
 import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.FluxDataFetcherResultProcessor
+import com.netflix.graphql.dgs.internal.MonoDataFetcherResultProcessor
 import com.netflix.graphql.dgs.internal.QueryValueCustomizer
 import com.netflix.graphql.dgs.reactive.DgsReactiveCustomContextBuilderWithRequest
 import com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveGraphQLContextBuilder
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveQueryExecutor
-import com.netflix.graphql.dgs.reactive.internal.FluxDataFetcherResultProcessor
-import com.netflix.graphql.dgs.reactive.internal.MonoDataFetcherResultProcessor
 import com.netflix.graphql.dgs.webflux.handlers.DefaultDgsWebfluxHttpHandler
 import com.netflix.graphql.dgs.webflux.handlers.DgsHandshakeWebSocketService
 import com.netflix.graphql.dgs.webflux.handlers.DgsReactiveWebsocketHandler
@@ -190,11 +190,13 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
     }
 
     @Bean
+    @ConditionalOnMissingBean
     open fun monoReactiveDataFetcherResultProcessor(): MonoDataFetcherResultProcessor {
         return MonoDataFetcherResultProcessor()
     }
 
     @Bean
+    @ConditionalOnMissingBean
     open fun fluxReactiveDataFetcherResultProcessor(): FluxDataFetcherResultProcessor {
         return FluxDataFetcherResultProcessor()
     }

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/MalformedQueryContentTest.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/MalformedQueryContentTest.kt
@@ -18,17 +18,18 @@ package com.netflix.graphql.dgs.webflux
 
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsTypeDefinitionRegistry
+import com.netflix.graphql.dgs.webflux.autoconfiguration.DgsWebFluxAutoConfiguration
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.web.reactive.config.EnableWebFlux
@@ -36,7 +37,7 @@ import org.springframework.web.reactive.config.EnableWebFlux
 @SpringBootTest
 @EnableWebFlux
 @AutoConfigureWebTestClient
-@EnableAutoConfiguration
+@Import(DgsWebFluxAutoConfiguration::class)
 class MalformedQueryContentTest {
 
     @Autowired

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/apq/DgsWebFluxAutomatedPersistedQueriesSmokeTest.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/apq/DgsWebFluxAutomatedPersistedQueriesSmokeTest.kt
@@ -18,6 +18,7 @@ package com.netflix.graphql.dgs.webflux.apq
 
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsTypeDefinitionRegistry
+import com.netflix.graphql.dgs.webflux.autoconfiguration.DgsWebFluxAutoConfiguration
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import org.junit.jupiter.api.MethodOrderer
@@ -27,12 +28,12 @@ import org.junit.jupiter.api.TestMethodOrder
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.config.EnableWebFlux
 
@@ -44,7 +45,7 @@ import org.springframework.web.reactive.config.EnableWebFlux
 )
 @EnableWebFlux
 @AutoConfigureWebTestClient
-@EnableAutoConfiguration
+@Import(DgsWebFluxAutoConfiguration::class)
 @Execution(ExecutionMode.SAME_THREAD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class DgsWebFluxAutomatedPersistedQueriesSmokeTest {

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework:spring-context")
 
     compileOnly("org.springframework.security:spring-security-core")
+    compileOnly("io.projectreactor:reactor-core")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -61,6 +61,9 @@
         "com.netflix.graphql.dgs:graphql-error-types": {
             "project": true
         },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.4.10"
+        },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.5.32"
         },
@@ -462,6 +465,9 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
             "locked": "1.3.8"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
+            "locked": "1.3.8"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
         },
@@ -558,6 +564,9 @@
             "locked": "1.3.8"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "locked": "1.3.8"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
             "locked": "1.3.8"
         },
         "org.slf4j:slf4j-api": {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/ReactiveDataFetcherResultProcessor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/ReactiveDataFetcherResultProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.reactive.internal
+package com.netflix.graphql.dgs.internal
 
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
-import com.netflix.graphql.dgs.internal.DataFetcherResultProcessor
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.lang.IllegalArgumentException


### PR DESCRIPTION
Move MonoDataFetcherResultProcessor and FluxDataFetcherResultProcessor out
of graphql-dgs-reactive and into graphql-dgs, so they can be used without
WebFlux. DgsAutoConfiguration will now register them as beans conditional
on the presence of the Mono / Flux classes.