### PR TITLE
Adopt GraphQL Java 18 and Federation 0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ bin/
 
 # VS Code
 .vscode/
+scripts/__pycache__

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -51,7 +51,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.6.0"
@@ -309,7 +309,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.6.0"
@@ -403,7 +403,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "17.0"
@@ -531,7 +531,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -552,6 +552,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
@@ -576,7 +577,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "17.0"
@@ -727,7 +728,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -43,7 +43,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -369,7 +369,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -431,7 +431,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -599,7 +599,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -697,7 +697,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -842,7 +842,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -904,7 +904,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -1075,7 +1075,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -46,7 +46,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -375,7 +375,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -408,6 +408,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
             "locked": "2.12.5"
@@ -439,7 +440,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -607,7 +608,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -730,7 +731,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -884,7 +885,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -917,6 +918,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
             "locked": "2.12.5"
@@ -948,7 +950,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -1123,7 +1125,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -38,7 +38,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -317,7 +317,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.12.5"
@@ -351,7 +351,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -449,7 +449,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -523,7 +523,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -624,7 +624,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.12.5"
@@ -658,7 +658,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -762,7 +762,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -35,7 +35,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "17.0"
@@ -288,7 +288,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -317,7 +317,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "17.0"
@@ -384,7 +384,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"
@@ -452,7 +452,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "17.0"
@@ -583,7 +583,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -609,7 +609,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "2.12.5"
         },
@@ -636,7 +637,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "17.0"
@@ -778,7 +779,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -35,7 +35,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "17.0-hibernate-validator-6.2.0.Final"
@@ -288,7 +288,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -317,7 +317,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "17.0-hibernate-validator-6.2.0.Final"
@@ -384,7 +384,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"
@@ -452,7 +452,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "17.0-hibernate-validator-6.2.0.Final"
@@ -583,7 +583,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -609,7 +609,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "2.12.5"
         },
@@ -636,7 +637,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "17.0-hibernate-validator-6.2.0.Final"
@@ -778,7 +779,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -33,7 +33,7 @@
             "locked": "1.0.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -255,7 +255,7 @@
             "locked": "1.0.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -267,7 +267,7 @@
             "locked": "1.5.32"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.30"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -310,7 +310,7 @@
             "locked": "1.0.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -351,7 +351,7 @@
             "locked": "1.0.2"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -366,7 +366,7 @@
             "locked": "1.5.32"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.30"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -35,7 +35,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -285,7 +285,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -314,7 +314,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -378,7 +378,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"
@@ -438,7 +438,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -507,7 +507,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -536,7 +536,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -603,7 +603,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     constraints {
         // GraphQL Platform
         api("com.graphql-java:graphql-java") {
-            version { require("17.3") }
+            version { require("18.0") }
         }
         api("com.graphql-java:graphql-java-extended-scalars") {
             version { require("17.0") }
@@ -57,7 +57,7 @@ dependencies {
             version { require("17.0-hibernate-validator-6.2.0.Final") }
         }
         api("com.apollographql.federation:federation-graphql-java-support") {
-            version { require("0.7.0") }
+            version { require("0.9.0") }
         }
         // ---
         api("com.jayway.jsonpath:json-path") {

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -38,7 +38,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -297,7 +297,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -326,7 +326,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -393,7 +393,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -459,7 +459,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -558,7 +558,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -588,7 +588,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -686,7 +686,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -46,7 +46,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -373,7 +373,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -405,7 +405,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -481,7 +481,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -552,7 +552,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -698,7 +698,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -724,7 +724,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "2.12.5"
         },
@@ -754,7 +755,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -905,7 +906,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -38,7 +38,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -309,7 +309,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -339,7 +339,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -416,7 +416,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -480,7 +480,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -570,7 +570,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -603,7 +603,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -686,7 +686,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -43,7 +43,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -341,7 +341,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -367,7 +367,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "2.12.5"
         },
@@ -394,7 +395,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -516,7 +517,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -609,7 +610,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -726,7 +727,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -752,7 +753,8 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
             "locked": "2.12.5"
         },
@@ -779,7 +781,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -904,7 +906,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -38,7 +38,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -302,7 +302,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -332,7 +332,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -414,7 +414,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -489,7 +489,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -594,7 +594,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -628,7 +628,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -739,7 +739,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -26,6 +26,9 @@
         }
     },
     "compileClasspath": {
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.12.5"
+        },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
@@ -35,7 +38,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -300,7 +303,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -330,7 +333,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -407,7 +410,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -462,6 +465,9 @@
         }
     },
     "testCompileClasspath": {
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.12.5"
+        },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.12.5"
         },
@@ -474,7 +480,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -570,7 +576,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -603,7 +609,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -698,7 +704,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -38,7 +38,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -294,7 +294,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -323,7 +323,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -387,7 +387,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -447,7 +447,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -519,7 +519,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
@@ -548,7 +548,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -615,7 +615,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -33,7 +33,7 @@
             "locked": "2.12.5"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -252,7 +252,7 @@
             "locked": "2.12.5"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -307,7 +307,7 @@
             "locked": "2.12.5"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -348,7 +348,7 @@
             "locked": "2.12.5"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -35,7 +35,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -296,7 +296,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -333,7 +333,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -413,7 +413,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"
@@ -480,7 +480,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -560,7 +560,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -597,7 +597,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -680,7 +680,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -45,7 +45,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -303,7 +303,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -339,7 +339,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -408,7 +408,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -478,7 +478,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -558,7 +558,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -594,7 +594,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -669,7 +669,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -42,7 +42,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -308,7 +308,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -345,7 +345,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -425,7 +425,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -502,7 +502,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -587,7 +587,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -624,7 +624,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -707,7 +707,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -45,7 +45,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -309,7 +309,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -345,7 +345,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -414,7 +414,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"
@@ -487,7 +487,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -573,7 +573,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -609,7 +609,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -687,7 +687,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -43,7 +43,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -346,7 +346,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -401,7 +401,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -538,7 +538,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -625,7 +625,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -747,7 +747,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "firstLevelTransitive": [
@@ -802,7 +802,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -942,7 +942,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.12.5"
@@ -43,7 +43,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.6.0"
@@ -294,7 +294,7 @@
     },
     "runtimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.12.5"
@@ -316,7 +316,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.6.0"
@@ -357,7 +357,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"
@@ -400,7 +400,7 @@
     },
     "testCompileClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.12.5"
@@ -416,7 +416,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "17.0"
@@ -495,7 +495,7 @@
     },
     "testRuntimeClasspath": {
         "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "0.7.0"
+            "locked": "0.9.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.12.5"
@@ -517,7 +517,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "17.0"
@@ -573,7 +573,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.35"
         },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.3.12.RELEASE"

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DefaultDgsFederationResolverTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DefaultDgsFederationResolverTest.kt
@@ -22,11 +22,11 @@ import com.netflix.graphql.dgs.exceptions.DgsInvalidInputArgumentException
 import com.netflix.graphql.dgs.federation.DefaultDgsFederationResolver
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.dgs.internal.EntityFetcherRegistry
-import graphql.TypeResolutionEnvironment
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherResult
 import graphql.execution.ExecutionStepInfo
 import graphql.execution.ResultPath
+import graphql.execution.TypeResolutionParameters
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.DataFetchingEnvironmentImpl
 import graphql.schema.GraphQLList
@@ -99,14 +99,11 @@ class DefaultDgsFederationResolverTest {
                 DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                     .typeResolver()
                     .getType(
-                        TypeResolutionEnvironment(
-                            Movie("123", "Stranger Things"),
-                            emptyMap(),
-                            null,
-                            null,
-                            graphQLSchema,
-                            null
-                        )
+                        TypeResolutionParameters
+                            .newParameters()
+                            .schema(graphQLSchema)
+                            .value(Movie("123", "Stranger Things"))
+                            .build()
                     )
             assertThat(type.name).isEqualTo("Movie")
         }
@@ -124,14 +121,11 @@ class DefaultDgsFederationResolverTest {
             val type = DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
                 .typeResolver()
                 .getType(
-                    TypeResolutionEnvironment(
-                        Movie("123", "Stranger Things"),
-                        emptyMap(),
-                        null,
-                        null,
-                        graphQLSchema,
-                        null
-                    )
+                    TypeResolutionParameters
+                        .newParameters()
+                        .schema(graphQLSchema)
+                        .value(Movie("123", "Stranger Things"))
+                        .build()
                 )
             assertThat(type).isNull()
         }
@@ -159,14 +153,11 @@ class DefaultDgsFederationResolverTest {
                 }
 
             val type = customTypeResolver.typeResolver().getType(
-                TypeResolutionEnvironment(
-                    Movie("123", "Stranger Things"),
-                    emptyMap(),
-                    null,
-                    null,
-                    graphQLSchema,
-                    null
-                )
+                TypeResolutionParameters
+                    .newParameters()
+                    .schema(graphQLSchema)
+                    .value(Movie("123", "Stranger Things"))
+                    .build()
             )
             assertThat(type.name).isEqualTo("DgsMovie")
         }

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -33,7 +33,7 @@
             "locked": "2.12.5"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -249,7 +249,7 @@
             "locked": "2.12.5"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -298,7 +298,7 @@
             "locked": "2.12.5"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
@@ -333,7 +333,7 @@
             "locked": "2.12.5"
         },
         "com.graphql-java:graphql-java": {
-            "locked": "17.3"
+            "locked": "18.0"
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

## GraphQL Java 18

Upgrade to [graphql-java 18.0] which brings a plethora of improvements.

[graphql-java 18.0]: https://github.com/graphql-java/graphql-java/releases/tag/v18.0

## Federation 0.9.0

* 0.9.0
    * Update protobuf-java to 3.19.4 (#141)
    * Add support for graphql-java GraphQLContext (#138). 
* 0.8.0
    * This release adds support for the @CacheControl directive in the form of a graphql-java instrumentation class, matching the behavior of the apollo-server's built-in cache control plugin. (#133)

For additional information please go to [Federation Release Notes].

[Federation Release Notes]: https://github.com/apollographql/federation-jvm/blob/master/RELEASE_NOTES.md
