### PR TITLE
Fix missing Reactor Context in Kotlin suspend datafetchers

### DIFF
--- a/dependencies.lock
+++ b/dependencies.lock
@@ -10,7 +10,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -38,7 +38,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -66,7 +66,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -86,7 +86,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -112,7 +112,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -138,7 +138,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -169,7 +169,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -189,7 +189,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -209,7 +209,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -232,7 +232,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -252,7 +252,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -275,7 +275,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -303,7 +303,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -81,7 +81,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -134,7 +134,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -154,7 +154,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -180,7 +180,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -206,7 +206,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -237,7 +237,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -257,7 +257,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -277,7 +277,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -342,7 +342,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -368,7 +368,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -473,7 +473,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -511,7 +511,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -663,7 +663,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -730,6 +730,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -764,7 +770,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -168,7 +168,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -215,7 +215,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -235,7 +235,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -261,7 +261,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -287,7 +287,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -318,7 +318,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -338,7 +338,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -358,7 +358,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -598,6 +598,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -628,7 +634,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -673,7 +679,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -791,7 +797,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -831,7 +837,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -1001,7 +1007,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -1074,6 +1080,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -1107,7 +1119,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -174,7 +174,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -221,7 +221,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -241,7 +241,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -267,7 +267,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -293,7 +293,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -324,7 +324,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -344,7 +344,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -364,7 +364,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -607,6 +607,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -647,7 +653,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -704,7 +710,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -827,7 +833,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -874,7 +880,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -1054,7 +1060,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1124,6 +1130,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -1170,7 +1182,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -110,7 +110,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -163,7 +163,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -183,7 +183,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -209,7 +209,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -235,7 +235,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -266,7 +266,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -286,7 +286,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -306,7 +306,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -448,6 +448,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -470,7 +476,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -504,7 +510,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -578,7 +584,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -607,7 +613,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -708,7 +714,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -761,6 +767,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -786,7 +798,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -87,7 +87,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -134,7 +134,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -154,7 +154,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -180,7 +180,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -206,7 +206,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -237,7 +237,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -257,7 +257,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -277,7 +277,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -383,6 +383,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -396,7 +402,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -428,7 +434,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -537,7 +543,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -572,7 +578,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -716,7 +722,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -778,6 +784,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -813,7 +825,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -87,7 +87,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -134,7 +134,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -154,7 +154,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -180,7 +180,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -206,7 +206,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -237,7 +237,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -257,7 +257,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -277,7 +277,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -383,6 +383,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -396,7 +402,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -428,7 +434,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -537,7 +543,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -572,7 +578,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -716,7 +722,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -778,6 +784,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -813,7 +825,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -51,7 +51,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -98,7 +98,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -118,7 +118,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -144,7 +144,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -170,7 +170,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -201,7 +201,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -221,7 +221,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -241,7 +241,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -276,7 +276,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -296,7 +296,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -316,7 +316,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "net.datafaker:datafaker": {
             "locked": "1.3.0"
@@ -337,7 +337,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -357,7 +357,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "net.datafaker:datafaker": {
             "locked": "1.3.0"
@@ -378,7 +378,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -84,7 +84,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -131,7 +131,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -151,7 +151,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -177,7 +177,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -203,7 +203,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -234,7 +234,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -254,7 +254,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -274,7 +274,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -377,6 +377,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -390,7 +396,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -422,7 +428,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -473,7 +479,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -496,7 +502,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -565,7 +571,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -602,6 +608,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -618,7 +630,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-platform-dependencies/dependencies.lock
+++ b/graphql-dgs-platform-dependencies/dependencies.lock
@@ -15,7 +15,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-platform/dependencies.lock
+++ b/graphql-dgs-platform/dependencies.lock
@@ -10,7 +10,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -93,7 +93,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -143,7 +143,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -163,7 +163,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -189,7 +189,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -215,7 +215,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -246,7 +246,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -266,7 +266,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -286,7 +286,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -392,6 +392,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -405,7 +411,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -440,7 +446,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -510,7 +516,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.1.6"
@@ -544,7 +550,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -633,7 +639,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.1.6"
@@ -685,6 +691,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -704,7 +716,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -125,7 +125,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.2"
+            "locked": "1.3.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -169,7 +169,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -219,7 +219,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -239,7 +239,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -265,7 +265,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -291,7 +291,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -322,7 +322,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -342,7 +342,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -362,7 +362,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -434,7 +434,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.2"
+            "locked": "1.3.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -480,6 +480,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -490,7 +496,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -525,7 +531,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -634,7 +640,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.2"
+            "locked": "1.3.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -643,7 +649,7 @@
             "locked": "1.8.5"
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -684,7 +690,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -831,7 +837,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.2"
+            "locked": "1.3.3"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -840,7 +846,7 @@
             "locked": "1.8.5"
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -905,6 +911,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -940,7 +952,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -105,7 +105,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -155,7 +155,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -175,7 +175,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -201,7 +201,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -227,7 +227,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -258,7 +258,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -278,7 +278,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -298,7 +298,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -415,6 +415,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -428,7 +434,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -461,7 +467,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -523,7 +529,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -556,7 +562,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -640,7 +646,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -685,6 +691,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -704,7 +716,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -140,7 +140,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -187,7 +187,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -207,7 +207,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -233,7 +233,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -259,7 +259,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -290,7 +290,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -310,7 +310,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -330,7 +330,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -516,6 +516,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -539,7 +545,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -586,7 +592,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -679,7 +685,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -716,7 +722,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -844,7 +850,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -905,6 +911,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -931,7 +943,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -98,7 +98,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -148,7 +148,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -168,7 +168,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -194,7 +194,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -220,7 +220,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -251,7 +251,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -271,7 +271,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -291,7 +291,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -413,6 +413,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -429,7 +435,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -467,7 +473,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -545,7 +551,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor.netty:reactor-netty": {
             "locked": "1.0.18"
@@ -580,7 +586,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -678,7 +684,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -738,6 +744,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -761,7 +773,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -99,7 +99,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -149,7 +149,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -169,7 +169,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -195,7 +195,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -221,7 +221,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -252,7 +252,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -272,7 +272,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -292,7 +292,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -409,6 +409,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -422,7 +428,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -458,7 +464,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -531,7 +537,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
@@ -562,7 +568,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -654,7 +660,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "4.0.4"
@@ -703,6 +709,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -725,7 +737,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -90,7 +90,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -140,7 +140,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -160,7 +160,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -186,7 +186,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -212,7 +212,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -243,7 +243,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -263,7 +263,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -283,7 +283,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -386,6 +386,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -396,7 +402,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -428,7 +434,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -482,7 +488,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "javax.servlet:javax.servlet-api": {
             "locked": "4.0.1"
@@ -508,7 +514,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -580,7 +586,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "javax.servlet:javax.servlet-api": {
             "locked": "4.0.1"
@@ -620,6 +626,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -633,7 +645,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -48,7 +48,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -95,7 +95,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -115,7 +115,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -141,7 +141,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -167,7 +167,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -198,7 +198,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -218,7 +218,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -238,7 +238,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -270,7 +270,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -290,7 +290,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -316,7 +316,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -331,7 +331,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -357,7 +357,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -372,7 +372,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -89,7 +89,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -142,7 +142,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -162,7 +162,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -188,7 +188,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -214,7 +214,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -245,7 +245,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -265,7 +265,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -285,7 +285,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -418,6 +418,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -431,7 +437,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -470,7 +476,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -525,7 +531,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -549,7 +555,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -646,7 +652,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -691,6 +697,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -707,7 +719,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -99,7 +99,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -152,7 +152,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -172,7 +172,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -198,7 +198,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -224,7 +224,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -255,7 +255,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -275,7 +275,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -295,7 +295,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -413,6 +413,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -423,7 +429,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -458,7 +464,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -523,7 +529,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -553,7 +559,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -639,7 +645,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -683,6 +689,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -699,7 +711,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -104,7 +104,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -154,7 +154,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -174,7 +174,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -200,7 +200,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -226,7 +226,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -257,7 +257,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -277,7 +277,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -297,7 +297,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -424,6 +424,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -440,7 +446,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -479,7 +485,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -548,7 +554,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -573,7 +579,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -667,7 +673,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -706,6 +712,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -725,7 +737,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -99,7 +99,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -155,7 +155,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -175,7 +175,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -201,7 +201,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -227,7 +227,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -258,7 +258,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -278,7 +278,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -298,7 +298,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -413,6 +413,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -426,7 +432,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -461,7 +467,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -526,7 +532,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.1.6"
@@ -556,7 +562,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -642,7 +648,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.1.6"
@@ -686,6 +692,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -702,7 +714,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -145,7 +145,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -192,7 +192,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -212,7 +212,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -238,7 +238,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -264,7 +264,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -295,7 +295,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -315,7 +315,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -335,7 +335,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -537,6 +537,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -558,7 +564,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -601,7 +607,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -701,7 +707,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -736,7 +742,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -872,7 +878,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -941,6 +947,12 @@
             ],
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -965,7 +977,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation("com.apollographql.federation:federation-graphql-java-support")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
     testImplementation("org.springframework.security:spring-security-core")
     testImplementation("io.projectreactor:reactor-core")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -83,11 +83,14 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.5.2"
+        },
         "org.springframework.boot:spring-boot-dependencies": {
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -143,7 +146,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -163,7 +166,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -189,7 +192,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -215,7 +218,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -246,7 +249,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -266,7 +269,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -286,7 +289,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -356,6 +359,9 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.5.2"
+        },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
@@ -366,7 +372,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -392,7 +398,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -441,7 +447,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -468,6 +474,9 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.5.2"
+        },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
             "locked": "1.5.2"
         },
@@ -478,7 +487,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -536,7 +545,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.4.17"
@@ -569,6 +578,9 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
             "locked": "1.5.2"
         },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.5.2"
+        },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
             "locked": "1.5.2"
         },
@@ -585,7 +597,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -16,7 +16,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -48,7 +48,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -95,7 +95,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -115,7 +115,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -141,7 +141,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -167,7 +167,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -198,7 +198,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -218,7 +218,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -238,7 +238,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -267,7 +267,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -287,7 +287,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -307,7 +307,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -322,7 +322,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"
@@ -342,7 +342,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-            "locked": "1.12.3"
+            "locked": "1.12.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -357,7 +357,7 @@
             "locked": "2.6.7"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.1"
+            "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
             "locked": "5.6.3"


### PR DESCRIPTION
Use same mechanism used by Spring Core to invoke a Kotlin
suspending function wrapped as a Mono or Flux as appropriate.
This ensures the Reactor Context is made available inside of the
Koltin coroutine context allowing access to values set outside of the
DGS framework (i.e. Spring Security / WebFilter).

- Add additional dependency to provide Koltin Reactor builder functions
required by Spring Core library.
- Update unit test to verify Kotlin suspending DataFetcher can access the
expected context.
- Update unit test to verify the query results to avoid false-positive test
results when an unexpected expection is thrown.
- Update unit test to remove custom ExecutorService to avoid race conditions.
This still allows for validating the delay() functions do not cause all
datafetchers to be processed sequentially on a single Unconfined Dispatcher.

Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This change ensures that the Reactor Context is added to the Kotlin coroutine context when invoking suspending datafetcher methods. This will allow for passing things such as custom Reactor subscriber context from WebFilters or Spring SecurityContextHolder into the coroutine without patching onto the `DgsContext.custom` field.

Issue https://github.com/Netflix/dgs-framework/issues/582

Alternatives considered
----

Couldn't think of a more sensible way to implement this other than doing exactly what Spring Web already does to solve this exact same problem. Has resulted in one more (small) dependency though, hopefully this is an acceptable trade-off?