### PR TITLE
chore(deps): Bump graphql-java-extended-validation to 18.1-hibernate-validator-6.2.0.Final

### DIFF
--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -84,7 +84,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -137,7 +137,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -157,7 +157,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -183,7 +183,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -209,7 +209,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -240,7 +240,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -260,7 +260,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -280,7 +280,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -345,7 +345,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -371,7 +371,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -514,7 +514,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -684,7 +684,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -773,7 +773,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -171,7 +171,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -218,7 +218,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -238,7 +238,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -264,7 +264,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -290,7 +290,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -321,7 +321,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -341,7 +341,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -361,7 +361,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -550,7 +550,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -637,7 +637,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -682,7 +682,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -840,7 +840,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -1032,7 +1032,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1122,7 +1122,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -177,7 +177,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -224,7 +224,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -244,7 +244,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -270,7 +270,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -296,7 +296,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -327,7 +327,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -347,7 +347,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -367,7 +367,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -559,7 +559,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -656,7 +656,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -713,7 +713,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -883,7 +883,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -1082,7 +1082,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1185,7 +1185,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -113,7 +113,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "locked": "5.3.19"
@@ -166,7 +166,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -186,7 +186,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -212,7 +212,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -238,7 +238,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -269,7 +269,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -289,7 +289,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -309,7 +309,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -407,7 +407,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -479,7 +479,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -513,7 +513,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -616,7 +616,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "locked": "5.3.19"
@@ -726,7 +726,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -801,7 +801,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -90,7 +90,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -137,7 +137,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -157,7 +157,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -183,7 +183,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -209,7 +209,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -240,7 +240,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -260,7 +260,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -280,7 +280,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -352,7 +352,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -405,7 +405,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -437,7 +437,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -581,7 +581,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -740,7 +740,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -828,7 +828,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -38,7 +38,7 @@
             "locked": "18.1"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "17.0-hibernate-validator-6.2.0.Final"
+            "locked": "18.1-hibernate-validator-6.2.0.Final"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -90,7 +90,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -137,7 +137,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -157,7 +157,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -183,7 +183,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -209,7 +209,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -240,7 +240,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -260,7 +260,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -280,7 +280,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -317,7 +317,7 @@
             "locked": "18.1"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "17.0-hibernate-validator-6.2.0.Final"
+            "locked": "18.1-hibernate-validator-6.2.0.Final"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -352,7 +352,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -405,7 +405,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -437,7 +437,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -464,7 +464,7 @@
             "locked": "18.1"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "17.0-hibernate-validator-6.2.0.Final"
+            "locked": "18.1-hibernate-validator-6.2.0.Final"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -581,7 +581,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -643,7 +643,7 @@
             "locked": "18.1"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "17.0-hibernate-validator-6.2.0.Final"
+            "locked": "18.1-hibernate-validator-6.2.0.Final"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -740,7 +740,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -828,7 +828,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -36,7 +36,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -54,7 +54,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -101,7 +101,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -121,7 +121,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -147,7 +147,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -173,7 +173,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -204,7 +204,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -224,7 +224,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -244,7 +244,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -261,7 +261,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -279,7 +279,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -299,7 +299,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -319,7 +319,7 @@
             "locked": "1.12.4"
         },
         "net.datafaker:datafaker": {
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -340,7 +340,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -360,7 +360,7 @@
             "locked": "1.12.4"
         },
         "net.datafaker:datafaker": {
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -381,7 +381,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -87,7 +87,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -134,7 +134,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -154,7 +154,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -180,7 +180,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -206,7 +206,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -237,7 +237,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -257,7 +257,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -277,7 +277,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -346,7 +346,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -399,7 +399,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -431,7 +431,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -505,7 +505,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -577,7 +577,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -633,7 +633,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-platform-dependencies/dependencies.lock
+++ b/graphql-dgs-platform-dependencies/dependencies.lock
@@ -18,7 +18,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
         }
         api("com.graphql-java:graphql-java-extended-validation") {
             // The version below will work with Jakarta EE 8 and use Hibernate Validator 6.2.
-            version { require("17.0-hibernate-validator-6.2.0.Final") }
+            version { require("18.1-hibernate-validator-6.2.0.Final") }
         }
         api("com.apollographql.federation:federation-graphql-java-support") {
             version { require("2.0.0") }

--- a/graphql-dgs-platform/dependencies.lock
+++ b/graphql-dgs-platform/dependencies.lock
@@ -13,7 +13,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -96,7 +96,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -146,7 +146,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -166,7 +166,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -192,7 +192,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -218,7 +218,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -249,7 +249,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -269,7 +269,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -289,7 +289,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -361,7 +361,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -414,7 +414,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -449,7 +449,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -553,7 +553,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -651,7 +651,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -719,7 +719,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -125,7 +125,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.3"
+            "locked": "1.3.4"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -172,7 +172,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context-support": {
             "locked": "5.3.19"
@@ -222,7 +222,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -242,7 +242,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -268,7 +268,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -294,7 +294,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -325,7 +325,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -345,7 +345,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -365,7 +365,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -434,7 +434,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.3"
+            "locked": "1.3.4"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -449,7 +449,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -499,7 +499,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -534,7 +534,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -640,7 +640,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.3"
+            "locked": "1.3.4"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -693,7 +693,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context-support": {
             "locked": "5.3.19"
@@ -837,7 +837,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.3"
+            "locked": "1.3.4"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -867,7 +867,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -955,7 +955,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -108,7 +108,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -158,7 +158,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -178,7 +178,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -204,7 +204,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -230,7 +230,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -261,7 +261,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -281,7 +281,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -301,7 +301,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -379,7 +379,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -437,7 +437,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -470,7 +470,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -565,7 +565,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -655,7 +655,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -719,7 +719,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -143,7 +143,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -190,7 +190,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -210,7 +210,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -236,7 +236,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -262,7 +262,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -293,7 +293,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -313,7 +313,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -333,7 +333,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -473,7 +473,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -548,7 +548,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -595,7 +595,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -725,7 +725,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -868,7 +868,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -946,7 +946,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -101,7 +101,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -151,7 +151,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -171,7 +171,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -197,7 +197,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -223,7 +223,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -254,7 +254,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -274,7 +274,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -294,7 +294,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -380,7 +380,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -438,7 +438,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -476,7 +476,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -589,7 +589,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -702,7 +702,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -776,7 +776,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -102,7 +102,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -152,7 +152,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -172,7 +172,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -198,7 +198,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -224,7 +224,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -255,7 +255,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -275,7 +275,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -295,7 +295,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -376,7 +376,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -431,7 +431,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -467,7 +467,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -571,7 +571,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -669,7 +669,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -740,7 +740,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -93,7 +93,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -143,7 +143,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -163,7 +163,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -189,7 +189,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -215,7 +215,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -246,7 +246,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -266,7 +266,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -286,7 +286,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -355,7 +355,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -405,7 +405,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -437,7 +437,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -517,7 +517,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -595,7 +595,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -648,7 +648,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -51,7 +51,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -98,7 +98,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -118,7 +118,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -144,7 +144,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -170,7 +170,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -201,7 +201,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -221,7 +221,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -241,7 +241,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -273,7 +273,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -293,7 +293,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -334,7 +334,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -375,7 +375,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -92,7 +92,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -145,7 +145,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -165,7 +165,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -191,7 +191,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -217,7 +217,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -248,7 +248,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -268,7 +268,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -288,7 +288,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -385,7 +385,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -440,7 +440,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -479,7 +479,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -558,7 +558,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -664,7 +664,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -722,7 +722,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -102,7 +102,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -155,7 +155,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -175,7 +175,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -201,7 +201,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -227,7 +227,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -258,7 +258,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -278,7 +278,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -298,7 +298,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -381,7 +381,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -432,7 +432,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -467,7 +467,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -562,7 +562,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -657,7 +657,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -714,7 +714,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -107,7 +107,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -157,7 +157,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -177,7 +177,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -203,7 +203,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -229,7 +229,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -260,7 +260,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -280,7 +280,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -300,7 +300,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -391,7 +391,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -449,7 +449,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -488,7 +488,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -582,7 +582,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -679,7 +679,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -740,7 +740,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -102,10 +102,10 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -158,7 +158,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -178,7 +178,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -204,7 +204,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -230,7 +230,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -261,7 +261,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -281,7 +281,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -301,7 +301,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -381,7 +381,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -435,7 +435,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -470,7 +470,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -565,7 +565,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -660,7 +660,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -717,7 +717,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -148,7 +148,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -195,7 +195,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -215,7 +215,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -241,7 +241,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -267,7 +267,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -298,7 +298,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -318,7 +318,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -338,7 +338,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -492,7 +492,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -567,7 +567,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
@@ -610,7 +610,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -745,7 +745,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -902,7 +902,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -980,7 +980,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -93,13 +93,13 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.19"
+            "locked": "5.3.20"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -149,7 +149,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -169,7 +169,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -195,7 +195,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -221,7 +221,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -252,7 +252,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -272,7 +272,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -292,7 +292,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -338,7 +338,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -375,7 +375,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
             "locked": "5.3.19"
@@ -401,7 +401,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -490,13 +490,13 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.19"
+            "locked": "5.3.20"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -557,7 +557,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.3.0"
+            "locked": "1.4.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.6.21"
@@ -600,13 +600,13 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.19"
+            "locked": "5.3.20"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -19,7 +19,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -51,7 +51,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -98,7 +98,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -118,7 +118,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -144,7 +144,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -170,7 +170,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -201,7 +201,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -221,7 +221,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -241,7 +241,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -270,7 +270,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -290,7 +290,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -325,7 +325,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"
@@ -360,7 +360,7 @@
             "locked": "2021.0.2"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.6.3"
+            "locked": "5.6.5"
         },
         "org.springframework:spring-framework-bom": {
             "locked": "5.3.18"


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Update graphql-java-extended-validation dependency to 18.1

