### PR TITLE
Fix deprecation warnings in DgsDataLoaderProvider

### DIFF
--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/ExampleMappedBatchLoaderFromField.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/ExampleMappedBatchLoaderFromField.java
@@ -21,6 +21,7 @@ import org.dataloader.MappedBatchLoader;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 
+@DgsComponent
 public class ExampleMappedBatchLoaderFromField {
     @DgsDataLoader(name = "exampleMappedLoaderFromField")
     public MappedBatchLoader<String, String> mappedLoader = keys -> CompletableFuture.supplyAsync(() -> {

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -20,205 +20,145 @@ import com.netflix.graphql.dgs.exceptions.DgsUnnamedDataLoaderOnFieldException
 import com.netflix.graphql.dgs.exceptions.InvalidDataLoaderTypeException
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import graphql.schema.DataFetchingEnvironmentImpl
-import io.mockk.every
-import io.mockk.impl.annotations.MockK
-import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.dataloader.BatchLoader
 import org.dataloader.DataLoaderRegistry
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.beans.factory.support.StaticListableBeanFactory
-import org.springframework.context.ApplicationContext
+import org.springframework.beans.factory.BeanCreationException
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.lang.IllegalStateException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
-@ExtendWith(MockKExtension::class)
 class DgsDataLoaderProviderTest {
-    @MockK
-    lateinit var applicationContextMock: ApplicationContext
 
-    @BeforeEach
-    fun setDataLoaderInstrumentationExtensionProvider() {
-        val listableBeanFactory = StaticListableBeanFactory()
-        every { applicationContextMock.getBeanProvider(DataLoaderInstrumentationExtensionProvider::class.java) } returns
-            listableBeanFactory.getBeanProvider(DataLoaderInstrumentationExtensionProvider::class.java)
-    }
+    private val applicationContextRunner: ApplicationContextRunner = ApplicationContextRunner()
+        .withBean(DgsDataLoaderProvider::class.java)
 
     @Test
     fun findDataLoaders() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                ExampleBatchLoader()
-            )
-        )
-
-        val provider = DgsDataLoaderProvider(applicationContextMock)
-        provider.findDataLoaders()
-        val dataLoaderRegistry = provider.buildRegistry()
-        Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
-        val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoader")
-        Assertions.assertNotNull(dataLoader)
+        applicationContextRunner.withBean(ExampleBatchLoader::class.java).run { context ->
+            val provider = context.getBean(DgsDataLoaderProvider::class.java)
+            val dataLoaderRegistry = provider.buildRegistry()
+            Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
+            val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoader")
+            Assertions.assertNotNull(dataLoader)
+        }
     }
 
     @Test
     fun dataLoaderInvalidType() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                object {}
-            )
-        )
-        val provider = DgsDataLoaderProvider(applicationContextMock)
-        assertThrows<InvalidDataLoaderTypeException> { provider.findDataLoaders() }
+        @DgsDataLoader
+        class Foo
+        applicationContextRunner.withBean(Foo::class.java)
+            .run { context ->
+                val exc = assertThrows<IllegalStateException> {
+                    context.getBean(DgsDataLoaderProvider::class.java)
+                }
+                assertThat(exc.cause)
+                    .isInstanceOf(BeanCreationException::class.java)
+                    .rootCause
+                    .isInstanceOf(InvalidDataLoaderTypeException::class.java)
+            }
     }
 
     @Test
     fun findDataLoadersFromFields() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                ExampleBatchLoaderFromField()
-            )
-        )
+        applicationContextRunner.withBean(ExampleBatchLoaderFromField::class.java).run { context ->
+            val provider = context.getBean(DgsDataLoaderProvider::class.java)
+            val dataLoaderRegistry = provider.buildRegistry()
+            Assertions.assertEquals(2, dataLoaderRegistry.dataLoaders.size)
+            val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoaderFromField")
+            Assertions.assertNotNull(dataLoader)
 
-        val provider = DgsDataLoaderProvider(applicationContextMock)
-        provider.findDataLoaders()
-        val dataLoaderRegistry = provider.buildRegistry()
-        Assertions.assertEquals(2, dataLoaderRegistry.dataLoaders.size)
-        val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoaderFromField")
-        Assertions.assertNotNull(dataLoader)
-
-        val privateDataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("privateExampleLoaderFromField")
-        Assertions.assertNotNull(privateDataLoader)
+            val privateDataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("privateExampleLoaderFromField")
+            Assertions.assertNotNull(privateDataLoader)
+        }
     }
 
     @Test
     fun findMappedDataLoaders() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                ExampleMappedBatchLoader()
-            )
-        )
-
-        val provider = DgsDataLoaderProvider(applicationContextMock)
-        provider.findDataLoaders()
-        val dataLoaderRegistry = provider.buildRegistry()
-        Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
-        val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoader")
-        Assertions.assertNotNull(dataLoader)
+        applicationContextRunner.withBean(ExampleMappedBatchLoader::class.java).run { context ->
+            val provider = context.getBean(DgsDataLoaderProvider::class.java)
+            val dataLoaderRegistry = provider.buildRegistry()
+            Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
+            val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoader")
+            Assertions.assertNotNull(dataLoader)
+        }
     }
 
     @Test
     fun findMappedDataLoadersFromFields() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                ExampleMappedBatchLoaderFromField()
-            )
-        )
+        applicationContextRunner.withBean(ExampleMappedBatchLoaderFromField::class.java).run { context ->
+            val provider = context.getBean(DgsDataLoaderProvider::class.java)
+            val dataLoaderRegistry = provider.buildRegistry()
+            Assertions.assertEquals(2, dataLoaderRegistry.dataLoaders.size)
+            val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoaderFromField")
+            Assertions.assertNotNull(dataLoader)
 
-        val provider = DgsDataLoaderProvider(applicationContextMock)
-        provider.findDataLoaders()
-        val dataLoaderRegistry = provider.buildRegistry()
-        Assertions.assertEquals(2, dataLoaderRegistry.dataLoaders.size)
-        val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoaderFromField")
-        Assertions.assertNotNull(dataLoader)
-
-        val privateDataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("privateExampleMappedLoaderFromField")
-        Assertions.assertNotNull(privateDataLoader)
+            val privateDataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("privateExampleMappedLoaderFromField")
+            Assertions.assertNotNull(privateDataLoader)
+        }
     }
 
     @Test
     fun dataLoaderConsumer() {
-        every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf("withRegistry" to ExampleDataLoaderWithRegistry())
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
+        applicationContextRunner.withBean(ExampleDataLoaderWithRegistry::class.java).run { context ->
+            val provider = context.getBean(DgsDataLoaderProvider::class.java)
+            val registry = provider.buildRegistry()
 
-        val provider = DgsDataLoaderProvider(applicationContextMock)
-        provider.findDataLoaders()
-        val registry = provider.buildRegistry()
-
-        // Use the dataloader's "load" method to check if the registry was set correctly, because the dataloader instance isn't itself a DgsDataLoaderRegistryConsumer
-        val dataLoader = registry.getDataLoader<String, String>("withRegistry")
-        val load = dataLoader.load("")
-        dataLoader.dispatch()
-        val loaderKeys = load.get()
-        assertThat(loaderKeys).isEqualTo(registry.keys.toMutableList()[0])
+            // Use the dataloader's "load" method to check if the registry was set correctly, because the dataloader instance isn't itself a DgsDataLoaderRegistryConsumer
+            val dataLoader = registry.getDataLoader<String, String>("withRegistry")
+            val load = dataLoader.load("")
+            dataLoader.dispatch()
+            val loaderKeys = load.get()
+            assertThat(loaderKeys).isEqualTo(registry.keys.first())
+        }
     }
 
     @Nested
     inner class UnnamedBatchLoaderTests {
         @Test
         fun findDataLoadersWithoutName() {
-            every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
-            every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns mapOf(
-                Pair(
-                    "helloFetcher",
-                    ExampleBatchLoaderWithoutName()
-                )
-            )
-
-            val provider = DgsDataLoaderProvider(applicationContextMock)
-            provider.findDataLoaders()
-            val dataLoaderRegistry = provider.buildRegistry()
-            Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
-            val dataLoader =
-                dataLoaderRegistry.getDataLoader<Any, Any>("ExampleBatchLoaderWithoutName")
-            Assertions.assertNotNull(dataLoader)
+            applicationContextRunner.withBean(ExampleBatchLoaderWithoutName::class.java).run { context ->
+                val provider = context.getBean(DgsDataLoaderProvider::class.java)
+                val dataLoaderRegistry = provider.buildRegistry()
+                Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
+                val dataLoader =
+                    dataLoaderRegistry.getDataLoader<Any, Any>("ExampleBatchLoaderWithoutName")
+                Assertions.assertNotNull(dataLoader)
+            }
         }
 
         @Test
         fun findDataLoadersWithoutNameByClass() {
-            every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns emptyMap()
-            val theLoader = ExampleBatchLoaderWithoutName()
-            Assertions.assertEquals(
-                DgsDataLoader.GENERATE_DATA_LOADER_NAME,
-                theLoader.javaClass.getAnnotation(DgsDataLoader::class.java).name
-            )
-            every {
-                applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java)
-            } returns mapOf(Pair("helloFetcher", theLoader))
-
-            val provider = DgsDataLoaderProvider(applicationContextMock)
-            provider.findDataLoaders()
-            val dataLoaderRegistry = provider.buildRegistry()
-            Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
-            val dataLoader = DgsDataFetchingEnvironment(
-                DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
-                    .dataLoaderRegistry(dataLoaderRegistry).build()
-            )
-                .getDataLoader<Any, Any>(ExampleBatchLoaderWithoutName::class.java)
-            Assertions.assertNotNull(dataLoader)
+            applicationContextRunner.withBean(ExampleBatchLoaderWithoutName::class.java).run { context ->
+                val provider = context.getBean(DgsDataLoaderProvider::class.java)
+                val dataLoaderRegistry = provider.buildRegistry()
+                Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
+                val dataLoader = DgsDataFetchingEnvironment(
+                    DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                        .dataLoaderRegistry(dataLoaderRegistry).build()
+                )
+                    .getDataLoader<Any, Any>(ExampleBatchLoaderWithoutName::class.java)
+                Assertions.assertNotNull(dataLoader)
+            }
         }
 
         @Test
         fun findDataLoadersFromFieldsWithoutName() {
-            every { applicationContextMock.getBeansWithAnnotation(DgsDataLoader::class.java) } returns emptyMap()
-            every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-                Pair(
-                    "helloFetcher",
-                    ExampleBatchLoaderWithoutNameFromField()
-                )
-            )
-
-            val provider = DgsDataLoaderProvider(applicationContextMock)
-            assertThatThrownBy { provider.findDataLoaders() }
-                .hasNoCause()
-                .isExactlyInstanceOf(DgsUnnamedDataLoaderOnFieldException::class.java)
-                .hasMessage(
-                    "Field `batchLoader` in class `com.netflix.graphql.dgs.ExampleBatchLoaderWithoutNameFromField` was annotated with @DgsDataLoader, but the data loader was not given a proper name"
-                )
+            applicationContextRunner.withBean(ExampleBatchLoaderWithoutNameFromField::class.java).run { context ->
+                assertThatThrownBy { context.getBean(DgsDataLoaderProvider::class.java) }
+                    .rootCause
+                    .isInstanceOf(DgsUnnamedDataLoaderOnFieldException::class.java)
+                    .hasMessage(
+                        "Field `batchLoader` in class `com.netflix.graphql.dgs.ExampleBatchLoaderWithoutNameFromField` was annotated with @DgsDataLoader, but the data loader was not given a proper name"
+                    )
+            }
         }
     }
 
@@ -231,8 +171,8 @@ class DgsDataLoaderProviderTest {
             this.registry = dataLoaderRegistry
         }
 
-        override fun load(keys: List<String>): CompletionStage<MutableList<String>>? {
-            return CompletableFuture.completedFuture(registry.keys.toMutableList())
+        override fun load(keys: List<String>): CompletionStage<List<String>> {
+            return CompletableFuture.completedFuture(registry.keys.toList())
         }
     }
 }


### PR DESCRIPTION
Switch to DataLoaderFactory in DgsDataLoaderProvider. Additionally, change tests to use ApplicationContextRunner, instead of mocking the Spring ApplicationContext.
