### PR TITLE
Stop calling deprecated exchange method on WebClient

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClient.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.util.ClassUtils
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.server.ResponseStatusException
@@ -207,9 +208,11 @@ internal object GraphQLClients {
             ObjectMapper().registerModule(KotlinModule.Builder().nullIsSameAsDefault(true).build())
         else ObjectMapper().registerKotlinModule()
 
-    internal val defaultHeaders = mapOf(
-        "Accept" to listOf("application/json"),
-        "Content-type" to listOf("application/json")
+    internal val defaultHeaders: HttpHeaders = HttpHeaders.readOnlyHttpHeaders(
+        HttpHeaders().apply {
+            accept = listOf(MediaType.APPLICATION_JSON)
+            contentType = MediaType.APPLICATION_JSON
+        }
     )
 
     fun handleResponse(response: HttpResponse, requestBody: String, url: String): GraphQLResponse {

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/SSESubscriptionGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/SSESubscriptionGraphQLClient.kt
@@ -20,11 +20,9 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.types.subscription.QueryPayload
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.WebClientResponseException
-import org.springframework.web.reactive.function.client.bodyToFlux
+import org.springframework.web.reactive.function.client.toEntityFlux
 import reactor.core.publisher.Flux
 import reactor.core.scheduler.Schedulers
-import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import java.util.*
 
@@ -48,17 +46,12 @@ class SSESubscriptionGraphQLClient(private val url: String, private val webClien
         return webClient.get()
             .uri("$url?query={query}", mapOf("query" to encodeQuery(jsonPayload)))
             .accept(MediaType.TEXT_EVENT_STREAM)
-            .exchange()
-            .flatMapMany { r ->
-                if (r.statusCode().is2xxSuccessful) {
-                    r.bodyToFlux<String>().map { GraphQLResponse(it, r.headers().asHttpHeaders()) }.onBackpressureBuffer()
-                } else {
-                    if (r.statusCode().is4xxClientError || r.statusCode().is3xxRedirection) {
-                        throw WebClientResponseException.create(r.rawStatusCode(), r.toString(), r.headers().asHttpHeaders(), byteArrayOf(), Charset.defaultCharset())
-                    } else {
-                        r.bodyToFlux<String>().map { throw WebClientResponseException.create(r.rawStatusCode(), r.toString(), r.headers().asHttpHeaders(), it.toByteArray(), Charset.defaultCharset()) }
-                    }
-                }
+            .retrieve()
+            .toEntityFlux<String>()
+            .flatMapMany { response ->
+                val headers = response.headers
+                response.body?.map { body -> GraphQLResponse(json = body, headers = headers) }
+                    ?: Flux.empty()
             }
             .publishOn(Schedulers.single())
     }

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClient.kt
@@ -17,7 +17,9 @@
 package com.netflix.graphql.dgs.client
 
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.toEntity
 import reactor.core.publisher.Mono
 import java.util.function.Consumer
 
@@ -31,9 +33,12 @@ import java.util.function.Consumer
  *      GraphQLResponse message = webClientGraphQLClient.reactiveExecuteQuery("{hello}").map(r -> r.extractValue<String>("hello"));
  *      message.subscribe();
  */
-class WebClientGraphQLClient(private val webclient: WebClient, private val headersConsumer: Consumer<HttpHeaders>?) : MonoGraphQLClient {
+class WebClientGraphQLClient(
+    private val webclient: WebClient,
+    private val headersConsumer: Consumer<HttpHeaders>
+) : MonoGraphQLClient {
 
-    constructor(webclient: WebClient) : this(webclient, null)
+    constructor(webclient: WebClient) : this(webclient, Consumer {})
     /**
      * @param query The query string. Note that you can use [code generation](https://netflix.github.io/dgs/generating-code-from-schema/#generating-query-apis-for-external-services) for a type safe query!
      * @return A [Mono] of [GraphQLResponse]. [GraphQLResponse] parses the response and gives easy access to data and errors.
@@ -78,12 +83,16 @@ class WebClientGraphQLClient(private val webclient: WebClient, private val heade
 
         return webclient.post()
             .bodyValue(serializedRequest)
-            .headers { consumer -> GraphQLClients.defaultHeaders.forEach(consumer::addAll) }
-            .headers(this.headersConsumer ?: Consumer { })
-            .exchange()
-            .flatMap { r ->
-                r.bodyToMono(String::class.java)
-                    .map { respBody -> HttpResponse(r.rawStatusCode(), respBody, r.headers().asHttpHeaders()) }
+            .headers { headers -> headers.addAll(GraphQLClients.defaultHeaders) }
+            .headers(this.headersConsumer)
+            .retrieve()
+            .toEntity<String>()
+            .map { response ->
+                HttpResponse(
+                    statusCode = response.statusCodeValue,
+                    body = response.body,
+                    headers = response.headers
+                )
             }
             .map { httpResponse -> handleResponse(httpResponse, serializedRequest) }
     }
@@ -91,7 +100,7 @@ class WebClientGraphQLClient(private val webclient: WebClient, private val heade
     private fun handleResponse(response: HttpResponse, requestBody: String): GraphQLResponse {
         val (statusCode, body) = response
         val headers = response.headers
-        if (statusCode !in 200..299) {
+        if (!HttpStatus.valueOf(statusCode).is2xxSuccessful) {
             throw GraphQLClientException(statusCode, webclient.toString(), body ?: "", requestBody)
         }
 


### PR DESCRIPTION
Since Spring 5.3, the exchange method on WebClient has been deprecated
in favor of retrieve. In addition to fixing that, perform some minor
clean up:

- Make GraphQLClients.defaultHeaders a read-only HttpHeaders instance,
  and use MediaType.APPLICATION_JSON to set the content types for
  the "Accept" and "Content-Type" headers.
- Change WebClientGraphQLClient to not allow a nullable headersConsumer
  parameter; instead, pass in the no-op Consumer {} from the single-arity
  constructor, which means at the use-site nullability is no longer necessary
  to check.