### PR TITLE
Fix bug in DgsDataLoaderProvider

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -183,7 +183,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
             extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
-        return DataLoaderFactory.newDataLoader(batchLoader, options)
+        return DataLoaderFactory.newDataLoader(extendedBatchLoader, options)
     }
 
     private fun <T> createDataLoader(


### PR DESCRIPTION
One of the createDataLoader methods was calling wrappedDataLoader, but then
was erroneously returning a reference to the unwrapped loader.
