### PR TITLE
Remove cyclic dependency between SchemaProvider and DefaultDgsFederat…

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
@@ -27,4 +27,5 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("com.github.ben-manes.caffeine:caffeine")
+    testImplementation("io.projectreactor:reactor-core")
 }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -522,6 +522,9 @@
         "io.mockk:mockk": {
             "locked": "1.12.2"
         },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.4.10"
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"
         },
@@ -641,6 +644,9 @@
         },
         "io.mockk:mockk": {
             "locked": "1.12.2"
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.4.10"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.10"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -21,19 +21,8 @@ import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilder
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilderWithRequest
 import com.netflix.graphql.dgs.exceptions.DefaultDataFetcherExceptionHandler
-import com.netflix.graphql.dgs.internal.CookieValueResolver
-import com.netflix.graphql.dgs.internal.DataFetcherResultProcessor
-import com.netflix.graphql.dgs.internal.DefaultDgsGraphQLContextBuilder
-import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
+import com.netflix.graphql.dgs.internal.*
 import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor.ReloadSchemaIndicator
-import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
-import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
-import com.netflix.graphql.dgs.internal.DgsNoOpPreparsedDocumentProvider
-import com.netflix.graphql.dgs.internal.DgsSchemaProvider
-import com.netflix.graphql.dgs.internal.FluxDataFetcherResultProcessor
-import com.netflix.graphql.dgs.internal.InputObjectMapper
-import com.netflix.graphql.dgs.internal.MonoDataFetcherResultProcessor
-import com.netflix.graphql.dgs.internal.QueryValueCustomizer
 import com.netflix.graphql.dgs.scalars.UploadScalar
 import com.netflix.graphql.mocking.MockProvider
 import graphql.execution.AsyncExecutionStrategy
@@ -168,7 +157,8 @@ open class DgsAutoConfiguration(
         dataFetcherResultProcessors: List<DataFetcherResultProcessor>,
         dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler> = Optional.empty(),
         cookieValueResolver: Optional<CookieValueResolver> = Optional.empty(),
-        inputObjectMapper: Optional<InputObjectMapper> = Optional.empty()
+        inputObjectMapper: Optional<InputObjectMapper> = Optional.empty(),
+        entityFetcherRegistry: EntityFetcherRegistry
     ): DgsSchemaProvider {
         return DgsSchemaProvider(
             applicationContext,
@@ -179,8 +169,14 @@ open class DgsAutoConfiguration(
             dataFetcherResultProcessors,
             dataFetcherExceptionHandler,
             cookieValueResolver,
-            inputObjectMapper.orElse(DefaultInputObjectMapper())
+            inputObjectMapper.orElse(DefaultInputObjectMapper()),
+            entityFetcherRegistry
         )
+    }
+
+    @Bean
+    open fun entityFetcherRegistry(): EntityFetcherRegistry {
+        return EntityFetcherRegistry()
     }
 
     @Bean

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/CustomFederationResolverTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/CustomFederationResolverTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsEntityFetcher
+import com.netflix.graphql.dgs.DgsFederationResolver
+import com.netflix.graphql.dgs.DgsQueryExecutor
+import com.netflix.graphql.dgs.federation.DefaultDgsFederationResolver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+class CustomFederationResolverTest {
+
+    private val context = WebApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(DgsAutoConfiguration::class.java))!!
+
+    @Test
+    fun `When a custom federation resolver is registered, it should be used`() {
+        context.withUserConfiguration(MyFederationConfig::class.java).run { ctx ->
+            assertThat(ctx).getBean(DgsQueryExecutor::class.java).extracting {
+                val representation = mapOf(Pair("__typename", "MyMovie"), Pair("id", "1"))
+                val variables = mapOf(Pair("representations", listOf(representation)))
+
+                val title = it.executeAndExtractJsonPathAsObject(
+                    """query (${'$'}representations:[_Any!]!) { 
+                                _entities(representations:${'$'}representations) {
+                                    ... on MyMovie {   
+                                        title 
+                                    } 
+                                }
+                            }""",
+                    "data['_entities'][0].title", variables, String::class.java
+                )
+
+                assertThat(title).isEqualTo("some title")
+            }
+        }
+    }
+
+    @Configuration
+    open class MyFederationConfig {
+        @Bean
+        open fun federationResolver(): DgsFederationResolver {
+            return MyFederationResolver()
+        }
+
+        @Bean
+        open fun movieFetcher(): MovieDataFetcher {
+            return MovieDataFetcher()
+        }
+    }
+
+    @DgsComponent
+    class MovieDataFetcher {
+        @DgsEntityFetcher(name = "MyMovie")
+        fun movieEntityFetcher(arguments: Map<String, Any>): Movie {
+            return Movie()
+        }
+    }
+
+    class MyFederationResolver : DefaultDgsFederationResolver() {
+        override fun typeMapping(): Map<Class<*>, String> {
+            return mapOf(Pair(Movie::class.java, "MyMovie"))
+        }
+    }
+
+    class Movie {
+        val title: String = "some title"
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/resources/schema/schema.graphqls
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/resources/schema/schema.graphqls
@@ -36,3 +36,8 @@ type Output {
 input NestedInput {
     input: Input
 }
+
+type MyMovie @key(fields: "id") @extends {
+    id: String
+    title: String
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -23,7 +23,7 @@ import com.netflix.graphql.dgs.DgsFederationResolver
 import com.netflix.graphql.dgs.exceptions.InvalidDgsEntityFetcher
 import com.netflix.graphql.dgs.exceptions.MissingDgsEntityFetcherException
 import com.netflix.graphql.dgs.exceptions.MissingFederatedQueryArgument
-import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.EntityFetcherRegistry
 import com.netflix.graphql.types.errors.TypedGraphQLError
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherExceptionHandlerParameters
@@ -52,10 +52,10 @@ open class DefaultDgsFederationResolver() :
      * The default constructor is used to extend the DefaultDgsFederationResolver. In that case injection is used to provide the schemaProvider.
      */
     constructor(
-        providedDgsSchemaProvider: DgsSchemaProvider,
+        entityFetcherRegistry: EntityFetcherRegistry,
         dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler>
     ) : this() {
-        dgsSchemaProvider = providedDgsSchemaProvider
+        this.entityFetcherRegistry = entityFetcherRegistry
         dgsExceptionHandler = dataFetcherExceptionHandler
     }
 
@@ -64,7 +64,7 @@ open class DefaultDgsFederationResolver() :
      */
     @Suppress("JoinDeclarationAndAssignment")
     @Autowired
-    lateinit var dgsSchemaProvider: DgsSchemaProvider
+    lateinit var entityFetcherRegistry: EntityFetcherRegistry
 
     @Autowired
     lateinit var dgsExceptionHandler: Optional<DataFetcherExceptionHandler>
@@ -81,7 +81,7 @@ open class DefaultDgsFederationResolver() :
                 Try.tryCall {
                     val typename = values["__typename"]
                         ?: throw MissingFederatedQueryArgument("__typename")
-                    val fetcher = dgsSchemaProvider.entityFetchers[typename]
+                    val fetcher = entityFetcherRegistry.entityFetchers[typename]
                         ?: throw MissingDgsEntityFetcherException(typename.toString())
 
                     if (!fetcher.second.parameterTypes.any { it.isAssignableFrom(Map::class.java) }) {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -72,10 +72,10 @@ class DgsSchemaProvider(
     private val dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler> = Optional.empty(),
     private val cookieValueResolver: Optional<CookieValueResolver> = Optional.empty(),
     private val inputObjectMapper: InputObjectMapper = DefaultInputObjectMapper(),
+    private val entityFetcherRegistry: EntityFetcherRegistry = EntityFetcherRegistry()
 ) {
 
     val dataFetcherInstrumentationEnabled = mutableMapOf<String, Boolean>()
-    val entityFetchers = mutableMapOf<String, Pair<Any, Method>>()
     val dataFetchers = mutableListOf<DatafetcherReference>()
 
     private val defaultParameterNameDiscoverer = DefaultParameterNameDiscoverer()
@@ -102,7 +102,7 @@ class DgsSchemaProvider(
         }
 
         val federationResolverInstance =
-            federationResolver.orElseGet { DefaultDgsFederationResolver(this, dataFetcherExceptionHandler) }
+            federationResolver.orElseGet { DefaultDgsFederationResolver(entityFetcherRegistry, dataFetcherExceptionHandler) }
 
         val entityFetcher = federationResolverInstance.entitiesFetcher()
         val typeResolver = federationResolverInstance.typeResolver()
@@ -310,7 +310,7 @@ class DgsSchemaProvider(
                     dataFetcherInstrumentationEnabled["${"__entities"}.${dgsEntityFetcherAnnotation.name}"] =
                         enableInstrumentation
 
-                    entityFetchers[dgsEntityFetcherAnnotation.name] = dgsComponent to method
+                    entityFetcherRegistry.entityFetchers[dgsEntityFetcherAnnotation.name] = dgsComponent to method
                 }
         }
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/EntityFetcherRegistry.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/EntityFetcherRegistry.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import java.lang.reflect.Method
+
+class EntityFetcherRegistry {
+    val entityFetchers = mutableMapOf<String, Pair<Any, Method>>()
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DefaultDgsFederationResolverTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DefaultDgsFederationResolverTest.kt
@@ -21,6 +21,7 @@ import com.netflix.graphql.dgs.exceptions.DefaultDataFetcherExceptionHandler
 import com.netflix.graphql.dgs.exceptions.DgsInvalidInputArgumentException
 import com.netflix.graphql.dgs.federation.DefaultDgsFederationResolver
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.EntityFetcherRegistry
 import graphql.TypeResolutionEnvironment
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherResult
@@ -55,6 +56,8 @@ class DefaultDgsFederationResolverTest {
     @MockK
     lateinit var applicationContextMock: ApplicationContext
 
+    lateinit var entityFetcherRegistry: EntityFetcherRegistry
+
     lateinit var dgsSchemaProvider: DgsSchemaProvider
 
     lateinit var dgsExceptionHandler: DataFetcherExceptionHandler
@@ -62,12 +65,15 @@ class DefaultDgsFederationResolverTest {
     @BeforeEach
     fun setup() {
         dgsExceptionHandler = DefaultDataFetcherExceptionHandler()
+        entityFetcherRegistry = EntityFetcherRegistry()
+
         dgsSchemaProvider = DgsSchemaProvider(
             applicationContext = applicationContextMock,
             federationResolver = Optional.empty(),
             existingTypeDefinitionRegistry = Optional.empty(),
             mockProviders = Optional.empty(),
-            dataFetcherExceptionHandler = Optional.of(dgsExceptionHandler)
+            dataFetcherExceptionHandler = Optional.of(dgsExceptionHandler),
+            entityFetcherRegistry = entityFetcherRegistry
         )
     }
 
@@ -90,7 +96,7 @@ class DefaultDgsFederationResolverTest {
             val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
 
             val type =
-                DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler))
+                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                     .typeResolver()
                     .getType(
                         TypeResolutionEnvironment(
@@ -115,7 +121,7 @@ class DefaultDgsFederationResolverTest {
 
             val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
 
-            val type = DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler))
+            val type = DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                 .typeResolver()
                 .getType(
                     TypeResolutionEnvironment(
@@ -146,7 +152,7 @@ class DefaultDgsFederationResolverTest {
 
             val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
             val customTypeResolver =
-                object : DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler)) {
+                object : DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler)) {
                     override fun typeMapping(): Map<Class<*>, String> {
                         return mapOf(Movie::class.java to "DgsMovie")
                     }
@@ -172,7 +178,7 @@ class DefaultDgsFederationResolverTest {
                 DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
             val result =
                 (
-                    DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                     )
@@ -190,7 +196,7 @@ class DefaultDgsFederationResolverTest {
                 DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
             val result =
                 (
-                    DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                     )
@@ -295,7 +301,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                     )
@@ -335,7 +341,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler)).entitiesFetcher()
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler)).entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                     )
 
@@ -411,7 +417,7 @@ class DefaultDgsFederationResolverTest {
             )
             val result =
                 (
-                    DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler)).entitiesFetcher()
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler)).entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                     )
 
@@ -452,7 +458,7 @@ class DefaultDgsFederationResolverTest {
                 DataFetchingEnvironmentImpl.newDataFetchingEnvironment().arguments(arguments).build()
 
             val result =
-                DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler))
+                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                     .entitiesFetcher().get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
 
             assertThat(result).isNotNull
@@ -469,7 +475,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(dgsSchemaProvider, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                         .entitiesFetcher().get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                     )
 


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Remove cyclic dependency between SchemaProvider and DefaultDgsFederationResolver.
I've introduced a `EntityFetcherRegistry` which is a bean shared by schemaProvider and the `DefaultDgsFederationResolver`, so that those beans don't depend on each other anymore.
