### PR TITLE
Fix how the GraphQLCSRFRequestHeaderValidationRule compares the content-type

### DIFF
--- a/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/FileUploadMutation.java
+++ b/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/FileUploadMutation.java
@@ -18,49 +18,73 @@ package com.netflix.graphql.dgs.example.datafetcher;
 
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.InputArgument;
 import graphql.schema.DataFetchingEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 @DgsComponent
 public class FileUploadMutation {
+    private static final Logger log = LoggerFactory.getLogger(FileUploadMutation.class);
+
+    /**
+     * Implementation of the _Data Fetcher_ that will handle file upload.
+     *
+     * To test file upload via the command line you will first have to create a file,
+     * let's say we name it {@code a.txt} and contains only {@code Hello World!}.
+     * After that, you can use the {@code curl} command to execute the filue upload of one file as follows:
+     * {@code
+     * <pre>
+     *  curl -a http://localhost:8080/graphql \
+     *      --header "graphql-require-preflight:true" \
+     *      -F operations='{ "query" : "mutation ($file: Upload!) { uploadFile(input: { files:[$file]} ) }", "variables": {"file": null } }' \
+     *      -F map='{ "0": ["variables.file"] }' \
+     *      -F 0=@a.txt
+     * </pre>
+     * }
+     *
+     * @param input the GraphQL input argument of type FileUploadInput, serialized to the java pojo FileUploadInput.
+     * @param dfe the Data Fetching Environment
+     * @return boolean that will be true if all files are uploaded.
+     */
     @DgsData(parentType = "Mutation", field = "uploadFile")
-    public boolean uploadFile(DataFetchingEnvironment dataFetchingEnvironment) {
-        Map<String,Object> input = dataFetchingEnvironment.getArgument("input");
-        @SuppressWarnings("unchecked")
-        List<MultipartFile> parts = (List<MultipartFile>) input.get("files");
-        parts.forEach(it -> {
-            String content = null;
+    public boolean uploadFile(@InputArgument FileUploadInput input, DataFetchingEnvironment dfe) {
+        List<MultipartFile> parts = input.getFiles();
+        for (int i = 0; i < parts.size(); i++) {
             try {
-                content = new String(it.getBytes());
+                String content = new String(parts.get(i).getBytes());
+                log.debug("File upload contents are\n{}\n", content);
             } catch (IOException e) {
+                log.error("Failed to upload file[{}]!", i, e);
                 e.printStackTrace();
             }
-        });
-
+        }
         return !parts.isEmpty();
     }
-}
 
-class FileUploadInput {
-    private String description;
-    private List<MultipartFile> files;
+    static class FileUploadInput {
+        private String description;
+        private List<MultipartFile> files;
 
-    public String getDescription() {
-        return description;
-    }
-    public void setDescription(String description) {
-        this.description = description;
-    }
+        public String getDescription() {
+            return description;
+        }
 
-    public List<MultipartFile> getFiles() {
-        return files;
-    }
-    public void setFiles(List<MultipartFile> file) {
-        this.files = file;
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public List<MultipartFile> getFiles() {
+            return files;
+        }
+
+        public void setFiles(List<MultipartFile> file) {
+            this.files = file;
+        }
     }
 }
 

--- a/graphql-dgs-example-java/src/main/resources/application.yml
+++ b/graphql-dgs-example-java/src/main/resources/application.yml
@@ -2,4 +2,6 @@ spring:
   application:
     name: dgs-example
 
-logging.level.graphql: DEBUG
+logging:
+  level:
+    com.netflix.graphql.dgs.example: DEBUG


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Fix how we compare the request's content-type with the _Media Types_ that are deemed to not enforce a pre-flight check, i.e. a CORS policy check.
