### PR TITLE
Fix response payload serialization in DgsReactiveWebsocketHandler

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsReactiveWebsocketHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DgsReactiveWebsocketHandler.kt
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.webflux.handlers
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.graphql.dgs.reactive.DgsReactiveQueryExecutor
+import graphql.ExecutionResult
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscription
 import org.slf4j.LoggerFactory
@@ -70,10 +71,10 @@ class DgsReactiveWebsocketHandler(private val dgsReactiveQueryExecutor: DgsReact
                             logger.debug("Starting subscription {} for session {}", queryPayload, webSocketSession.id)
                             dgsReactiveQueryExecutor.execute(queryPayload.query, queryPayload.variables)
                                 .flatMapMany { executionResult ->
-                                    val publisher: Publisher<Any> = executionResult.getData()
-                                    Flux.from(publisher).map {
+                                    val publisher: Publisher<ExecutionResult> = executionResult.getData()
+                                    Flux.from(publisher).map { executionResult ->
                                         toWebsocketMessage(
-                                            OperationMessage(GQL_DATA, it, operationMessage.id),
+                                            OperationMessage(GQL_DATA, DataPayload(data = executionResult.getData(), errors = executionResult.errors), operationMessage.id),
                                             webSocketSession
                                         )
                                     }.doOnSubscribe {

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsTest.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsTest.kt
@@ -28,6 +28,7 @@ import com.netflix.graphql.dgs.webflux.handlers.DgsReactiveWebsocketHandler.Comp
 import com.netflix.graphql.dgs.webflux.handlers.OperationMessage
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
+import org.junit.jupiter.api.Test
 import org.reactivestreams.Publisher
 import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfiguration
 import org.springframework.boot.autoconfigure.web.reactive.ReactiveWebServerFactoryAutoConfiguration
@@ -60,6 +61,7 @@ import java.time.Duration
 )
 open class WebsocketSubscriptionsTest(@param:LocalServerPort val port: Int) {
 
+    @Test
     fun `Basic subscription flow`() {
 
         val client: WebSocketClient = ReactorNettyWebSocketClient()
@@ -71,12 +73,13 @@ open class WebsocketSubscriptionsTest(@param:LocalServerPort val port: Int) {
         StepVerifier.create(execute).expectComplete().verify()
 
         StepVerifier.create(output.asFlux().map { it.payload.toString() })
-            .expectNext("{errors=[], data={ticker=1}, extensions=null, dataPresent=true}")
-            .expectNext("{errors=[], data={ticker=2}, extensions=null, dataPresent=true}")
-            .expectNext("{errors=[], data={ticker=3}, extensions=null, dataPresent=true}")
+            .expectNext("{data={ticker=1}, errors=[]}")
+            .expectNext("{data={ticker=2}, errors=[]}")
+            .expectNext("{data={ticker=3}, errors=[]}")
             .verifyComplete()
     }
 
+    @Test
     fun `Subscription with error flow`() {
 
         val client: WebSocketClient = ReactorNettyWebSocketClient()
@@ -89,14 +92,15 @@ open class WebsocketSubscriptionsTest(@param:LocalServerPort val port: Int) {
         StepVerifier.create(execute).expectComplete().verify()
 
         StepVerifier.create(output.asFlux().map { it.payload.toString() })
-            .expectNext("{errors=[], data={withError=1}, extensions=null, dataPresent=true}")
-            .expectNext("{errors=[], data={withError=2}, extensions=null, dataPresent=true}")
-            .expectNext("{errors=[], data={withError=3}, extensions=null, dataPresent=true}")
+            .expectNext("{data={withError=1}, errors=[]}")
+            .expectNext("{data={withError=2}, errors=[]}")
+            .expectNext("{data={withError=3}, errors=[]}")
             .expectNext("{data=null, errors=[Broken producer]}")
             .verifyError()
     }
 
-    fun `Client stops subscription`(protocol: String) {
+    @Test
+    fun `Client stops subscription`() {
 
         val client: WebSocketClient = ReactorNettyWebSocketClient()
         val url = URI("ws://localhost:$port/subscriptions")
@@ -108,8 +112,8 @@ open class WebsocketSubscriptionsTest(@param:LocalServerPort val port: Int) {
         StepVerifier.create(execute).expectComplete().verify()
 
         StepVerifier.create(output.asFlux().map { it.payload.toString() })
-            .expectNext("{errors=[], data={withDelay=1}, extensions=null, dataPresent=true}")
-            .expectNext("{errors=[], data={withDelay=2}, extensions=null, dataPresent=true}")
+            .expectNext("{data={withDelay=1}, errors=[]}")
+            .expectNext("{data={withDelay=2}, errors=[]}")
             .verifyComplete()
     }
 


### PR DESCRIPTION
DgsReactiveWebsocketHandler was serializing the ExecutionResult from GraphQL
directly, which resulted in extraneous fields being included in the response.

Fixes issue #1036.
