### PR TITLE
CSRF attack mitigation on requests with multipart/form-data, plain-text, or empty content-types

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -110,6 +110,7 @@ class MicrometerServletSmokeTest {
             // We will also assert that the tag reflected by the metric is not affected by the alias.
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": "query my_op_1{ping}" }""")
         ).andExpect(status().isOk)
             .andExpect(content().json("""{"data":{"ping":"pong"}}""", false))
@@ -149,6 +150,7 @@ class MicrometerServletSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": "{someTrivialThings}" }""")
         ).andExpect(status().isOk)
             .andExpect(content().json("""{"data":{"someTrivialThings":"some insignificance"}}""", false))
@@ -177,6 +179,7 @@ class MicrometerServletSmokeTest {
             // We will also assert that the tag reflected by the metric is not affected by the alias.
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": " mutation my_op_1{buzz}" }""".trimMargin())
         ).andExpect(status().isOk)
             .andExpect(content().json("""{"data":{"buzz":"buzz"}}""", false))
@@ -218,6 +221,7 @@ class MicrometerServletSmokeTest {
             // We will also assert that the tag reflected by the metric is not affected by the alias.
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content(
                     """
                     | {
@@ -264,6 +268,7 @@ class MicrometerServletSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content(
                     """{"query": 
                     |   "{transform(input: [\"A madam in a racecar.\", \"A man, a plan, a canal - Panama\" ]){ index value upperCased reversed } }" }
@@ -352,6 +357,7 @@ class MicrometerServletSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": "fail" }""")
         ).andExpect(status().isOk)
             .andExpect(
@@ -404,6 +410,7 @@ class MicrometerServletSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": "{ hello }" }""")
         ).andExpect(status().isOk)
             .andExpect(
@@ -463,6 +470,7 @@ class MicrometerServletSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": "{triggerInternalFailure}" }""")
         ).andExpect(status().isOk)
             .andExpect(
@@ -533,6 +541,7 @@ class MicrometerServletSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": "{triggerBadRequestFailure}" }""")
         ).andExpect(status().isOk)
             .andExpect(
@@ -601,6 +610,7 @@ class MicrometerServletSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": "{triggerCustomFailure}" }""")
         ).andExpect(status().isOk)
             .andExpect(
@@ -671,6 +681,7 @@ class MicrometerServletSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType("application/json")
                 .content("""{ "query": "{ triggerInternalFailure triggerBadRequestFailure triggerCustomFailure }" }""")
         ).andExpect(status().isOk)
             .andExpect(

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -34,6 +34,7 @@ import com.netflix.graphql.dgs.webflux.handlers.DefaultDgsWebfluxHttpHandler
 import com.netflix.graphql.dgs.webflux.handlers.DgsHandshakeWebSocketService
 import com.netflix.graphql.dgs.webflux.handlers.DgsReactiveWebsocketHandler
 import com.netflix.graphql.dgs.webflux.handlers.DgsWebfluxHttpHandler
+import com.netflix.graphql.dgs.webflux.handlers.GraphQLMediaTypes
 import graphql.ExecutionInput
 import graphql.GraphQL
 import graphql.execution.AsyncExecutionStrategy
@@ -58,7 +59,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.ReactiveAdapterRegistry
 import org.springframework.core.env.Environment
-import org.springframework.http.MediaType
 import org.springframework.web.reactive.BindingContext
 import org.springframework.web.reactive.function.server.RequestPredicates.accept
 import org.springframework.web.reactive.function.server.RouterFunction
@@ -165,7 +165,10 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
 
     @Bean
     @ConditionalOnMissingBean
-    open fun dgsWebfluxHttpHandler(dgsQueryExecutor: DgsReactiveQueryExecutor, @Qualifier("dgsObjectMapper") dgsObjectMapper: ObjectMapper): DgsWebfluxHttpHandler {
+    open fun dgsWebfluxHttpHandler(
+        dgsQueryExecutor: DgsReactiveQueryExecutor,
+        @Qualifier("dgsObjectMapper") dgsObjectMapper: ObjectMapper
+    ): DgsWebfluxHttpHandler {
         return DefaultDgsWebfluxHttpHandler(dgsQueryExecutor, dgsObjectMapper)
     }
 
@@ -173,7 +176,8 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
     open fun dgsGraphQlRouter(dgsWebfluxHttpHandler: DgsWebfluxHttpHandler): RouterFunction<ServerResponse> {
         return RouterFunctions.route()
             .POST(
-                configProps.path, accept(MediaType.APPLICATION_JSON, MediaType.valueOf("application/graphql")),
+                configProps.path,
+                accept(*GraphQLMediaTypes.ACCEPTABLE_MEDIA_TYPES.toTypedArray()),
                 dgsWebfluxHttpHandler::graphql
             ).build()
     }
@@ -249,12 +253,21 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             registry: ReactiveAdapterRegistry,
             @Dgs bindingContext: BindingContext
         ): ArgumentResolver {
-            return SyncHandlerMethodArgumentResolverAdapter(CookieValueMethodArgumentResolver(beanFactory, registry), bindingContext)
+            return SyncHandlerMethodArgumentResolverAdapter(
+                CookieValueMethodArgumentResolver(beanFactory, registry),
+                bindingContext
+            )
         }
 
         @Bean
-        open fun requestHeaderMapArgumentResolver(registry: ReactiveAdapterRegistry, @Dgs bindingContext: BindingContext): ArgumentResolver {
-            return SyncHandlerMethodArgumentResolverAdapter(RequestHeaderMapMethodArgumentResolver(registry), bindingContext)
+        open fun requestHeaderMapArgumentResolver(
+            registry: ReactiveAdapterRegistry,
+            @Dgs bindingContext: BindingContext
+        ): ArgumentResolver {
+            return SyncHandlerMethodArgumentResolverAdapter(
+                RequestHeaderMapMethodArgumentResolver(registry),
+                bindingContext
+            )
         }
 
         @Bean
@@ -263,7 +276,10 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             registry: ReactiveAdapterRegistry,
             @Dgs bindingContext: BindingContext
         ): ArgumentResolver {
-            return SyncHandlerMethodArgumentResolverAdapter(RequestHeaderMethodArgumentResolver(beanFactory, registry), bindingContext)
+            return SyncHandlerMethodArgumentResolverAdapter(
+                RequestHeaderMethodArgumentResolver(beanFactory, registry),
+                bindingContext
+            )
         }
 
         @Bean
@@ -288,7 +304,10 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
             registry: ReactiveAdapterRegistry,
             @Dgs bindingContext: BindingContext
         ): ArgumentResolver {
-            return SyncHandlerMethodArgumentResolverAdapter(RequestParamMapMethodArgumentResolver(registry), bindingContext)
+            return SyncHandlerMethodArgumentResolverAdapter(
+                RequestParamMapMethodArgumentResolver(registry),
+                bindingContext
+            )
         }
     }
 }

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DefaultDgsWebfluxHttpHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DefaultDgsWebfluxHttpHandler.kt
@@ -28,14 +28,17 @@ import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 
-class DefaultDgsWebfluxHttpHandler(private val dgsQueryExecutor: DgsReactiveQueryExecutor, private val objectMapper: ObjectMapper) : DgsWebfluxHttpHandler {
+class DefaultDgsWebfluxHttpHandler(
+    private val dgsQueryExecutor: DgsReactiveQueryExecutor,
+    private val objectMapper: ObjectMapper
+) : DgsWebfluxHttpHandler {
 
     override fun graphql(request: ServerRequest): Mono<ServerResponse> {
         @Suppress("UNCHECKED_CAST") val executionResult: Mono<ExecutionResult> =
 
             request.bodyToMono(String::class.java)
                 .flatMap { body ->
-                    if ("application/graphql" == request.headers().firstHeader("Content-Type")) {
+                    if (GraphQLMediaTypes.isApplicationGraphQL(request)) {
                         Mono.just(QueryInput(body))
                     } else {
                         Mono.fromCallable {

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/GraphQLMediaTypes.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/GraphQLMediaTypes.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webflux.handlers
+
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.server.ServerRequest
+
+object GraphQLMediaTypes {
+    private val GRAPHQL_MEDIA_TYPE = MediaType("application", "graphql")
+    val ACCEPTABLE_MEDIA_TYPES = listOf(GRAPHQL_MEDIA_TYPE, MediaType.APPLICATION_JSON)
+
+    fun isApplicationGraphQL(request: ServerRequest): Boolean {
+        return request.headers().contentType().map { GRAPHQL_MEDIA_TYPE.includes(it) }.orElse(false)
+    }
+}

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -11,6 +11,12 @@
       "type": "java.lang.Boolean",
       "description": "Enables GraphiQL functionality.",
       "defaultValue": "true"
+    },
+    {
+      "name": "dgs.graphql.header.validation.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enables recommended GDS GraphQL HTTP Header validation rules.",
+      "defaultValue": "true"
     }
   ]
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcAutoConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcAutoConfiguration

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/MalformedQueryContentTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/MalformedQueryContentTest.kt
@@ -29,6 +29,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -43,10 +44,22 @@ class MalformedQueryContentTest {
     lateinit var mvc: MockMvc
 
     @Test
+    fun `Should provide a valid content-type`() {
+        val uriBuilder =
+            MockMvcRequestBuilders
+                .post("/graphql")
+                .content("  ")
+
+        mvc.perform(uriBuilder)
+            .andExpect(status().isUnsupportedMediaType)
+    }
+
+    @Test
     fun `Should return a bad request error if the POST request has no content`() {
         val uriBuilder =
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("  ")
 
         mvc.perform(uriBuilder)
@@ -59,6 +72,7 @@ class MalformedQueryContentTest {
         val uriBuilder =
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("{")
 
         mvc.perform(uriBuilder)
@@ -71,6 +85,7 @@ class MalformedQueryContentTest {
         val uriBuilder =
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("{  }")
 
         mvc.perform(uriBuilder)

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/apq/DgsWebMVCAutomatedPersistedQueriesSmokeTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/apq/DgsWebMVCAutomatedPersistedQueriesSmokeTest.kt
@@ -33,6 +33,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -64,6 +65,7 @@ class DgsWebMVCAutomatedPersistedQueriesSmokeTest {
         val uriBuilder =
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                        |{
@@ -107,6 +109,7 @@ class DgsWebMVCAutomatedPersistedQueriesSmokeTest {
         val uriBuilder =
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                        |{
@@ -143,6 +146,7 @@ class DgsWebMVCAutomatedPersistedQueriesSmokeTest {
         val uriBuilder =
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                        |{

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/WebRequestTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/WebRequestTest.kt
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -70,6 +71,7 @@ class WebRequestTest {
     fun `WebRequest should be available on DgsContext`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingWebRequest }" }""")
         )
             .andExpect(status().isOk)
@@ -80,6 +82,7 @@ class WebRequestTest {
     fun `@RequestHeader should be available`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingHeader }" }""")
                 .header("myheader", "hello")
         )
@@ -91,6 +94,7 @@ class WebRequestTest {
     fun `@RequestHeader should support defaultValue`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingHeader }" }""")
         )
             .andExpect(status().isOk)
@@ -101,6 +105,7 @@ class WebRequestTest {
     fun `@RequestHeader should throw an exception when not provided but required and no default is set`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingRequiredHeader }" }""")
         )
             .andExpect(status().isOk)
@@ -114,6 +119,7 @@ class WebRequestTest {
     fun `@RequestHeader should use null if not required and not provided`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingOptionalHeader }" }""")
         )
             .andExpect(status().isOk)
@@ -124,6 +130,7 @@ class WebRequestTest {
     fun `@RequestHeader should support Optional for not provided values`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingOptionalHeaderAsOptionalType }" }""")
         )
             .andExpect(status().isOk)
@@ -137,6 +144,7 @@ class WebRequestTest {
     fun `@RequestHeader should support Optional for provided values`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingOptionalHeaderAsOptionalType }" }""")
                 .header("myheader", "hello")
         )
@@ -148,6 +156,7 @@ class WebRequestTest {
     fun `@RequestParam should be available`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingParam }" }""")
                 .param("myParam", "paramValue")
         )
@@ -159,6 +168,7 @@ class WebRequestTest {
     fun `@RequestParam should properly handle multiple param values`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingParam }" }""")
                 .param("myParam", "paramValue")
                 .param("myParam", "paramValue2")
@@ -171,6 +181,7 @@ class WebRequestTest {
     fun `@RequestParam should use default when no parameter was provided`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingParam }" }""")
         )
             .andExpect(status().isOk)
@@ -181,6 +192,7 @@ class WebRequestTest {
     fun `@RequestParam should throw exception when no parameter was provided and no default is set`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingParamRequired }" }""")
         )
             .andExpect(status().isOk)
@@ -194,6 +206,7 @@ class WebRequestTest {
     fun `@RequestParam should use null when not required and not provided`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingOptionalParam }" }""")
         )
             .andExpect(status().isOk)
@@ -204,6 +217,7 @@ class WebRequestTest {
     fun `@RequestParam should support Optional parameters with non required null values`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingOptionalParamAsOptionalType }" }""")
         )
             .andExpect(status().isOk)
@@ -217,6 +231,7 @@ class WebRequestTest {
     fun `@RequestParam should support Optional parameters`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingOptionalParamAsOptionalType }" }""")
                 .param("myParam", "hello")
         )
@@ -228,6 +243,7 @@ class WebRequestTest {
     fun `Custom context builder should have access to headers`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ usingContextWithRequest }" }""")
                 .header("myheader", "hello")
         )
@@ -239,6 +255,7 @@ class WebRequestTest {
     fun `@CookieValue should give access to cookie`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ withCookie }" }""")
                 .cookie(Cookie("myCookie", "cookiehello"))
         )
@@ -250,6 +267,7 @@ class WebRequestTest {
     fun `@CookieValue should allow Optional type`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ withOptionalCookie }" }""")
                 .cookie(Cookie("myCookie", "cookiehello"))
         )
@@ -261,6 +279,7 @@ class WebRequestTest {
     fun `@CookieValue should allow empty Optional type`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ withEmptyOptionalCookie }" }""")
         )
             .andExpect(status().isOk)
@@ -271,6 +290,7 @@ class WebRequestTest {
     fun `@CookieValue should allow null when not required`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ withEmptyCookie }" }""")
         )
             .andExpect(status().isOk)
@@ -281,6 +301,7 @@ class WebRequestTest {
     fun `@CookieValue should throw exception when required but not set`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ withRequiredCookie }" }""")
         )
             .andExpect(status().isOk)
@@ -294,6 +315,7 @@ class WebRequestTest {
     fun `@CookieValue should support default value`() {
         mockMvc.perform(
             MockMvcRequestBuilders.post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"query": "{ withDefaultCookie }" }""")
         )
             .andExpect(status().isOk)

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DefaultDgsGraphQLRequestHeaderValidator.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DefaultDgsGraphQLRequestHeaderValidator.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.mvc
+
+import org.springframework.http.HttpHeaders
+
+class DefaultDgsGraphQLRequestHeaderValidator(
+    private val contentTypePredicates: List<GraphQLRequestContentTypePredicate> = listOf(GraphQLRequestContentTypePredicate.STRICT_GRAPHQL_CONTENT_TYPES_PREDICATE),
+    private val validationRules: List<GraphQLRequestHeaderValidationRule> = DgsGraphQLRequestHeaderValidator.RECOMMENDED_GRAPHQL_REQUEST_HEADERS_VALIDATOR,
+) : DgsGraphQLRequestHeaderValidator {
+
+    override fun assert(headers: HttpHeaders) {
+        if (contentTypePredicates.isNotEmpty()) {
+            contentTypePredicates.find { it.accept(headers.contentType) }
+                ?: throw DgsGraphQLRequestHeaderValidator
+                    .GraphqlRequestContentTypePredicateException("Unsupported Content-Type ${headers.contentType}")
+        }
+        validationRules.forEach { it.assert(headers) }
+    }
+}

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsGraphQLRequestHeaderValidator.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsGraphQLRequestHeaderValidator.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.mvc
+
+import org.springframework.http.HttpHeaders
+
+fun interface DgsGraphQLRequestHeaderValidator {
+    companion object {
+        /** Recommended GraphQL request header validator. **/
+        val RECOMMENDED_GRAPHQL_REQUEST_HEADERS_VALIDATOR = listOf(GraphQLCSRFRequestHeaderValidationRule())
+    }
+
+    @kotlin.jvm.Throws(GraphqlRequestHeaderValidationException::class)
+    fun assert(headers: HttpHeaders)
+
+    open class GraphqlRequestHeaderValidationException(s: String) : IllegalArgumentException(s)
+
+    open class GraphqlRequestContentTypePredicateException(s: String) : GraphqlRequestHeaderValidationException(s)
+
+    open class GraphQLRequestHeaderRuleException(s: String) : GraphqlRequestHeaderValidationException(s)
+}

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -31,6 +31,7 @@ import graphql.execution.reactive.SubscriptionPublisher
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
@@ -69,18 +70,19 @@ import org.springframework.web.multipart.MultipartFile
 @RestController
 open class DgsRestController(
     open val dgsQueryExecutor: DgsQueryExecutor,
-    open val mapper: ObjectMapper = jacksonObjectMapper()
+    open val mapper: ObjectMapper = jacksonObjectMapper(),
+    open val dgsGraphQLRequestHeaderValidator: DgsGraphQLRequestHeaderValidator = DefaultDgsGraphQLRequestHeaderValidator()
 ) {
 
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
-        private val GRAPHQL_MEDIA_TYPE = MediaType("application", "graphql")
     }
 
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
+    // TODO Allow users to disable multipart-form/data
     @RequestMapping(
         "#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.path}",
-        produces = ["application/json"]
+        produces = [MediaType.APPLICATION_JSON_VALUE]
     )
     fun graphql(
         @RequestBody body: String?,
@@ -91,15 +93,31 @@ open class DgsRestController(
         webRequest: WebRequest
     ): ResponseEntity<String> {
 
-        logger.debug("Starting /graphql handling")
+        logger.debug("Validate HTTP Headers for the GraphQL endpoint...")
+        try {
+            dgsGraphQLRequestHeaderValidator.assert(headers)
+        } catch (e: DgsGraphQLRequestHeaderValidator.GraphqlRequestContentTypePredicateException) {
+            logger.debug("Unsupported Media-Type {}.", headers.contentType, e)
+            return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body("Unsupported media type.")
+        } catch (e: DgsGraphQLRequestHeaderValidator.GraphQLRequestHeaderRuleException) {
+            logger.debug("The Request Headers failed a DGS Header validation rule.", e)
+            return ResponseEntity.badRequest().body(e.message)
+        } catch (e: DgsGraphQLRequestHeaderValidator.GraphqlRequestHeaderValidationException) {
+            logger.debug("The DGS Request Header Validator deemed the request headers as invalid.", e)
+            return ResponseEntity.badRequest().body(e.message)
+        } catch (e: Exception) {
+            logger.error("The DGS Request Header Validator failed with exception!", e)
+            return ResponseEntity.internalServerError().body("Unable to validate the HTTP Request Headers.")
+        }
+
+        logger.debug("Starting HTTP GraphQL handling...")
 
         val inputQuery: Map<String, Any>
         val queryVariables: Map<String, Any>
         val extensions: Map<String, Any>
         if (body != null) {
             logger.debug("Reading input value: '{}'", body)
-
-            if (GRAPHQL_MEDIA_TYPE.includes(headers.contentType)) {
+            if (GraphQLMediaTypes.includesApplicationGraphQL(headers)) {
                 inputQuery = mapOf("query" to body)
                 queryVariables = emptyMap()
                 extensions = emptyMap()

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestSchemaJsonController.kt
@@ -23,6 +23,7 @@ import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.introspection.IntrospectionQuery
 import graphql.schema.GraphQLSchema
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -36,7 +37,10 @@ import org.springframework.web.bind.annotation.RestController
 open class DgsRestSchemaJsonController(open val schemaProvider: DgsSchemaProvider) {
 
     // The @ConfigurationProperties bean name is <prefix>-<fqn>
-    @RequestMapping("#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.schemaJson.path}", produces = ["application/json"])
+    @RequestMapping(
+        "#{@'dgs.graphql-com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcConfigurationProperties'.schemaJson.path}",
+        produces = [ MediaType.APPLICATION_JSON_VALUE ]
+    )
     fun schema(): String {
         val graphQLSchema: GraphQLSchema = schemaProvider.schema()
         val graphQL = GraphQL.newGraphQL(graphQLSchema).build()

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/GraphQLCSRFRequestHeaderValidationRule.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/GraphQLCSRFRequestHeaderValidationRule.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.mvc
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.util.StringUtils
+
+/**
+ * Implementation of a [GraphQLRequestHeaderValidationRule] that will make sure that the HTTP Request
+ * Has either a content-type that enforces a _pre-flight_ check or has a preflight header, defined below.
+ * A content-type that enforces a _pre-flight_ check shouldn't be any of the content-types defined in [NON_PREFLIGHTED_CONTENT_TYPES].
+ * Which are the _pre-flight_ headers we support? See [GRAPHQL_PREFLIGHT_REQUESTS_HEADERS]
+ *
+ * What is a _pre-flight_ check?
+ * It is a check that a common browser will do to enforce a [CORS policy](https://github.com/apollographql/apollo-server/security/advisories/GHSA-2p3c-p3qw-69r4).
+ *
+ * **Note**, is the responsibility of the applications to define a sensible CORS policy that will prevent a CSRF attack.
+ */
+class GraphQLCSRFRequestHeaderValidationRule : GraphQLRequestHeaderValidationRule {
+    companion object {
+        // CSRF Prevention Request Headers
+        @Suppress("MemberVisibilityCanBePrivate")
+        const val HEADER_X_APOLLO_OPERATION_NAME = "x-apollo-operation-name"
+
+        @Suppress("MemberVisibilityCanBePrivate")
+        const val HEADER_APOLLO_REQUIRE_PREFLIGHT = "apollo-require-preflight"
+
+        @Suppress("MemberVisibilityCanBePrivate")
+        const val HEADER_GRAPHQL_REQUIRE_PREFLIGHT = "graphql-require-preflight"
+
+        /**
+         * Headers, defined as `content-type`, that will not enforce a _preflight_ check by browsers.
+         * In other words, if the `content-type` of the request matches any of these the browser will not enforce a CORS
+         * check.
+         *
+         * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+         */
+        val NON_PREFLIGHTED_CONTENT_TYPES = listOf(
+            MediaType.APPLICATION_FORM_URLENCODED, MediaType.MULTIPART_FORM_DATA, MediaType.TEXT_PLAIN
+        )
+
+        /**
+         * Headers that should be available in case the request has either no `content-type` or one
+         * that matches any of the [NON_PREFLIGHTED_CONTENT_TYPES].
+         * Clients, which is the case with Apollo Client for example, *should always*  define a `content-type` even
+         * if they are doing a `GET` request.
+         *
+         * Apollo Client Web, Apollo iOS, and Apollo Kotlin always send `x-apollo-operation-name` for example.
+         *
+         * @see https://github.com/apollographql/apollo-server/blob/version-4/packages/server/src/preventCsrf.ts
+         */
+        val GRAPHQL_PREFLIGHT_REQUESTS_HEADERS = listOf(
+            HEADER_APOLLO_REQUIRE_PREFLIGHT, HEADER_X_APOLLO_OPERATION_NAME, HEADER_GRAPHQL_REQUIRE_PREFLIGHT
+        )
+
+        /**
+         * > We don't want random websites to be able to execute actual GraphQL operations
+         * > from a user's browser unless our CORS policy supports it. It's not good
+         * > enough just to ensure that the browser can't read the response from the
+         * > operation; we also want to prevent CSRF, where the attacker can cause side
+         * > effects with an operation or can measure the timing of a read operation. Our
+         * > goal is to ensure that we don't run the context function or execute the
+         * > GraphQL operation until the browser has evaluated the CORS policy, which
+         * > means we want all operations to be pre-flighted. We can do that by only
+         * > processing operations that have at least one header set that appears to be
+         * > manually set by the JS code rather than by the browser automatically.
+         *
+         * > POST requests generally have a content-type `application/json`, which is
+         * > sufficient to trigger preflighting. So we take extra care with requests that
+         * > specify no content-type or that specify one of the three non-preflighted
+         * > content types. For those operations, we require (if this feature is enabled)
+         * > one of a set of specific headers to be set. By ensuring that every operation
+         * > either has a custom content-type or sets one of these headers, we know we
+         * > won't execute operations at the request of origins who our CORS policy will
+         * > block.
+         *
+         * From [Apollo Server](https://github.com/apollographql/apollo-server/blob/version-4/packages/server/src/preventCsrf.ts)
+         */
+        fun assertGraphQLCsrf(
+            headers: HttpHeaders,
+            csrfPreventionRequestHeaders: List<String> = GRAPHQL_PREFLIGHT_REQUESTS_HEADERS
+        ) {
+            val contentType: MediaType? = headers.contentType
+            if (contentType != null && !NON_PREFLIGHTED_CONTENT_TYPES.contains(contentType)) {
+                // We managed to parse a MIME type that was not one of the
+                // CORS-safe-listed ones. (Probably application/json!) That means that if
+                // the client is a browser, the browser must have applied CORS
+                // preflighting, and we don't have to worry about CSRF.
+                return
+            }
+            // Either there was no content-type, or the content-type parsed properly as
+            // one of the three CORS-safelisted values. Let's look for another header that
+            // (if this was a browser) must have been set by the user's code and would
+            // have caused a preflight.
+            val csrfInFlightHeader: String? = csrfPreventionRequestHeaders.find { headers.contains(it) }
+            if (StringUtils.hasText(csrfInFlightHeader)) {
+                return
+            }
+            throw DgsGraphQLRequestHeaderValidator.GraphQLRequestHeaderRuleException(
+                "Expecting a CSRF Prevention Header but none was found, supported headers are $csrfPreventionRequestHeaders."
+            )
+        }
+    }
+
+    override fun assert(headers: HttpHeaders) {
+        assertGraphQLCsrf(headers)
+    }
+}

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/GraphQLMediaTypes.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/GraphQLMediaTypes.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.mvc
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+
+@SuppressWarnings("unused")
+object GraphQLMediaTypes {
+    val GRAPHQL_MEDIA_TYPE = MediaType("application", "graphql")
+    const val GRAPHQL_MEDIA_TYPE_VALUE = "application/graphql"
+
+    fun includesApplicationGraphQL(headers: HttpHeaders): Boolean {
+        return GRAPHQL_MEDIA_TYPE.includes(headers.contentType)
+    }
+}

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/GraphQLRequestContentTypePredicate.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/GraphQLRequestContentTypePredicate.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.mvc
+
+import org.springframework.core.annotation.Order
+import org.springframework.http.MediaType
+
+/**
+ * A [GraphQLRequestContentTypePredicate] is a predicate function that is meant to be be evaluated against the
+ * content-type expressed by the HTTP headers.
+ *
+ * @see DgsGraphQLRequestHeaderValidator
+ * @see DefaultDgsGraphQLRequestHeaderValidator
+ */
+@Order
+fun interface GraphQLRequestContentTypePredicate {
+
+    fun accept(contentType: MediaType?): Boolean
+
+    companion object {
+        /** The media-types that a GraphQL should strictly support.*/
+        private val STRICT_GRAPHQL_CONTENT_TYPES =
+            listOf(MediaType.APPLICATION_JSON, GraphQLMediaTypes.GRAPHQL_MEDIA_TYPE, MediaType.MULTIPART_FORM_DATA)
+
+        /**
+         * Implementation of a content type predicate that will accept none-null content-types that match any of the
+         * media-types defined by [STRICT_GRAPHQL_CONTENT_TYPES]
+         */
+        val STRICT_GRAPHQL_CONTENT_TYPES_PREDICATE = GraphQLRequestContentTypePredicate { mediaType ->
+            mediaType != null && STRICT_GRAPHQL_CONTENT_TYPES.find { it.isCompatibleWith(mediaType) } != null
+        }
+
+        val RECOMMENDED_GRAPHQL_CONTENT_TYPE_PREDICATES = listOf(STRICT_GRAPHQL_CONTENT_TYPES_PREDICATE)
+    }
+}

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/GraphQLRequestHeaderValidationRule.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/GraphQLRequestHeaderValidationRule.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.mvc
+
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpHeaders
+
+/**
+ * Represents a function that has the intent to validate the HTTP Headers before the GraphQL Query is even parsed.
+ * For example, the [GraphQLCSRFRequestHeaderValidationRule] enforces a `content-type` policy that prevents a CSRF
+ * exploit for GraphQL endpoints.
+ */
+@Order
+fun interface GraphQLRequestHeaderValidationRule {
+    /**
+     * Validate the [HttpHeaders], and in case it is not valid, throw a [DgsGraphQLRequestHeaderRuleException] exception or any of its derivatives.
+     * @throws DgsGraphQLRequestHeaderValidator.GraphQLRequestHeaderRuleException
+     */
+    @kotlin.jvm.Throws(DgsGraphQLRequestHeaderValidator.GraphQLRequestHeaderRuleException::class)
+    fun assert(headers: HttpHeaders)
+}

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsMultipartPostControllerTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsMultipartPostControllerTest.kt
@@ -26,7 +26,9 @@ import io.mockk.junit5.MockKExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.util.Lists
 import org.assertj.core.util.Maps
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.HttpHeaders
@@ -38,14 +40,25 @@ import org.springframework.web.multipart.MultipartFile
 
 @ExtendWith(MockKExtension::class)
 class DgsMultipartPostControllerTest {
+
+    private val httpHeaders = HttpHeaders()
+
     @MockK
     lateinit var dgsQueryExecutor: DgsQueryExecutor
 
     @MockK
     lateinit var webRequest: WebRequest
 
+    @BeforeEach
+    fun setHeaders() {
+        httpHeaders.clear()
+        httpHeaders.contentType = MediaType.MULTIPART_FORM_DATA
+        httpHeaders.add(GraphQLCSRFRequestHeaderValidationRule.HEADER_GRAPHQL_REQUIRE_PREFLIGHT, null)
+    }
+
     @Test
-    fun singleFileUpload() {
+    fun `Multipart form request should require a preflight header`() {
+        @Language("JSON")
         val operation = """
             { 
                 "query": "mutation(${'$'}file: Upload!) {uploadFile(file: ${'$'}file)}",
@@ -55,7 +68,50 @@ class DgsMultipartPostControllerTest {
             }
         """.trimIndent()
 
-        val map = """
+        @Language("JSON")
+        val varParameters = """ { "0": ["variables.file"] } """.trimIndent()
+
+        val file1: MultipartFile = MockMultipartFile("foo", "foo.txt", MediaType.TEXT_PLAIN_VALUE, "Hello World".toByteArray())
+
+        val queryString = "mutation(${'$'}file: Upload!) {uploadFile(file: ${'$'}file)}"
+        val variablesMap: MutableMap<String, Any> = Maps.newHashMap("file", file1)
+
+        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any(), any()) } returns(
+            ExecutionResultImpl.newExecutionResult().data(mapOf("Response" to "success")).build()
+            )
+        // HTTP Headers with only the expected content-type but no preflight
+        val noPreflightHeader = HttpHeaders()
+        noPreflightHeader.contentType = MediaType.MULTIPART_FORM_DATA
+
+        val result = DgsRestController(dgsQueryExecutor).graphql(
+            body = null,
+            fileParams = Maps.newHashMap("0", file1),
+            operation = operation,
+            mapParam = varParameters,
+            noPreflightHeader,
+            webRequest
+        )
+
+        assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(result.body)
+            .isNotEmpty
+            .contains("Expecting a CSRF Prevention Header but none was found, supported headers are [apollo-require-preflight, x-apollo-operation-name, graphql-require-preflight].")
+    }
+
+    @Test
+    fun singleFileUpload() {
+        @Language("JSON")
+        val operation = """
+            { 
+                "query": "mutation(${'$'}file: Upload!) {uploadFile(file: ${'$'}file)}",
+                "variables": { 
+                    "file": null
+                }
+            }
+        """.trimIndent()
+
+        @Language("JSON")
+        val varParameters = """
             { 
                 "0": ["variables.file"]
             }
@@ -66,9 +122,18 @@ class DgsMultipartPostControllerTest {
         val queryString = "mutation(${'$'}file: Upload!) {uploadFile(file: ${'$'}file)}"
         val variablesMap: MutableMap<String, Any> = Maps.newHashMap("file", file1)
 
-        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any(), any()) } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("Response", "success"))).build()
+        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any(), any()) } returns(
+            ExecutionResultImpl.newExecutionResult().data(mapOf("Response" to "success")).build()
+            )
 
-        val result = DgsRestController(dgsQueryExecutor).graphql(null, Maps.newHashMap("0", file1), operation, map, HttpHeaders(), webRequest)
+        val result = DgsRestController(dgsQueryExecutor).graphql(
+            body = null,
+            fileParams = Maps.newHashMap("0", file1),
+            operation = operation,
+            mapParam = varParameters,
+            httpHeaders,
+            webRequest
+        )
 
         val mapper = jacksonObjectMapper()
         val (data, errors) = mapper.readValue(result.body, GraphQLResponse::class.java)
@@ -78,6 +143,7 @@ class DgsMultipartPostControllerTest {
 
     @Test
     fun multipleFileUpload() {
+        @Language("JSON")
         val operation = """
             { 
                 "query": "mutation(${'$'}input: FileUploadInput!) {uploadFile(input: ${'$'}input)}",
@@ -90,7 +156,8 @@ class DgsMultipartPostControllerTest {
             }
         """.trimIndent()
 
-        val map = """
+        @Language("JSON")
+        val varParameters = """
             { 
                 "0": ["variables.input.files.0"], 
                 "1": ["variables.input.files.1"] 
@@ -104,9 +171,18 @@ class DgsMultipartPostControllerTest {
         val queryInputMap = Maps.newHashMap<String, Any>("description", "test")
         queryInputMap["files"] = Lists.newArrayList(file1, file2)
 
-        every { dgsQueryExecutor.execute(queryString, mapOf("input" to queryInputMap), any(), any(), any(), any()) } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("Response", "success"))).build()
+        every { dgsQueryExecutor.execute(queryString, mapOf("input" to queryInputMap), any(), any(), any(), any()) } returns(
+            ExecutionResultImpl.newExecutionResult().data(mapOf("Response" to "success")).build()
+            )
 
-        val result = DgsRestController(dgsQueryExecutor).graphql(null, mapOf("0" to file1, "1" to file2), operation, map, HttpHeaders(), webRequest)
+        val result = DgsRestController(dgsQueryExecutor).graphql(
+            body = null,
+            fileParams = mapOf("0" to file1, "1" to file2),
+            operation = operation,
+            mapParam = varParameters,
+            httpHeaders,
+            webRequest
+        )
 
         val mapper = jacksonObjectMapper()
         val (data, errors) = mapper.readValue(result.body, GraphQLResponse::class.java)
@@ -116,6 +192,7 @@ class DgsMultipartPostControllerTest {
 
     @Test
     fun arrayOfFilesUpload() {
+        @Language("JSON")
         val operation = """
             { 
                 "query": "mutation(${'$'}files: [Upload!]!) {uploadFile(files: ${'$'}files)}",
@@ -125,7 +202,8 @@ class DgsMultipartPostControllerTest {
             }
         """.trimIndent()
 
-        val map = """
+        @Language("JSON")
+        val varParameters = """
             { 
                 "0": ["variables.files.0"], 
                 "1": ["variables.files.1"]
@@ -138,9 +216,18 @@ class DgsMultipartPostControllerTest {
         val queryString = "mutation(${'$'}files: [Upload!]!) {uploadFile(files: ${'$'}files)}"
         val variablesMap: MutableMap<String, Any> = Maps.newHashMap("files", Lists.newArrayList(file1, file2))
 
-        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any(), any()) } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("Response", "success"))).build()
+        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any(), any()) } returns(
+            ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("Response", "success"))).build()
+            )
 
-        val result = DgsRestController(dgsQueryExecutor).graphql(null, mapOf("0" to file1, "1" to file2), operation, map, HttpHeaders(), webRequest)
+        val result = DgsRestController(dgsQueryExecutor).graphql(
+            body = null,
+            fileParams = mapOf("0" to file1, "1" to file2),
+            operation = operation,
+            mapParam = varParameters,
+            httpHeaders,
+            webRequest
+        )
 
         val mapper = jacksonObjectMapper()
         val (data, errors) = mapper.readValue(result.body, GraphQLResponse::class.java)
@@ -150,6 +237,7 @@ class DgsMultipartPostControllerTest {
 
     @Test
     fun incorrectFileUploadWithMissingParts() {
+        @Language("JSON")
         val operation = """
             { 
                 "query": "mutation(${'$'}file: Upload!) {uploadFile(file: ${'$'}file)}",
@@ -159,7 +247,8 @@ class DgsMultipartPostControllerTest {
             }
         """.trimIndent()
 
-        val map = """
+        @Language("JSON")
+        val varParameters = """
             { 
                 "0": ["variables.file"]
             }
@@ -168,20 +257,29 @@ class DgsMultipartPostControllerTest {
         val file: MultipartFile = MockMultipartFile("foo", "foo.txt", MediaType.TEXT_PLAIN_VALUE, "Hello World".toByteArray())
 
         // missing operation part
-        var responseEntity = DgsRestController(dgsQueryExecutor).graphql(null, mapOf("0" to file), null, map, HttpHeaders(), webRequest)
+        var responseEntity = DgsRestController(dgsQueryExecutor).graphql(
+            body = null,
+            fileParams = mapOf("0" to file),
+            operation = null,
+            mapParam = varParameters,
+            httpHeaders,
+            webRequest
+        )
+
         assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
 
         // missing file parts
-        responseEntity = DgsRestController(dgsQueryExecutor).graphql(null, null, operation, map, HttpHeaders(), webRequest)
+        responseEntity = DgsRestController(dgsQueryExecutor).graphql(null, null, operation, varParameters, httpHeaders, webRequest)
         assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
 
         // missing mapped object paths part
-        responseEntity = DgsRestController(dgsQueryExecutor).graphql(null, mapOf("0" to file), operation, null, HttpHeaders(), webRequest)
+        responseEntity = DgsRestController(dgsQueryExecutor).graphql(null, mapOf("0" to file), operation, null, httpHeaders, webRequest)
         assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
     @Test
     fun malformedFileUploadWithIncorrectMappedPath() {
+        @Language("JSON")
         val operation = """
             { 
                 "query": "mutation(${'$'}file: Upload!) {uploadFile(file: ${'$'}file)}",
@@ -192,7 +290,8 @@ class DgsMultipartPostControllerTest {
         """.trimIndent()
 
         // set up incorrect object mapping path
-        val map = """
+        @Language("JSON")
+        val varParameters = """
             { 
                 "0": ["variables.file.0"]
             }
@@ -201,7 +300,14 @@ class DgsMultipartPostControllerTest {
         val file: MultipartFile = MockMultipartFile("foo", "foo.txt", MediaType.TEXT_PLAIN_VALUE, "Hello World".toByteArray())
 
         assertThrows(RuntimeException::class.java) {
-            DgsRestController(dgsQueryExecutor).graphql(null, mapOf("0" to file), operation, map, HttpHeaders(), webRequest)
+            DgsRestController(dgsQueryExecutor).graphql(
+                body = null,
+                fileParams = mapOf("0" to file),
+                operation = operation,
+                mapParam = varParameters,
+                httpHeaders,
+                webRequest
+            )
         }
     }
 

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsRestControllerTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsRestControllerTest.kt
@@ -26,6 +26,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.slot
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.HttpHeaders
@@ -36,11 +37,20 @@ import org.springframework.web.context.request.WebRequest
 
 @ExtendWith(MockKExtension::class)
 class DgsRestControllerTest {
+
+    private val httpHeaders = HttpHeaders()
+
     @MockK
     lateinit var dgsQueryExecutor: DgsQueryExecutor
 
     @MockK
     lateinit var webRequest: WebRequest
+
+    @BeforeEach
+    fun setHeaders() {
+        httpHeaders.clear()
+        httpHeaders.contentType = MediaType.APPLICATION_JSON
+    }
 
     @Test
     fun `Is able to execute a a well formed query`() {
@@ -62,8 +72,7 @@ class DgsRestControllerTest {
             )
         } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("hello", "hello"))).build()
 
-        val result =
-            DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, HttpHeaders(), webRequest)
+        val result = DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, httpHeaders, webRequest)
         val mapper = jacksonObjectMapper()
         val (data, errors) = mapper.readValue(result.body, GraphQLResponse::class.java)
         assertThat(errors.size).isEqualTo(0)
@@ -93,7 +102,7 @@ class DgsRestControllerTest {
         } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("hi", "there"))).build()
 
         val result =
-            DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, HttpHeaders(), webRequest)
+            DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, httpHeaders, webRequest)
         val mapper = jacksonObjectMapper()
         val (data, errors) = mapper.readValue(result.body, GraphQLResponse::class.java)
         assertThat(errors.size).isEqualTo(0)
@@ -152,7 +161,7 @@ class DgsRestControllerTest {
             .data(SubscriptionPublisher(null, null)).build()
 
         val result =
-            DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, HttpHeaders(), webRequest)
+            DgsRestController(dgsQueryExecutor).graphql(requestBody, null, null, null, httpHeaders, webRequest)
         assertThat(result.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
         assertThat(result.body).isEqualTo("Trying to execute subscription on /graphql. Use /subscriptions instead!")
     }
@@ -162,7 +171,7 @@ class DgsRestControllerTest {
         val requestBody = ""
         val result =
             DgsRestController(dgsQueryExecutor)
-                .graphql(requestBody, null, null, null, HttpHeaders(), webRequest)
+                .graphql(requestBody, null, null, null, httpHeaders, webRequest)
 
         assertThat(result)
             .isInstanceOf(ResponseEntity::class.java)

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -101,10 +101,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -129,12 +126,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -159,10 +151,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -198,10 +187,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -234,12 +220,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -268,10 +249,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -301,10 +279,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -338,10 +313,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -351,6 +323,39 @@ internal class InputArgumentTest {
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
         Assertions.assertEquals("Hello, tester, tester 2", data["hello"])
+
+        verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
+    }
+
+    @Test
+    fun `@InputArgument on an optional list of integers`() {
+        val expectedNumbers = listOf(1, 2, 3)
+
+        val schema = """
+            type Query {
+                numbers(list: [Int]): String
+            }
+        """.trimIndent()
+
+        val fetcher = object {
+            @DgsQuery(field = "numbers")
+            fun numbers(@InputArgument("list") listOptional: Optional<List<Int>>, dfe: DataFetchingEnvironment): String {
+                assertThat(listOptional).isNotEmpty
+                assertThat(listOptional.get()).containsExactlyElementsOf(expectedNumbers)
+                return "Numbers are ${listOptional.map{ it.joinToString(", ") }.orElse("na")}"
+            }
+        }
+
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("numbersFetcher" to fetcher)
+        every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
+        every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
+
+        val build = GraphQL.newGraphQL(provider.schema(schema)).build()
+        val executionResult = build.execute("""{ numbers(list: [1, 2, 3]) }""")
+        assertThat(executionResult.isDataPresent).isTrue
+
+        val data = executionResult.getData<Map<String, *>>()
+        assertThat(data["numbers"]).isEqualTo("Numbers are 1, 2, 3")
 
         verify { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) }
     }
@@ -381,12 +386,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -431,10 +431,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -480,10 +477,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -517,10 +511,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -627,10 +618,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -671,10 +659,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -719,10 +704,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -766,12 +748,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -802,11 +779,8 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            ),
-            Pair("Upload", UploadScalar()),
+            "helloFetcher" to fetcher,
+            "Upload" to UploadScalar(),
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -817,7 +791,7 @@ internal class InputArgumentTest {
         val build = GraphQL.newGraphQL(provider.schema(schema)).build()
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput().query("mutation(\$input: Upload!)  { upload(file: \$input) }")
-                .variables(mapOf(Pair("input", file)))
+                .variables(mapOf("input" to file))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -840,12 +814,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1015,12 +984,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1056,10 +1020,7 @@ internal class InputArgumentTest {
         }
 
         every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
+            "helloFetcher" to fetcher
         )
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
@@ -1082,12 +1043,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1239,12 +1195,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1276,12 +1227,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1315,12 +1261,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1354,12 +1295,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1395,12 +1331,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1485,12 +1416,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1560,12 +1486,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1608,12 +1529,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1649,12 +1565,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1694,12 +1605,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 
@@ -1741,12 +1647,7 @@ internal class InputArgumentTest {
             }
         }
 
-        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf(
-            Pair(
-                "helloFetcher",
-                fetcher
-            )
-        )
+        every { applicationContextMock.getBeansWithAnnotation(DgsComponent::class.java) } returns mapOf("helloFetcher" to fetcher)
         every { applicationContextMock.getBeansWithAnnotation(DgsScalar::class.java) } returns emptyMap()
         every { applicationContextMock.getBeansWithAnnotation(DgsDirective::class.java) } returns emptyMap()
 


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

## TL;DR

* DGS will only accept requests with `content-type` of `application/json`, `application/graphql`, and `multipart/form-data`.
* DGS will enforce a _pre-flight_ header if the `content-type` is `multipart/form-data`. Acceptable _pre-flight_ headers are "x-apollo-operation-name",  "apollo-require-preflight", or "graphql-require-preflight" 

## Context

This commit addresses CSRF attacks that can leverage the execution of JS code attached to a
`content-type: multipart/form-data`, or other content-types which will not force the browsers to do a _preflight_ check
and enforce the CORS policy. **Application developers should provide a sensible CORS policy** as well as,
if they use cookies, a sensible cookie _SameSite_ policy.

DGS MVC supports the execution of GraphQL operations via HTTP POST requests with `content-type: multipart/form-data`.
Because they are POST requests, they can contain GraphQL mutations. Because they use `content-type: multipart/form-data`,
they can be "simple requests" which are not _preflighted_ by browsers.

Spring Boot applications using DGS that set `SameSite=None` cookies for authentication are then open to JS code from any origin can that can cause browsers to send `cookie-authenticated` Mutations to the GraphQL endpoint,
this will then be executed without checking your CORS policy first.  Although the attack won't be able to see the response to the mutation if your CORS policy is set up properly, the side effects of the mutation will still occur.

In addition, if the Spring Boot application using DGS relies on network properties for security (whether by explicitly
looking at the client's IP address or by only being available on a private network), then JS on any origin can cause browsers (which may be on a private network or have an allowed IP address) to send mutations to your GraphQL server,
which will be executed without checking your CORS policy first. (This attack does not require your server to use cookies.
It is in some cases prevented by some browsers such as Chrome.)

For additional context visit [Apollo Server 2 graphql-upload CSRF Page].

[Apollo Server 2 graphql-upload CSRF Page]: https://github.com/apollographql/apollo-server/security/advisories/GHSA-2p3c-p3qw-69r4

## Changes

With this commit DGS MVC will now enforce that all request targeting the
`/graphql` endpoint define their content type as either `multipart/form-data`, `application/json`, or `application/graphql`. this _limitation_ on supported content-types can be disabled, this is mentioned below).
In addition, if the content-type is `multipart/form-data`, `application/x-www-form-urlencoded`, or `text/plain`  there is the expectation that the request should also include one of the following _preflight_ headers:

* "x-apollo-operation-name"
* "apollo-require-preflight"
* "graphql-require-preflight"

This is *important* if you are using *file upload* since your clients will now have to send any of the headers mentioned above.

Although **not recommended** you can disable the _preflight_ check by setting `dgs.graphql.header.validation.enabled` to `false`.

