### PR TITLE
Stop using deprecated context methods

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
@@ -26,13 +26,7 @@ import org.dataloader.DataLoader
 class DgsDataFetchingEnvironment(private val dfe: DataFetchingEnvironment) : DataFetchingEnvironment by dfe {
 
     fun getDgsContext(): DgsContext {
-        @Suppress("deprecation")
-        val context = dfe.getContext<Any?>()
-        if (context is DgsContext) {
-            return context
-        } else {
-            throw RuntimeException("""Context object of type '${context::class.java.name}' is not a DgsContext. This method does not work if you have a custom implementation of DgsContextBuilder""")
-        }
+        return DgsContext.from(this)
     }
 
     fun <K, V> getDataLoader(loaderClass: Class<*>): DataLoader<K, V> {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
@@ -108,8 +108,7 @@ object BaseDgsQueryExecutor {
                 .operationName(operationName)
                 .variables(variables)
                 .dataLoaderRegistry(dataLoaderRegistry)
-                .context(dgsContext)
-                .graphQLContext { b -> b.of(DgsContext.GRAPHQL_CONTEXT_NAMESPACE_KEY, dgsContext) }
+                .graphQLContext(dgsContext)
 
         if (extensions != null) {
             executionInputBuilder.extensions(extensions)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
@@ -37,7 +37,7 @@ open class DefaultDgsGraphQLContextBuilder(
     }
 
     private fun buildDgsContext(dgsRequestData: DgsWebMvcRequestData?): DgsContext {
-        @Suppress("DEPRECATION") val customContext = when {
+        val customContext = when {
             dgsCustomContextBuilderWithRequest.isPresent -> dgsCustomContextBuilderWithRequest.get().build(
                 dgsRequestData?.extensions ?: mapOf(),
                 HttpHeaders.readOnlyHttpHeaders(

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/sortby/JMovieSortByField.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/sortby/JMovieSortByField.java
@@ -16,7 +16,7 @@
 
 package com.netflix.graphql.dgs.internal.java.test.inputobjects.sortby;
 
-enum JMovieSortByField {
+public enum JMovieSortByField {
     TITLE,
     RELEASEDATE
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
@@ -25,7 +25,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
-import io.mockk.verify
 import org.dataloader.DataLoader
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -251,96 +250,5 @@ internal class DgsDataFetchingEnvironmentTest {
         Assertions.assertTrue(executionResult.isDataPresent)
         val result = executionResult.getData() as Map<String, String>
         Assertions.assertEquals("C", result["hello"])
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun verifyDelegation() {
-        val dgsDfe = DgsDataFetchingEnvironment(dfeMock)
-
-        dgsDfe.getSource<String>()
-        verify { dfeMock.getSource() }
-
-        dgsDfe.getArgument<String>("name")
-        verify { dfeMock.getArgument("name") }
-
-        dgsDfe.arguments
-        verify { dfeMock.arguments }
-
-        dgsDfe.containsArgument("name")
-        verify { dfeMock.containsArgument("name") }
-
-        dgsDfe.getArgument<String>("name")
-        verify { dfeMock.getArgument<String>("name") }
-
-        dgsDfe.getArgumentOrDefault("name", "")
-        verify { dfeMock.getArgumentOrDefault("name", "") }
-
-        dgsDfe.getContext<String>()
-        verify { dfeMock.getContext<String>() }
-
-        dgsDfe.getLocalContext<String>()
-        verify { dfeMock.getLocalContext() }
-
-        dgsDfe.getRoot<String>()
-        verify { dfeMock.getRoot() }
-
-        dgsDfe.fieldDefinition
-        verify { dfeMock.fieldDefinition }
-
-        @Suppress("DEPRECATION")
-        dgsDfe.fields
-        verify { dfeMock.fields }
-
-        dgsDfe.mergedField
-        verify { dfeMock.mergedField }
-
-        dgsDfe.field
-        verify { dfeMock.field }
-
-        dgsDfe.fieldType
-        verify { dfeMock.fieldType }
-
-        dgsDfe.executionStepInfo
-        verify { dfeMock.executionStepInfo }
-
-        dgsDfe.parentType
-        verify { dfeMock.parentType }
-
-        dgsDfe.graphQLSchema
-        verify { dfeMock.graphQLSchema }
-
-        dgsDfe.fragmentsByName
-        verify { dfeMock.fragmentsByName }
-
-        dgsDfe.executionId
-        verify { dfeMock.executionId }
-
-        dgsDfe.selectionSet
-        verify { dfeMock.selectionSet }
-
-        dgsDfe.queryDirectives
-        verify { dfeMock.queryDirectives }
-
-        dgsDfe.getDataLoader<String, String>("loaderA")
-        verify { dfeMock.getDataLoader<String, String>("loaderA") }
-
-        dgsDfe.dataLoaderRegistry
-        verify { dfeMock.dataLoaderRegistry }
-
-        dgsDfe.cacheControl
-        verify { dfeMock.cacheControl }
-
-        dgsDfe.locale
-        verify { dfeMock.locale }
-
-        dgsDfe.operationDefinition
-        verify { dfeMock.operationDefinition }
-
-        dgsDfe.document
-        verify { dfeMock.document }
-
-        dgsDfe.variables
-        verify { dfeMock.variables }
     }
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -1062,7 +1062,10 @@ internal class InputArgumentTest {
         val build = GraphQL.newGraphQL(schema).build()
         val httpHeaders = HttpHeaders()
         httpHeaders.add("Referer", "localhost")
-        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
+        val executionResult = build.execute(
+            ExecutionInput.newExecutionInput("""{hello}""")
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders)))
+        )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
         Assertions.assertEquals("From, localhost", data["hello"])
@@ -1095,7 +1098,10 @@ internal class InputArgumentTest {
         val build = GraphQL.newGraphQL(schema).build()
         val httpHeaders = HttpHeaders()
         httpHeaders.add("Referer", "localhost")
-        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
+        val executionResult = build.execute(
+            ExecutionInput.newExecutionInput("""{hello}""")
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders)))
+        )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
         Assertions.assertEquals("From, localhost", data["hello"])
@@ -1128,7 +1134,10 @@ internal class InputArgumentTest {
         val build = GraphQL.newGraphQL(schema).build()
         val httpHeaders = HttpHeaders()
         httpHeaders.add("Referer", "localhost")
-        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
+        val executionResult = build.execute(
+            ExecutionInput.newExecutionInput("""{hello}""")
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders)))
+        )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
         Assertions.assertEquals("From, localhost", data["hello"])
@@ -1161,7 +1170,10 @@ internal class InputArgumentTest {
         val build = GraphQL.newGraphQL(schema).build()
         val httpHeaders = HttpHeaders()
         httpHeaders.add("Referer", "localhost")
-        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
+        val executionResult = build.execute(
+            ExecutionInput.newExecutionInput("""{hello}""")
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders)))
+        )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
         Assertions.assertEquals("From, localhost", data["hello"])
@@ -1193,7 +1205,10 @@ internal class InputArgumentTest {
         val build = GraphQL.newGraphQL(schema).build()
         val httpHeaders = HttpHeaders()
         httpHeaders.add("Referer", "localhost")
-        val executionResult = build.execute(ExecutionInput.newExecutionInput("""{hello}""").context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders))))
+        val executionResult = build.execute(
+            ExecutionInput.newExecutionInput("""{hello}""")
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders)))
+        )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
         Assertions.assertEquals("From, localhost", data["hello"])
@@ -1227,7 +1242,7 @@ internal class InputArgumentTest {
         httpHeaders.add("Referer", "localhost")
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -1264,7 +1279,7 @@ internal class InputArgumentTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, webRequest)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, webRequest)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -1301,7 +1316,7 @@ internal class InputArgumentTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, webRequest)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, webRequest)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -1338,7 +1353,7 @@ internal class InputArgumentTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .context(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, webRequest)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, webRequest)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()


### PR DESCRIPTION
Switch to using GraphQLContext related methods in DataFetchingEnvironment
and ExecutionInput. Update DgsContext so that it can be passed directly
on the ExecutionInput.Builder's graphQLContext method, and add a static
helper to pull the DgsContext instance from the DataFetchingEnvironment.