### PR TITLE
Remove usage of NoOpPreparsedDocumentProvider

### DIFF
--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
@@ -32,7 +32,6 @@ import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.NonNullableFieldWasNullError
 import graphql.execution.instrumentation.Instrumentation
-import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
 import org.slf4j.Logger
@@ -54,7 +53,7 @@ class DefaultDgsReactiveQueryExecutor(
     private val mutationExecutionStrategy: ExecutionStrategy,
     private val idProvider: Optional<ExecutionIdProvider>,
     private val reloadIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator = DefaultDgsQueryExecutor.ReloadSchemaIndicator { false },
-    private val preparsedDocumentProvider: PreparsedDocumentProvider = NoOpPreparsedDocumentProvider.INSTANCE,
+    private val preparsedDocumentProvider: PreparsedDocumentProvider? = null,
     private val queryValueCustomizer: QueryValueCustomizer = QueryValueCustomizer { query -> query }
 ) : com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor {
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -32,7 +32,6 @@ import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.instrumentation.ChainedInstrumentation
 import graphql.execution.instrumentation.Instrumentation
-import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.DataFetcherFactory
 import graphql.schema.GraphQLCodeRegistry
@@ -86,7 +85,7 @@ open class DgsAutoConfiguration(
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
         reloadSchemaIndicator: ReloadSchemaIndicator,
-        preparsedDocumentProvider: PreparsedDocumentProvider,
+        preparsedDocumentProvider: ObjectProvider<PreparsedDocumentProvider>,
         queryValueCustomizer: QueryValueCustomizer
     ): DgsQueryExecutor {
         val queryExecutionStrategy =
@@ -111,7 +110,7 @@ open class DgsAutoConfiguration(
             mutationExecutionStrategy = mutationExecutionStrategy,
             idProvider = idProvider,
             reloadIndicator = reloadSchemaIndicator,
-            preparsedDocumentProvider = preparsedDocumentProvider,
+            preparsedDocumentProvider = preparsedDocumentProvider.ifAvailable,
             queryValueCustomizer = queryValueCustomizer
         )
     }
@@ -120,12 +119,6 @@ open class DgsAutoConfiguration(
     @ConditionalOnMissingBean
     open fun defaultQueryValueCustomizer(): QueryValueCustomizer {
         return QueryValueCustomizer { a -> a }
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    open fun preparsedDocumentProvider(): PreparsedDocumentProvider {
-        return NoOpPreparsedDocumentProvider.INSTANCE
     }
 
     @Bean

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -92,7 +92,7 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
         @Qualifier("mutation") providedMutationExecutionStrategy: Optional<ExecutionStrategy>,
         idProvider: Optional<ExecutionIdProvider>,
         reloadSchemaIndicator: DefaultDgsQueryExecutor.ReloadSchemaIndicator,
-        preparsedDocumentProvider: PreparsedDocumentProvider,
+        preparsedDocumentProvider: ObjectProvider<PreparsedDocumentProvider>,
         queryValueCustomizer: QueryValueCustomizer
     ): DgsReactiveQueryExecutor {
 
@@ -117,7 +117,7 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             mutationExecutionStrategy = mutationExecutionStrategy,
             idProvider = idProvider,
             reloadIndicator = reloadSchemaIndicator,
-            preparsedDocumentProvider = preparsedDocumentProvider,
+            preparsedDocumentProvider = preparsedDocumentProvider.ifAvailable,
             queryValueCustomizer = queryValueCustomizer
         )
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
@@ -70,7 +70,7 @@ object BaseDgsQueryExecutor {
         queryExecutionStrategy: ExecutionStrategy,
         mutationExecutionStrategy: ExecutionStrategy,
         idProvider: Optional<ExecutionIdProvider>,
-        preparsedDocumentProvider: PreparsedDocumentProvider,
+        preparsedDocumentProvider: PreparsedDocumentProvider?,
     ): CompletableFuture<ExecutionResult> {
 
         if (!StringUtils.hasText(query)) {
@@ -89,10 +89,10 @@ object BaseDgsQueryExecutor {
 
         val graphQLBuilder =
             GraphQL.newGraphQL(graphQLSchema)
-                .preparsedDocumentProvider(preparsedDocumentProvider)
                 .queryExecutionStrategy(queryExecutionStrategy)
                 .mutationExecutionStrategy(mutationExecutionStrategy)
 
+        preparsedDocumentProvider?.let { graphQLBuilder.preparsedDocumentProvider(it) }
         instrumentation?.let { graphQLBuilder.instrumentation(it) }
         idProvider.ifPresent { graphQLBuilder.executionIdProvider(it) }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -30,7 +30,6 @@ import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
 import graphql.execution.NonNullableFieldWasNullError
 import graphql.execution.instrumentation.Instrumentation
-import graphql.execution.preparsed.NoOpPreparsedDocumentProvider
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
 import org.slf4j.Logger
@@ -53,7 +52,7 @@ class DefaultDgsQueryExecutor(
     private val mutationExecutionStrategy: ExecutionStrategy,
     private val idProvider: Optional<ExecutionIdProvider>,
     private val reloadIndicator: ReloadSchemaIndicator = ReloadSchemaIndicator { false },
-    private val preparsedDocumentProvider: PreparsedDocumentProvider = NoOpPreparsedDocumentProvider.INSTANCE,
+    private val preparsedDocumentProvider: PreparsedDocumentProvider? = null,
     private val queryValueCustomizer: QueryValueCustomizer = QueryValueCustomizer { query -> query }
 ) : DgsQueryExecutor {
 


### PR DESCRIPTION
NoOpPreparsedDocumentProvider is marked as internal in graphql-java; however, it is
the default PreparsedDocumentProvider used by the GraphQL.Builder, so we can use it
by virtue of simply not passing anything in when no PreparsedDocumentProvider bean
is available.