### PR TITLE
feature: add UUID Scalar

### DIFF
--- a/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
+++ b/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
@@ -135,6 +135,25 @@ open class DgsExtendedScalarsAutoConfiguration {
         }
     }
 
+
+    @ConditionalOnProperty(
+        prefix = "dgs.graphql.extensions.scalars.ids",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    @Configuration(proxyBeanMethods = false)
+    open class IDsExtendedScalarsAutoConfiguration {
+        @Bean
+        open fun idsExtendedScalarsRegistrar(): ExtendedScalarRegistrar {
+            return object : AbstractExtendedScalarRegistrar() {
+                override fun getScalars(): List<GraphQLScalarType> {
+                    return listOf(ExtendedScalars.UUID)
+                }
+            }
+        }
+    }
+
     @DgsComponent
     @FunctionalInterface
     fun interface ExtendedScalarRegistrar {

--- a/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
+++ b/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
@@ -135,7 +135,6 @@ open class DgsExtendedScalarsAutoConfiguration {
         }
     }
 
-
     @ConditionalOnProperty(
         prefix = "dgs.graphql.extensions.scalars.ids",
         name = ["enabled"],

--- a/graphql-dgs-extended-scalars/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfigurationTests.kt
+++ b/graphql-dgs-extended-scalars/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfigurationTests.kt
@@ -38,7 +38,6 @@ internal class DgsExtendedScalarsAutoConfigurationTests {
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.ObjectsExtendedScalarsAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.TimeExtendedScalarsAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.IDsExtendedScalarsAutoConfiguration::class.java)
-
         }
     }
 

--- a/graphql-dgs-extended-scalars/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfigurationTests.kt
+++ b/graphql-dgs-extended-scalars/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfigurationTests.kt
@@ -37,6 +37,8 @@ internal class DgsExtendedScalarsAutoConfigurationTests {
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.ObjectsExtendedScalarsAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.TimeExtendedScalarsAutoConfiguration::class.java)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration.IDsExtendedScalarsAutoConfiguration::class.java)
+
         }
     }
 
@@ -95,6 +97,18 @@ internal class DgsExtendedScalarsAutoConfigurationTests {
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration::class.java)
             assertThat(context)
                 .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.CharsExtendedScalarsAutoConfiguration::class.java)
+        }
+    }
+
+    @Test
+    fun `IDs scalars can be disabled`() {
+        context.withPropertyValues(
+            "dgs.graphql.extensions.scalars.ids.enabled=false"
+        ).run { context ->
+            assertThat(context)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration::class.java)
+            assertThat(context)
+                .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.IDsExtendedScalarsAutoConfiguration::class.java)
         }
     }
 }


### PR DESCRIPTION
`graphql-java-extended-scalars:18.0` introduced a [new UUID scalar type](https://github.com/graphql-java/graphql-java-extended-scalars#id-scalars)

Adding UUID Scalar into new configuration group `dgs.graphql.extensions.scalars.ids.enabled`

Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_

