### PR TITLE
Update webflux to have a configurable object mapper.

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.dgs.webflux.autoconfiguration
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.dgs.internal.CookieValueResolver
 import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
@@ -135,9 +137,16 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
     }
 
     @Bean
+    @Qualifier("dgsObjectMapper")
+    @ConditionalOnMissingBean(name = ["dgsObjectMapper"])
+    open fun dgsObjectMapper(): ObjectMapper {
+        return jacksonObjectMapper()
+    }
+
+    @Bean
     @ConditionalOnMissingBean
-    open fun dgsWebfluxHttpHandler(dgsQueryExecutor: DgsReactiveQueryExecutor): DgsWebfluxHttpHandler {
-        return DefaultDgsWebfluxHttpHandler(dgsQueryExecutor)
+    open fun dgsWebfluxHttpHandler(dgsQueryExecutor: DgsReactiveQueryExecutor, @Qualifier("dgsObjectMapper") dgsObjectMapper: ObjectMapper): DgsWebfluxHttpHandler {
+        return DefaultDgsWebfluxHttpHandler(dgsQueryExecutor, dgsObjectMapper)
     }
 
     @Bean

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DefaultDgsWebfluxHttpHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DefaultDgsWebfluxHttpHandler.kt
@@ -17,8 +17,8 @@
 package com.netflix.graphql.dgs.webflux.handlers
 
 import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor
 import graphql.ExecutionResult
@@ -28,7 +28,7 @@ import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 
-class DefaultDgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQueryExecutor) : DgsWebfluxHttpHandler {
+class DefaultDgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQueryExecutor, private val objectMapper: ObjectMapper) : DgsWebfluxHttpHandler {
 
     override fun graphql(request: ServerRequest): Mono<ServerResponse> {
         @Suppress("UNCHECKED_CAST") val executionResult: Mono<ExecutionResult> =
@@ -39,7 +39,7 @@ class DefaultDgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQuer
                         Mono.just(QueryInput(body))
                     } else {
                         Mono.fromCallable {
-                            val readValue = mapper.readValue<Map<String, Any>>(body)
+                            val readValue = objectMapper.readValue<Map<String, Any>>(body)
                             val query: String? = when (val iq = readValue["query"]) {
                                 is String -> iq
                                 else -> null
@@ -90,7 +90,6 @@ class DefaultDgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQuer
 
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(DefaultDgsWebfluxHttpHandler::class.java)
-        private val mapper = jacksonObjectMapper()
     }
 }
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
We addressed the same issue earlier for only webmvc stack in #943. This PR makes the object mapper configurable for the webmvc stack as well.

_Describe the new behavior from this PR, and why it's needed_
Issue #943

