### PR TITLE
Fold changes to `dependencies.lock` files in diffs by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dependencies.lock linguist-generated


### PR DESCRIPTION
Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [X] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [X] Make sure the PR doesn't introduce backward compatibility issues
- [X] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Other (please describe):

Changes in this PR
----

Hides changes to `dependencies.lock` files in diffs&prs by default.

Scrolling through diffs is often times cumbersome, this alleviates the pain a little bit.

Technique documented over at https://github.com/github/linguist/blob/master/docs/overrides.md (should also work for GitLab).

Example of this working is available at https://github.com/jord1e/dgs-framework/pull/4/files

![afbeelding](https://user-images.githubusercontent.com/30464310/162575554-8060a7fb-3698-4500-ad5d-972e8d0b3458.png)

... After clicking `Load diff`:


![afbeelding](https://user-images.githubusercontent.com/30464310/162575561-85b2a27d-b172-494c-bff9-7d550e077d7a.png)


Alternatives considered
----

N/A

