### PR TITLE
Wrap the DataLoaders after inspection for DgsDataLoaderRegistryConsumer

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/DgsDataLoaderInstrumentationProvider.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/DgsDataLoaderInstrumentationProvider.kt
@@ -29,7 +29,8 @@ class DgsDataLoaderInstrumentationProvider(
                     .to(BatchLoaderInterceptor(original, name, meterRegistrySupplier.get()))
             ByteBuddy()
                 .subclass(BatchLoader::class.java)
-                .method(ElementMatchers.named("load")).intercept(withBinders)
+                .method(ElementMatchers.named("load"))
+                .intercept(withBinders)
                 .make()
                 .load(javaClass.classLoader)
                 .loaded
@@ -44,7 +45,8 @@ class DgsDataLoaderInstrumentationProvider(
 
             ByteBuddy()
                 .subclass(BatchLoaderWithContext::class.java)
-                .method(ElementMatchers.named("load")).intercept(withBinders)
+                .method(ElementMatchers.named("load"))
+                .intercept(withBinders)
                 .make()
                 .load(javaClass.classLoader)
                 .loaded
@@ -60,7 +62,8 @@ class DgsDataLoaderInstrumentationProvider(
 
             ByteBuddy()
                 .subclass(MappedBatchLoader::class.java)
-                .method(ElementMatchers.named("load")).intercept(withBinders)
+                .method(ElementMatchers.named("load"))
+                .intercept(withBinders)
                 .make()
                 .load(javaClass.classLoader)
                 .loaded
@@ -77,7 +80,8 @@ class DgsDataLoaderInstrumentationProvider(
                 .to(MappedBatchLoaderWithContextInterceptor(original, name, meterRegistrySupplier.get()))
             ByteBuddy()
                 .subclass(MappedBatchLoaderWithContext::class.java)
-                .method(ElementMatchers.named("load")).intercept(withBinders)
+                .method(ElementMatchers.named("load"))
+                .intercept(withBinders)
                 .make()
                 .load(javaClass.classLoader)
                 .loaded

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -146,11 +146,11 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
     ): DataLoader<*, *> {
         val options = dataLoaderOptions(dgsDataLoader)
 
-        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
-        if (extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
-            extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
+        if (batchLoader is DgsDataLoaderRegistryConsumer) {
+            batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
+        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
         return DataLoaderFactory.newDataLoader(extendedBatchLoader, options)
     }
 
@@ -161,10 +161,10 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
     ): DataLoader<*, *> {
         val options = dataLoaderOptions(dgsDataLoader)
 
-        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
-        if (extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
-            extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
+        if (batchLoader is DgsDataLoaderRegistryConsumer) {
+            batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
+        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
 
         return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options)
     }
@@ -178,11 +178,11 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         val options = dataLoaderOptions(dgsDataLoader)
             .setBatchLoaderContextProvider(supplier::get)
 
-        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
-        if (extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
-            extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
+        if (batchLoader is DgsDataLoaderRegistryConsumer) {
+            batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
+        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
         return DataLoaderFactory.newDataLoader(extendedBatchLoader, options)
     }
 
@@ -195,11 +195,11 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         val options = dataLoaderOptions(dgsDataLoader)
             .setBatchLoaderContextProvider(supplier::get)
 
-        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
-        if (extendedBatchLoader is DgsDataLoaderRegistryConsumer) {
-            extendedBatchLoader.setDataLoaderRegistry(dataLoaderRegistry)
+        if (batchLoader is DgsDataLoaderRegistryConsumer) {
+            batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
+        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
         return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options)
     }
 


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

We need to test if a DataLoaders are an instance of `DgsDataLoaderRegistryConsumer`
before the reference is wrapped.

Fixes #1067
