### PR TITLE
DgsSchemaProvider API to expose resolved Datafetchers & field instrumentation

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -125,7 +125,7 @@ class DgsGraphQLMetricsInstrumentation(
         if (parameters.isTrivialDataFetcher ||
             state.isIntrospectionQuery ||
             TagUtils.shouldIgnoreTag(gqlField) ||
-            !schemaProvider.dataFetcherInstrumentationEnabled.getOrDefault(gqlField, true)
+            !schemaProvider.isFieldInstrumentationEnabled(gqlField)
         ) {
             return dataFetcher
         }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

The DgsSchemaProvider now provides an API to expose the resolved datafetchers as well as a new method that can be used to identify if a given GraphQL `<Type name>.<field name>` has instrumentation enabled.