### PR TITLE
Automatic DgsDataLoader naming

### DIFF
--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Component
 public @interface DgsDataLoader {
-    String name();
+    String GENERATE_DATA_LOADER_NAME = "NETFLIX_DGS_GENERATE_DATALOADER_NAME";
+
+    String name() default GENERATE_DATA_LOADER_NAME;
 
     boolean caching() default true;
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,14 @@ import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.graphql.dgs.DgsDataLoaderRegistryConsumer
 import com.netflix.graphql.dgs.exceptions.InvalidDataLoaderTypeException
 import com.netflix.graphql.dgs.exceptions.UnsupportedSecuredDataLoaderException
-import org.dataloader.*
+import com.netflix.graphql.dgs.internal.utils.DataLoaderNameUtil
+import org.dataloader.BatchLoader
+import org.dataloader.BatchLoaderWithContext
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderOptions
+import org.dataloader.DataLoaderRegistry
+import org.dataloader.MappedBatchLoader
+import org.dataloader.MappedBatchLoaderWithContext
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.aop.support.AopUtils
@@ -37,10 +44,12 @@ import javax.annotation.PostConstruct
  */
 class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) {
 
-    private val batchLoaders = mutableListOf<Pair<BatchLoader<*, *>, DgsDataLoader>>()
-    private val batchLoadersWithContext = mutableListOf<Pair<BatchLoaderWithContext<*, *>, DgsDataLoader>>()
-    private val mappedBatchLoaders = mutableListOf<Pair<MappedBatchLoader<*, *>, DgsDataLoader>>()
-    private val mappedBatchLoadersWithContext = mutableListOf<Pair<MappedBatchLoaderWithContext<*, *>, DgsDataLoader>>()
+    data class LoaderHolder<T>(val theLoader: T, val annotation: DgsDataLoader, val name: String)
+
+    private val batchLoaders = mutableListOf<LoaderHolder<BatchLoader<*, *>>>()
+    private val batchLoadersWithContext = mutableListOf<LoaderHolder<BatchLoaderWithContext<*, *>>>()
+    private val mappedBatchLoaders = mutableListOf<LoaderHolder<MappedBatchLoader<*, *>>>()
+    private val mappedBatchLoadersWithContext = mutableListOf<LoaderHolder<MappedBatchLoaderWithContext<*, *>>>()
 
     fun buildRegistry(): DataLoaderRegistry {
         return buildRegistryWithContextSupplier { null }
@@ -50,24 +59,17 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         val startTime = System.currentTimeMillis()
 
         val dataLoaderRegistry = DataLoaderRegistry()
-        batchLoaders.forEach { dataLoaderRegistry.register(it.second.name, createDataLoader(it.first, it.second, dataLoaderRegistry)) }
+        batchLoaders.forEach {
+            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, dataLoaderRegistry))
+        }
         mappedBatchLoaders.forEach {
-            dataLoaderRegistry.register(
-                it.second.name,
-                createDataLoader(it.first, it.second, dataLoaderRegistry)
-            )
+            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, dataLoaderRegistry))
         }
         batchLoadersWithContext.forEach {
-            dataLoaderRegistry.register(
-                it.second.name,
-                createDataLoader(it.first, it.second, contextSupplier, dataLoaderRegistry)
-            )
+            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, contextSupplier, dataLoaderRegistry))
         }
         mappedBatchLoadersWithContext.forEach {
-            dataLoaderRegistry.register(
-                it.second.name,
-                createDataLoader(it.first, it.second, contextSupplier, dataLoaderRegistry)
-            )
+            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, contextSupplier, dataLoaderRegistry))
         }
 
         val endTime = System.currentTimeMillis()
@@ -96,15 +98,12 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
                     val annotation = field.getAnnotation(DgsDataLoader::class.java)
                     ReflectionUtils.makeAccessible(field)
 
+                    val name: () -> String = { DataLoaderNameUtil.getDataLoaderName(field, annotation) }
                     when (val get = field.get(dgsComponent)) {
-                        is BatchLoader<*, *> ->
-                            batchLoaders.add(get to annotation)
-                        is BatchLoaderWithContext<*, *> ->
-                            batchLoadersWithContext.add(get to annotation)
-                        is MappedBatchLoader<*, *> ->
-                            mappedBatchLoaders.add(get to annotation)
-                        is MappedBatchLoaderWithContext<*, *> ->
-                            mappedBatchLoadersWithContext.add(get to annotation)
+                        is BatchLoader<*, *> -> batchLoaders.add(LoaderHolder(get, annotation, name()))
+                        is BatchLoaderWithContext<*, *> -> batchLoadersWithContext.add(LoaderHolder(get, annotation, name()))
+                        is MappedBatchLoader<*, *> -> mappedBatchLoaders.add(LoaderHolder(get, annotation, name()))
+                        is MappedBatchLoaderWithContext<*, *> -> mappedBatchLoadersWithContext.add(LoaderHolder(get, annotation, name()))
                         else -> throw InvalidDataLoaderTypeException(dgsComponent::class.java)
                     }
                 }
@@ -116,15 +115,16 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         dataLoaders.values.forEach { dgsComponent ->
             val javaClass = AopUtils.getTargetClass(dgsComponent)
             val annotation = javaClass.getAnnotation(DgsDataLoader::class.java)
+            val name: () -> String = { DataLoaderNameUtil.getDataLoaderName(javaClass, annotation) }
             when (dgsComponent) {
                 is BatchLoader<*, *> ->
-                    batchLoaders.add(Pair(dgsComponent, annotation))
+                    batchLoaders.add(LoaderHolder(dgsComponent, annotation, name()))
                 is BatchLoaderWithContext<*, *> ->
-                    batchLoadersWithContext.add(Pair(dgsComponent, annotation))
+                    batchLoadersWithContext.add(LoaderHolder(dgsComponent, annotation, name()))
                 is MappedBatchLoader<*, *> ->
-                    mappedBatchLoaders.add(Pair(dgsComponent, annotation))
+                    mappedBatchLoaders.add(LoaderHolder(dgsComponent, annotation, name()))
                 is MappedBatchLoaderWithContext<*, *> ->
-                    mappedBatchLoadersWithContext.add(Pair(dgsComponent, annotation))
+                    mappedBatchLoadersWithContext.add(LoaderHolder(dgsComponent, annotation, name()))
                 else -> throw InvalidDataLoaderTypeException(dgsComponent::class.java)
             }
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/DataLoaderNameUtil.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/DataLoaderNameUtil.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.utils
+
+import com.netflix.graphql.dgs.DgsDataLoader
+import java.lang.reflect.Field
+
+object DataLoaderNameUtil {
+
+    fun getDataLoaderName(field: Field, annotation: DgsDataLoader): String {
+        return if (annotation.name == DgsDataLoader.GENERATE_DATA_LOADER_NAME)
+            "DGS_DATALOADER_FIELD_" + field.declaringClass.name + "#" + field.name else annotation.name
+    }
+
+    fun getDataLoaderName(clazz: Class<*>, annotation: DgsDataLoader): String {
+        return if (annotation.name == DgsDataLoader.GENERATE_DATA_LOADER_NAME)
+            "DGS_DATALOADER_CLASS_" + clazz.name else annotation.name
+    }
+}

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/ExampleBatchLoaderWithoutNameFromField.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/ExampleBatchLoaderWithoutNameFromField.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs;
+
+import org.dataloader.BatchLoader;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+@DgsComponent
+public class ExampleBatchLoaderWithoutNameFromField {
+    @DgsDataLoader
+    public BatchLoader<String, String> batchLoader = keys -> CompletableFuture.supplyAsync(() -> {
+        List<String> values = new ArrayList<>();
+        values.add("a");
+        values.add("b");
+        values.add("c");
+        return values;
+    });
+
+    @DgsDataLoader
+    BatchLoader<String, String> privateBatchLoader = keys -> CompletableFuture.supplyAsync(() -> {
+        List<String> values = new ArrayList<>();
+        values.add("a");
+        values.add("b");
+        values.add("c");
+        return values;
+    });
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithoutName.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithoutName.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.BatchLoader
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader
+class ExampleBatchLoaderWithoutName : BatchLoader<String, String> {
+    override fun load(keys: MutableList<String>?): CompletionStage<MutableList<String>> {
+        return CompletableFuture.supplyAsync { mutableListOf("a", "b", "c") }
+    }
+}


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This PR automatically names dataloaders, which is useful when using the `DgsDataFetchingEnvironment#getDataLoader(Class)` method.

It also implements automatic naming of field loaders, which is arguably less useful. If anyone objects to this we can error out on nameless field dataloaders.

Something to consider is that metric and tracing solutions may expose (field?)/class/package names of the dataloader. In the future we can add a `DgsDataLoaderNamingFactory` or something that gives library consumers the ability to modify the name programmatically (e.g. - only use the class name instead of the FQN) - this PR does not implement this.

Partially related to https://github.com/Netflix/dgs-framework/issues/861

Alternatives considered
----

Name the loaders


