### PR TITLE
Avoid passing in empty ChainedInstrumentation

### DIFF
--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
@@ -31,7 +31,7 @@ import graphql.ExecutionResult
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.NonNullableFieldWasNullError
-import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
@@ -49,7 +49,7 @@ class DefaultDgsReactiveQueryExecutor(
     private val schemaProvider: DgsSchemaProvider,
     private val dataLoaderProvider: DgsDataLoaderProvider,
     private val contextBuilder: DefaultDgsReactiveGraphQLContextBuilder,
-    private val chainedInstrumentation: ChainedInstrumentation,
+    private val instrumentation: Instrumentation?,
     private val queryExecutionStrategy: ExecutionStrategy,
     private val mutationExecutionStrategy: ExecutionStrategy,
     private val idProvider: Optional<ExecutionIdProvider>,
@@ -80,18 +80,18 @@ class DefaultDgsReactiveQueryExecutor(
             .flatMap { (gqlSchema, dgsContext) ->
                 Mono.fromCompletionStage(
                     BaseDgsQueryExecutor.baseExecute(
-                        queryValueCustomizer.apply(query),
-                        variables,
-                        extensions,
-                        operationName,
-                        dgsContext,
-                        gqlSchema,
-                        dataLoaderProvider,
-                        chainedInstrumentation,
-                        queryExecutionStrategy,
-                        mutationExecutionStrategy,
-                        idProvider,
-                        preparsedDocumentProvider
+                        query = queryValueCustomizer.apply(query),
+                        variables = variables,
+                        extensions = extensions,
+                        operationName = operationName,
+                        dgsContext = dgsContext,
+                        graphQLSchema = gqlSchema,
+                        dataLoaderProvider = dataLoaderProvider,
+                        instrumentation = instrumentation,
+                        queryExecutionStrategy = queryExecutionStrategy,
+                        mutationExecutionStrategy = mutationExecutionStrategy,
+                        idProvider = idProvider,
+                        preparsedDocumentProvider = preparsedDocumentProvider
                     )
                 ).doOnEach { result ->
                     if (result.hasValue()) {

--- a/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/DefaultDgsReactiveQueryExecutorTest.kt
+++ b/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/DefaultDgsReactiveQueryExecutorTest.kt
@@ -30,7 +30,7 @@ import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveGraphQLContex
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveQueryExecutor
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
-import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -135,11 +135,14 @@ internal class DefaultDgsReactiveQueryExecutorTest {
         )
 
         dgsQueryExecutor = DefaultDgsReactiveQueryExecutor(
-            schema, provider, dgsDataLoaderProvider,
-            DefaultDgsReactiveGraphQLContextBuilder(
-                Optional.empty()
-            ),
-            ChainedInstrumentation(), AsyncExecutionStrategy(), AsyncSerialExecutionStrategy(), Optional.empty()
+            defaultSchema = schema,
+            schemaProvider = provider,
+            dataLoaderProvider = dgsDataLoaderProvider,
+            contextBuilder = DefaultDgsReactiveGraphQLContextBuilder(Optional.empty()),
+            instrumentation = SimpleInstrumentation.INSTANCE,
+            queryExecutionStrategy = AsyncExecutionStrategy(),
+            mutationExecutionStrategy = AsyncSerialExecutionStrategy(),
+            idProvider = Optional.empty()
         )
     }
 

--- a/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/ReactiveReturnTypesTest.kt
+++ b/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/ReactiveReturnTypesTest.kt
@@ -29,7 +29,7 @@ import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveGraphQLContex
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveQueryExecutor
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
-import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -138,11 +138,14 @@ internal class ReactiveReturnTypesTest {
         )
 
         dgsQueryExecutor = DefaultDgsReactiveQueryExecutor(
-            schema, provider, dgsDataLoaderProvider,
-            DefaultDgsReactiveGraphQLContextBuilder(
-                Optional.empty()
-            ),
-            ChainedInstrumentation(), AsyncExecutionStrategy(), AsyncSerialExecutionStrategy(), Optional.empty()
+            defaultSchema = schema,
+            schemaProvider = provider,
+            dataLoaderProvider = dgsDataLoaderProvider,
+            contextBuilder = DefaultDgsReactiveGraphQLContextBuilder(Optional.empty()),
+            instrumentation = SimpleInstrumentation.INSTANCE,
+            queryExecutionStrategy = AsyncExecutionStrategy(),
+            mutationExecutionStrategy = AsyncSerialExecutionStrategy(),
+            idProvider = Optional.empty()
         )
     }
 

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -42,9 +42,11 @@ import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.introspection.IntrospectionQuery
 import graphql.schema.GraphQLSchema
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -69,6 +71,7 @@ import reactor.core.publisher.Mono
 import reactor.netty.http.server.WebsocketServerSpec
 import java.net.URI
 import java.util.*
+import kotlin.streams.toList
 
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
 @Configuration
@@ -83,7 +86,7 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
         dgsDataLoaderProvider: DgsDataLoaderProvider,
         dgsContextBuilder: DefaultDgsReactiveGraphQLContextBuilder,
         dataFetcherExceptionHandler: DataFetcherExceptionHandler,
-        chainedInstrumentation: ChainedInstrumentation,
+        instrumentations: ObjectProvider<Instrumentation>,
         environment: Environment,
         @Qualifier("query") providedQueryExecutionStrategy: Optional<ExecutionStrategy>,
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
@@ -97,18 +100,25 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             providedQueryExecutionStrategy.orElse(AsyncExecutionStrategy(dataFetcherExceptionHandler))
         val mutationExecutionStrategy =
             providedMutationExecutionStrategy.orElse(AsyncSerialExecutionStrategy(dataFetcherExceptionHandler))
+        val instrumentationImpls = instrumentations.orderedStream().toList()
+        val instrumentation: Instrumentation? = when {
+            instrumentationImpls.size == 1 -> instrumentationImpls.single()
+            instrumentationImpls.isNotEmpty() -> ChainedInstrumentation(instrumentationImpls)
+            else -> null
+        }
+
         return DefaultDgsReactiveQueryExecutor(
-            schema,
-            schemaProvider,
-            dgsDataLoaderProvider,
-            dgsContextBuilder,
-            chainedInstrumentation,
-            queryExecutionStrategy,
-            mutationExecutionStrategy,
-            idProvider,
-            reloadSchemaIndicator,
-            preparsedDocumentProvider,
-            queryValueCustomizer
+            defaultSchema = schema,
+            schemaProvider = schemaProvider,
+            dataLoaderProvider = dgsDataLoaderProvider,
+            contextBuilder = dgsContextBuilder,
+            instrumentation = instrumentation,
+            queryExecutionStrategy = queryExecutionStrategy,
+            mutationExecutionStrategy = mutationExecutionStrategy,
+            idProvider = idProvider,
+            reloadIndicator = reloadSchemaIndicator,
+            preparsedDocumentProvider = preparsedDocumentProvider,
+            queryValueCustomizer = queryValueCustomizer
         )
     }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.internal
 
 import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.jayway.jsonpath.Configuration
@@ -31,10 +32,10 @@ import com.netflix.graphql.types.errors.TypedGraphQLError
 import graphql.*
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
-import graphql.execution.SubscriptionExecutionStrategy
-import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.util.StringUtils
 import java.util.*
@@ -42,12 +43,12 @@ import java.util.concurrent.CompletableFuture
 
 object BaseDgsQueryExecutor {
 
-    private val logger = LoggerFactory.getLogger(BaseDgsQueryExecutor::class.java)
+    private val logger: Logger = LoggerFactory.getLogger(BaseDgsQueryExecutor::class.java)
 
-    val objectMapper = jacksonObjectMapper()
+    val objectMapper: ObjectMapper = jacksonObjectMapper()
         .registerModule(JavaTimeModule())
         .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
-        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)!!
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 
     val parseContext: ParseContext =
         JsonPath.using(
@@ -65,12 +66,12 @@ object BaseDgsQueryExecutor {
         dgsContext: DgsContext,
         graphQLSchema: GraphQLSchema,
         dataLoaderProvider: DgsDataLoaderProvider,
-        chainedInstrumentation: ChainedInstrumentation,
+        instrumentation: Instrumentation?,
         queryExecutionStrategy: ExecutionStrategy,
         mutationExecutionStrategy: ExecutionStrategy,
         idProvider: Optional<ExecutionIdProvider>,
         preparsedDocumentProvider: PreparsedDocumentProvider,
-    ): CompletableFuture<out ExecutionResult> {
+    ): CompletableFuture<ExecutionResult> {
 
         if (!StringUtils.hasText(query)) {
             return CompletableFuture.completedFuture(
@@ -89,15 +90,13 @@ object BaseDgsQueryExecutor {
         val graphQLBuilder =
             GraphQL.newGraphQL(graphQLSchema)
                 .preparsedDocumentProvider(preparsedDocumentProvider)
-                .instrumentation(chainedInstrumentation)
                 .queryExecutionStrategy(queryExecutionStrategy)
                 .mutationExecutionStrategy(mutationExecutionStrategy)
-                .subscriptionExecutionStrategy(SubscriptionExecutionStrategy())
 
-        if (idProvider.isPresent) {
-            graphQLBuilder.executionIdProvider(idProvider.get())
-        }
-        val graphQL = graphQLBuilder.build()
+        instrumentation?.let { graphQLBuilder.instrumentation(it) }
+        idProvider.ifPresent { graphQLBuilder.executionIdProvider(it) }
+
+        val graphQL: GraphQL = graphQLBuilder.build()
 
         val dataLoaderRegistry = dataLoaderProvider.buildRegistryWithContextSupplier { dgsContext }
 
@@ -109,10 +108,7 @@ object BaseDgsQueryExecutor {
                 .variables(variables)
                 .dataLoaderRegistry(dataLoaderRegistry)
                 .graphQLContext(dgsContext)
-
-        if (extensions != null) {
-            executionInputBuilder.extensions(extensions)
-        }
+                .extensions(extensions.orEmpty())
 
         return try {
             graphQL.executeAsync(executionInputBuilder.build())

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -16,7 +16,9 @@
 
 package com.netflix.graphql.dgs.internal
 
-import com.jayway.jsonpath.*
+import com.jayway.jsonpath.DocumentContext
+import com.jayway.jsonpath.JsonPath
+import com.jayway.jsonpath.TypeRef
 import com.jayway.jsonpath.spi.mapper.MappingException
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.exceptions.DgsQueryExecutionDataExtractionException
@@ -27,7 +29,7 @@ import graphql.*
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.NonNullableFieldWasNullError
-import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
@@ -46,7 +48,7 @@ class DefaultDgsQueryExecutor(
     private val schemaProvider: DgsSchemaProvider,
     private val dataLoaderProvider: DgsDataLoaderProvider,
     private val contextBuilder: DefaultDgsGraphQLContextBuilder,
-    private val chainedInstrumentation: ChainedInstrumentation,
+    private val instrumentation: Instrumentation?,
     private val queryExecutionStrategy: ExecutionStrategy,
     private val mutationExecutionStrategy: ExecutionStrategy,
     private val idProvider: Optional<ExecutionIdProvider>,
@@ -74,18 +76,18 @@ class DefaultDgsQueryExecutor(
 
         val executionResult =
             BaseDgsQueryExecutor.baseExecute(
-                queryValueCustomizer.apply(query),
-                variables,
-                extensions,
-                operationName,
-                dgsContext,
-                graphQLSchema,
-                dataLoaderProvider,
-                chainedInstrumentation,
-                queryExecutionStrategy,
-                mutationExecutionStrategy,
-                idProvider,
-                preparsedDocumentProvider,
+                query = queryValueCustomizer.apply(query),
+                variables = variables,
+                extensions = extensions,
+                operationName = operationName,
+                dgsContext = dgsContext,
+                graphQLSchema = graphQLSchema,
+                dataLoaderProvider = dataLoaderProvider,
+                instrumentation = instrumentation,
+                queryExecutionStrategy = queryExecutionStrategy,
+                mutationExecutionStrategy = mutationExecutionStrategy,
+                idProvider = idProvider,
+                preparsedDocumentProvider = preparsedDocumentProvider,
             )
 
         // Check for NonNullableFieldWasNull errors, and log them explicitly because they don't run through the exception handlers.

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
@@ -24,7 +24,7 @@ import com.netflix.graphql.dgs.exceptions.QueryException
 import com.netflix.graphql.types.errors.ErrorType
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
-import graphql.execution.instrumentation.ChainedInstrumentation
+import graphql.execution.instrumentation.SimpleInstrumentation
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -140,14 +140,14 @@ internal class DefaultDgsQueryExecutorTest {
         )
 
         dgsQueryExecutor = DefaultDgsQueryExecutor(
-            schema,
-            provider,
-            dgsDataLoaderProvider,
-            DefaultDgsGraphQLContextBuilder(Optional.empty()),
-            ChainedInstrumentation(),
-            AsyncExecutionStrategy(),
-            AsyncSerialExecutionStrategy(),
-            Optional.empty()
+            defaultSchema = schema,
+            schemaProvider = provider,
+            dataLoaderProvider = dgsDataLoaderProvider,
+            contextBuilder = DefaultDgsGraphQLContextBuilder(Optional.empty()),
+            instrumentation = SimpleInstrumentation.INSTANCE,
+            queryExecutionStrategy = AsyncExecutionStrategy(),
+            mutationExecutionStrategy = AsyncSerialExecutionStrategy(),
+            idProvider = Optional.empty()
         )
     }
 


### PR DESCRIPTION
When no Instrumentation beans are supplied, avoid passing in a ChainedInstrumentation
instance containing an empty list of Instrumentations. Doing so would result in some
unnecessary overhead, as the builder's internal checkInstrumentationDefaultState method
will attempt to add its own default instrumentation.

Not that I did actually see this show up in flame graphs, for a case where I had no instrumentation registered, it was spending time in ChainedInstrumentation's internals, looking up state in a HashMap, etc. This is because by passing in an empty ChainedInstrumentation, we end up with the default DataLoaderDispatcherInstrumentation instance wrapped unnecessarily in a ChainedInstrumentation.