### PR TITLE
Make the object mapper used for query execution configurable.

### DIFF
--- a/graphql-dgs-spring-webmvc-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-webmvc-autoconfigure/build.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework:spring-webmvc")
     implementation("jakarta.servlet:jakarta.servlet-api")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
 
     testImplementation(project(":graphql-dgs-spring-boot-oss-autoconfigure"))
     testImplementation("org.springframework.boot:spring-boot-starter-web")

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfiguration.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfiguration.kt
@@ -16,13 +16,17 @@
 
 package com.netflix.graphql.dgs.webmvc.autoconfigure
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.internal.CookieValueResolver
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.dgs.mvc.DgsRestController
 import com.netflix.graphql.dgs.mvc.DgsRestSchemaJsonController
 import com.netflix.graphql.dgs.mvc.ServletCookieValueResolver
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -36,8 +40,15 @@ import org.springframework.web.servlet.DispatcherServlet
 @EnableConfigurationProperties(DgsWebMvcConfigurationProperties::class)
 open class DgsWebMvcAutoConfiguration {
     @Bean
-    open fun dgsRestController(dgsQueryExecutor: DgsQueryExecutor): DgsRestController {
-        return DgsRestController(dgsQueryExecutor)
+    @Qualifier("dgsObjectMapper")
+    @ConditionalOnMissingBean(name = ["dgsObjectMapper"])
+    open fun dgsObjectMapper(): ObjectMapper {
+        return jacksonObjectMapper()
+    }
+
+    @Bean
+    open fun dgsRestController(dgsQueryExecutor: DgsQueryExecutor, @Qualifier("dgsObjectMapper") objectMapper: ObjectMapper): DgsRestController {
+        return DgsRestController(dgsQueryExecutor, objectMapper)
     }
 
     @Bean

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.mvc
 
 import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -66,7 +67,8 @@ import org.springframework.web.multipart.MultipartFile
 
 @RestController
 open class DgsRestController(
-    open val dgsQueryExecutor: DgsQueryExecutor
+    open val dgsQueryExecutor: DgsQueryExecutor,
+    open val mapper: ObjectMapper = jacksonObjectMapper()
 ) {
 
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
@@ -219,6 +221,5 @@ open class DgsRestController(
 
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
-        private val mapper = jacksonObjectMapper()
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This PR makes the object mapper used for query deserialization configurable.

_Describe the new behavior from this PR, and why it's needed_
Issue #813
