### PR TITLE
Support @RequestHeader with HttpHeader/Map/MultiValueMap types.

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.future.asCompletableFuture
 import org.slf4j.LoggerFactory
 import org.springframework.core.DefaultParameterNameDiscoverer
 import org.springframework.core.annotation.AnnotationUtils
+import org.springframework.http.HttpHeaders
+import org.springframework.util.MultiValueMap
 import org.springframework.util.ReflectionUtils
 import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.RequestHeader
@@ -174,6 +176,13 @@ class DataFetcherInvoker(
         val annotation = AnnotationUtils.getAnnotation(parameter, RequestHeader::class.java)!!
         val name: String = AnnotationUtils.getAnnotationAttributes(annotation)["name"] as String
         val parameterName = name.ifBlank { parameterNames[idx] }
+
+        if (parameter.type.isAssignableFrom(Map::class.java)) {
+            return getValueAsOptional(requestData?.headers?.toSingleValueMap(), parameter)
+        } else if (parameter.type.isAssignableFrom(HttpHeaders::class.java) || parameter.type.isAssignableFrom(MultiValueMap::class.java)) {
+            return getValueAsOptional(requestData?.headers, parameter)
+        }
+
         val value = requestData?.headers?.get(parameterName)?.let {
             if (parameter.type.isAssignableFrom(List::class.java)) {
                 it

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -68,6 +68,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.multipart.MultipartFile
+import org.springframework.util.MultiValueMap
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -1042,6 +1043,105 @@ internal class InputArgumentTest {
             @DgsData(parentType = "Query", field = "hello")
             fun someFetcher(@RequestHeader referer: String): String {
                 return "From, $referer"
+            }
+        }
+
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
+            Pair(
+                "helloFetcher",
+                fetcher
+            )
+        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
+
+        val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+        val schema = provider.schema()
+
+        val build = GraphQL.newGraphQL(schema).build()
+        val httpHeaders = HttpHeaders()
+        httpHeaders.add("Referer", "localhost")
+        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
+        Assertions.assertTrue(executionResult.isDataPresent)
+        val data = executionResult.getData<Map<String, *>>()
+        Assertions.assertEquals("From, localhost", data["hello"])
+
+        verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
+    }
+
+    @Test
+    fun `A @RequestHeader argument with map should be supported`() {
+        val fetcher = object : Any() {
+            @DgsData(parentType = "Query", field = "hello")
+            fun someFetcher(@RequestHeader headers: Map<String, String>): String {
+                val header = headers.get("Referer")
+                return "From, $header"
+            }
+        }
+
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
+            Pair(
+                "helloFetcher",
+                fetcher
+            )
+        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
+
+        val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+        val schema = provider.schema()
+
+        val build = GraphQL.newGraphQL(schema).build()
+        val httpHeaders = HttpHeaders()
+        httpHeaders.add("Referer", "localhost")
+        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
+        Assertions.assertTrue(executionResult.isDataPresent)
+        val data = executionResult.getData<Map<String, *>>()
+        Assertions.assertEquals("From, localhost", data["hello"])
+
+        verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
+    }
+
+    @Test
+    fun `A @RequestHeader argument with multi-value map should be supported`() {
+        val fetcher = object : Any() {
+            @DgsData(parentType = "Query", field = "hello")
+            fun someFetcher(@RequestHeader headers: MultiValueMap<String, String>): String {
+                val header = headers.getFirst("Referer")
+                return "From, $header"
+            }
+        }
+
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
+            Pair(
+                "helloFetcher",
+                fetcher
+            )
+        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
+
+        val provider = DgsSchemaProvider(applicationContextMock, Optional.empty(), Optional.empty(), Optional.empty())
+        val schema = provider.schema()
+
+        val build = GraphQL.newGraphQL(schema).build()
+        val httpHeaders = HttpHeaders()
+        httpHeaders.add("Referer", "localhost")
+        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
+        Assertions.assertTrue(executionResult.isDataPresent)
+        val data = executionResult.getData<Map<String, *>>()
+        Assertions.assertEquals("From, localhost", data["hello"])
+
+        verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
+    }
+
+    @Test
+    fun `A @RequestHeader argument with HttpHeaders should be supported`() {
+        val fetcher = object : Any() {
+            @DgsData(parentType = "Query", field = "hello")
+            fun someFetcher(@RequestHeader headers: HttpHeaders): String {
+                val header = headers.getFirst("Referer")
+                return "From, $header"
             }
         }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -64,11 +64,11 @@ import org.springframework.context.ApplicationContext
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
+import org.springframework.util.MultiValueMap
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.multipart.MultipartFile
-import org.springframework.util.MultiValueMap
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*


### PR DESCRIPTION

Pull Request type
----

- [x] Bugfix

Changes in this PR
----
This PR adds the ability to use `@RequestHeader` annotation with HttpHeaders, Map<String, String> and MultiValueMap<String, String> types.

_Describe the new behavior from this PR, and why it's needed_
Issue #934
