### PR TITLE
Preserve Reactor context in reactive data fetcher

### DIFF
--- a/graphql-dgs-example-java-webflux/src/main/java/com/netflix/graphql/dgs/example/reactive/datafetchers/UsingWebFluxReactorContext.java
+++ b/graphql-dgs-example-java-webflux/src/main/java/com/netflix/graphql/dgs/example/reactive/datafetchers/UsingWebFluxReactorContext.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.example.reactive.datafetchers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsQuery;
+import reactor.core.publisher.Mono;
+
+@DgsComponent
+public class UsingWebFluxReactorContext {
+    @DgsQuery
+    public Mono<String> usingContext() {
+        return Mono.deferContextual(context -> Mono.just("Query with request ID: " + context.get("RequestId")));
+    }
+}

--- a/graphql-dgs-example-java-webflux/src/main/java/com/netflix/graphql/dgs/example/web/RequestIdWebFilter.java
+++ b/graphql-dgs-example-java-webflux/src/main/java/com/netflix/graphql/dgs/example/web/RequestIdWebFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.example.web;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+
+@Component
+public class RequestIdWebFilter implements WebFilter {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(exchange).contextWrite(Context.of("RequestId", exchange.getRequest().getId()));
+    }
+}

--- a/graphql-dgs-example-java-webflux/src/main/resources/schema/extraschema.graphqls
+++ b/graphql-dgs-example-java-webflux/src/main/resources/schema/extraschema.graphqls
@@ -1,4 +1,5 @@
 extend type Query {
     mono: String
     flux: [Int]
+    usingContext: String
 }

--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
@@ -41,18 +41,22 @@ open class DefaultDgsReactiveGraphQLContextBuilder(
             )
         } else Mono.empty()
 
-        return customContext.flatMap {
-            Mono.just(
+        return Mono.deferContextual { context ->
+            customContext.flatMap {
+                Mono.just(
+                    DgsContext(
+                        it,
+                        dgsRequestData,
+                        context,
+                    )
+                )
+            }.defaultIfEmpty(
                 DgsContext(
-                    it,
-                    dgsRequestData
+                    requestData = dgsRequestData,
+                    reactorContext = context,
                 )
             )
-        }.defaultIfEmpty(
-            DgsContext(
-                requestData = dgsRequestData
-            )
-        )
+        }
     }
 }
 

--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.reactive.internal
 
 import com.netflix.graphql.dgs.context.DgsContext
+import com.netflix.graphql.dgs.context.ReactiveDgsContext
 import com.netflix.graphql.dgs.internal.DgsRequestData
 import com.netflix.graphql.dgs.reactive.DgsReactiveCustomContextBuilderWithRequest
 import org.springframework.http.HttpHeaders
@@ -42,18 +43,16 @@ open class DefaultDgsReactiveGraphQLContextBuilder(
         } else Mono.empty()
 
         return Mono.deferContextual { context ->
-            customContext.flatMap {
-                Mono.just(
-                    DgsContext(
-                        it,
-                        dgsRequestData,
-                        context,
-                    )
+            customContext.map {
+                ReactiveDgsContext(
+                    it,
+                    dgsRequestData,
+                    context
                 )
             }.defaultIfEmpty(
-                DgsContext(
+                ReactiveDgsContext(
                     requestData = dgsRequestData,
-                    reactorContext = context,
+                    reactorContext = context
                 )
             )
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
@@ -21,13 +21,18 @@ import graphql.ExecutionInput
 import graphql.GraphQLContext
 import graphql.schema.DataFetchingEnvironment
 import org.dataloader.BatchLoaderEnvironment
+import reactor.util.context.ContextView
 import java.util.function.Consumer
 
 /**
  * Context class that is created per request, and is added to both DataFetchingEnvironment and BatchLoaderEnvironment.
  * Custom data can be added by providing a [DgsCustomContextBuilder].
  */
-open class DgsContext(val customContext: Any? = null, val requestData: DgsRequestData?) : Consumer<GraphQLContext.Builder> {
+open class DgsContext(
+    val customContext: Any? = null,
+    val requestData: DgsRequestData?,
+    val reactorContext: ContextView? = null
+) : Consumer<GraphQLContext.Builder> {
 
     private enum class GraphQLContextKey { DGS_CONTEXT_KEY }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
@@ -21,18 +21,13 @@ import graphql.ExecutionInput
 import graphql.GraphQLContext
 import graphql.schema.DataFetchingEnvironment
 import org.dataloader.BatchLoaderEnvironment
-import reactor.util.context.ContextView
 import java.util.function.Consumer
 
 /**
  * Context class that is created per request, and is added to both DataFetchingEnvironment and BatchLoaderEnvironment.
  * Custom data can be added by providing a [DgsCustomContextBuilder].
  */
-open class DgsContext(
-    val customContext: Any? = null,
-    val requestData: DgsRequestData?,
-    val reactorContext: ContextView? = null
-) : Consumer<GraphQLContext.Builder> {
+open class DgsContext(val customContext: Any? = null, val requestData: DgsRequestData?) : Consumer<GraphQLContext.Builder> {
 
     private enum class GraphQLContextKey { DGS_CONTEXT_KEY }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/ReactiveDgsContext.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/ReactiveDgsContext.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.context
+
+import com.netflix.graphql.dgs.internal.DgsRequestData
+import graphql.GraphQLContext
+import graphql.schema.DataFetchingEnvironment
+import reactor.util.context.Context
+import reactor.util.context.ContextView
+import kotlin.reflect.safeCast
+
+class ReactiveDgsContext(
+    customContext: Any? = null,
+    requestData: DgsRequestData?,
+    val reactorContext: ContextView? = Context.empty()
+) : DgsContext(customContext, requestData) {
+    companion object {
+        @JvmStatic
+        fun from(graphQLContext: GraphQLContext): ReactiveDgsContext? {
+            return ReactiveDgsContext::class.safeCast(DgsContext.from(graphQLContext))
+        }
+
+        @JvmStatic
+        fun from(dfe: DataFetchingEnvironment): ReactiveDgsContext? {
+            return from(dfe.graphQlContext)
+        }
+    }
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/ReactiveDataFetcherResultProcessor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/ReactiveDataFetcherResultProcessor.kt
@@ -17,11 +17,10 @@
 package com.netflix.graphql.dgs.internal
 
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
-import com.netflix.graphql.dgs.context.DgsContext
+import com.netflix.graphql.dgs.context.ReactiveDgsContext
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.util.context.Context
-import java.lang.IllegalArgumentException
 
 class MonoDataFetcherResultProcessor : DataFetcherResultProcessor {
     override fun supportsType(originalResult: Any): Boolean {
@@ -52,4 +51,4 @@ class FluxDataFetcherResultProcessor : DataFetcherResultProcessor {
 }
 
 private fun reactorContextFrom(dfe: DgsDataFetchingEnvironment) =
-    DgsContext.from(dfe).reactorContext ?: Context.empty()
+    ReactiveDgsContext.from(dfe)?.reactorContext ?: Context.empty()


### PR DESCRIPTION
- Add field to DgsContext to store nullable ContextView instance when
creating a DgsContext in of the DefaultDgsReactiveGraphQLContextBuilder.
- Read Reactor context inside reactive data fetcher result processor
implementations and copy onto the subscriber context for the data fetcher
operation.
- Add example of setting and accessing the Reactor context inside a WebFlux
application; including a sample WebFilter and DgsQuery

Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
See comment https://github.com/Netflix/dgs-framework/pull/1040#issuecomment-1122616050

Alternatives considered
----

I had considered just wiring the existing solution from https://github.com/Netflix/dgs-framework/issues/375 in the Spring auto-configuration. However, this would end up conflicting with any other 'custom' result processors or custom context builders which users' themselves registered. It would also be specific to _just_ the Web Request context or Security Holder context.
There is one field which was I chose to add to `DgsContext`. However, this has not caused any compilation issues in sub-modules without that required dependency as the new argument is either omitted or remains as `null` in non-reactive projects (I'm happy for someone to double check this however!).

The chosen approach should allow for the context to be preserved transparently, outside of any other customisations and preserves the entire Reactor Context as it was available when building the initial `DgsContext`.
