### PR TITLE
Add support for defining a default DataFetcherFactory via autoconfig

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -33,6 +33,7 @@ import graphql.execution.ExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
+import graphql.schema.DataFetcherFactory
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLSchema
 import graphql.schema.idl.TypeDefinitionRegistry
@@ -85,8 +86,10 @@ open class DgsAutoConfiguration(
         preparsedDocumentProvider: PreparsedDocumentProvider,
         queryValueCustomizer: QueryValueCustomizer
     ): DgsQueryExecutor {
-        val queryExecutionStrategy = providedQueryExecutionStrategy.orElse(AsyncExecutionStrategy(dataFetcherExceptionHandler))
-        val mutationExecutionStrategy = providedMutationExecutionStrategy.orElse(AsyncSerialExecutionStrategy(dataFetcherExceptionHandler))
+        val queryExecutionStrategy =
+            providedQueryExecutionStrategy.orElse(AsyncExecutionStrategy(dataFetcherExceptionHandler))
+        val mutationExecutionStrategy =
+            providedMutationExecutionStrategy.orElse(AsyncSerialExecutionStrategy(dataFetcherExceptionHandler))
         return DefaultDgsQueryExecutor(
             schema,
             schemaProvider,
@@ -158,7 +161,8 @@ open class DgsAutoConfiguration(
         dataFetcherExceptionHandler: Optional<DataFetcherExceptionHandler> = Optional.empty(),
         cookieValueResolver: Optional<CookieValueResolver> = Optional.empty(),
         inputObjectMapper: Optional<InputObjectMapper> = Optional.empty(),
-        entityFetcherRegistry: EntityFetcherRegistry
+        entityFetcherRegistry: EntityFetcherRegistry,
+        defaultDataFetcherFactory: Optional<DataFetcherFactory<*>> = Optional.empty()
     ): DgsSchemaProvider {
         return DgsSchemaProvider(
             applicationContext,
@@ -170,7 +174,8 @@ open class DgsAutoConfiguration(
             dataFetcherExceptionHandler,
             cookieValueResolver,
             inputObjectMapper.orElse(DefaultInputObjectMapper()),
-            entityFetcherRegistry
+            entityFetcherRegistry,
+            defaultDataFetcherFactory
         )
     }
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfigurationTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfigurationTest.kt
@@ -101,15 +101,15 @@ class DgsAutoConfigurationTest {
             assertThat(ctx).getBean(DgsQueryExecutor::class.java).extracting {
                 val json = it.executeAndExtractJsonPath<Any>(
                     " query availableQueries {\n" +
-                            "  __schema {\n" +
-                            "    queryType {\n" +
-                            "      fields {\n" +
-                            "        name\n" +
-                            "        description\n" +
-                            "      }\n" +
-                            "    }\n" +
-                            "  }\n" +
-                            "}",
+                        "  __schema {\n" +
+                        "    queryType {\n" +
+                        "      fields {\n" +
+                        "        name\n" +
+                        "        description\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}",
                     "data.__schema.queryType.fields[0].name"
                 )
                 assertThat(json).isEqualTo("hello")

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/CustomDataFetcherFactory.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/CustomDataFetcherFactory.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig.testcomponents
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsData
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetcherFactories
+import graphql.schema.DataFetcherFactory
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.FieldCoordinates
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+object TestDataFetcher : DataFetcher<Any> {
+    override fun get(environment: DataFetchingEnvironment): Any {
+        return "not world"
+    }
+}
+
+@Configuration
+open class CustomDataFetcherFactory {
+    @Bean
+    open fun coolDataFetcherFactory(): DataFetcherFactory<*> {
+        return DataFetcherFactories.useDataFetcher(TestDataFetcher)
+    }
+}
+
+data class SimpleNested(val hello: String)
+
+@DgsComponent
+class CustomDataFetcherFactoryTest {
+    @DgsData(parentType = "Query", field = "simpleNested")
+    fun hello(dfe: DataFetchingEnvironment): SimpleNested {
+        val coordinates = FieldCoordinates.coordinates("Query", "simpleNested")
+        val fieldDefinition = dfe.graphQLSchema.getFieldDefinition(coordinates)
+        return SimpleNested("world")
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/CustomDataFetcherFactory.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/CustomDataFetcherFactory.kt
@@ -22,7 +22,6 @@ import graphql.schema.DataFetcher
 import graphql.schema.DataFetcherFactories
 import graphql.schema.DataFetcherFactory
 import graphql.schema.DataFetchingEnvironment
-import graphql.schema.FieldCoordinates
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -46,8 +45,6 @@ data class SimpleNested(val hello: String)
 class CustomDataFetcherFactoryTest {
     @DgsData(parentType = "Query", field = "simpleNested")
     fun hello(dfe: DataFetchingEnvironment): SimpleNested {
-        val coordinates = FieldCoordinates.coordinates("Query", "simpleNested")
-        val fieldDefinition = dfe.graphQLSchema.getFieldDefinition(coordinates)
         return SimpleNested("world")
     }
 }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/resources/schema/schema.graphqls
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/resources/schema/schema.graphqls
@@ -21,6 +21,12 @@ type Query {
     withIgnoredField(input: Input): Output
 
     withIgnoredFieldNested(nestedInput: NestedInput): Output
+
+    simpleNested: SimpleNested!
+}
+
+type SimpleNested {
+    hello: String!
 }
 
 input Input {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -383,8 +383,8 @@ class DgsSchemaProvider(
                         overrideTypeResolver = dgsComponents.any { component ->
                             component.javaClass.methods.any { method ->
                                 method.isAnnotationPresent(DgsTypeResolver::class.java) &&
-                                        method.getAnnotation(DgsTypeResolver::class.java).name == annotation.name &&
-                                        component != dgsComponent
+                                    method.getAnnotation(DgsTypeResolver::class.java).name == annotation.name &&
+                                    component != dgsComponent
                             }
                         }
                     }


### PR DESCRIPTION
Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [X] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [X] Make sure the PR doesn't introduce backward compatibility issues
- [X] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

By default a `PropertyDataFetcher` will be configured when no data fetcher has been specified. You can provide a custom `DataFetcherFactory` to `GraphQLCodeRegistry` which gives you the ability to change this default behaviour.

I have been doing some work on dynamically generating the `PropertyDataFetcher` logic directly (instead of `PropertyDataFetcher`'s reflection behaviour)  in a class using the ASM bytecode library: https://github.com/jord1e/graphql-java-asm-datafetcher

By simply providing a `AsmDataFetcherFactory` the required classes get generated lazily, **increasing performance by 10x+**, matching handwritten data fetchers, in my initial testing (I will further work on this proof of concept to make it better match the default `PropertyDataFetcher` i.e. add generic Map<Object, Object> support).

This is not the only use-case of course but the ability to define a `DataFetcherFactory` as a bean is a low maintaince thing we can do.

Alternatives considered
----

N/A, Spring for GraphQL has a way to customize the GraphQL instance, I don't think DGS has this.

