### PR TITLE
Addressing DgsGraphQLMetricsInstrumentation Latency increase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 
 # Gradle
 /build/
+/out/
 # Also covers /buildSrc/build/
 /*/build/
+/*/out/
 /.gradle/
 /buildSrc/.gradle/
 

--- a/graphql-dgs-spring-boot-micrometer/src/jmh/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentationBenchmark.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/jmh/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentationBenchmark.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.metrics.micrometer
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsQuery
+import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.FallbackEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
+import com.netflix.graphql.dgs.internal.method.MethodDataFetcherFactory
+import graphql.ExecutionInput
+import graphql.GraphQL
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.mock.env.MockEnvironment
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(value = [ Mode.Throughput, Mode.AverageTime ])
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+open class DgsGraphQLMetricsInstrumentationBenchmark {
+
+    private lateinit var applicationContext: AnnotationConfigApplicationContext
+
+    private lateinit var graphql: GraphQL
+
+    @Setup
+    @BeforeEach
+    open fun setup() {
+        val mockEnvironment = MockEnvironment()
+
+        applicationContext = AnnotationConfigApplicationContext()
+        applicationContext.environment = mockEnvironment
+        applicationContext.register(BenchmarkedDataFetcher::class.java)
+        applicationContext.refresh()
+        applicationContext.start()
+
+        val provider = DgsSchemaProvider(
+            applicationContext = applicationContext,
+            federationResolver = Optional.empty(),
+            existingTypeDefinitionRegistry = Optional.empty(),
+            methodDataFetcherFactory = MethodDataFetcherFactory(
+                listOf(
+                    InputArgumentResolver(DefaultInputObjectMapper()),
+                    DataFetchingEnvironmentArgumentResolver(),
+                    FallbackEnvironmentArgumentResolver()
+                )
+            )
+        )
+
+        val simpleMeter = SimpleMeterRegistry()
+        val properties = DgsGraphQLMetricsProperties()
+        val metricsInstrumentation = DgsGraphQLMetricsInstrumentation(
+            schemaProvider = provider,
+            registrySupplier = { simpleMeter },
+            tagsProvider = DgsGraphQLCollatedMetricsTagsProvider(),
+            properties = properties,
+            limitedTagMetricResolver = SpectatorLimitedTagMetricResolver(properties.tags)
+        )
+
+        graphql = GraphQL.newGraphQL(provider.schema(schema)).instrumentation(metricsInstrumentation).build()
+    }
+
+    @AfterEach
+    @TearDown
+    fun destroy() {
+        applicationContext.stop()
+    }
+
+    @Benchmark
+    @Test
+    open fun helloGraphQLQuery() {
+        val executionResult = graphql.execute(simpleHelloQuery)
+        assertThat(executionResult).isNotNull
+        assertThat(executionResult.errors).isEmpty()
+        assertThat(executionResult.isDataPresent).isTrue
+        val data = executionResult.getData<Map<String, *>>()
+        assertThat(data).hasEntrySatisfying("hello") {
+            assertThat(it).isInstanceOf(String::class.java).asString().isNotEmpty()
+        }
+    }
+
+    @Benchmark
+    @Test
+    open fun numbers() {
+        val executionResult = graphql.execute(numbersExecutionInput)
+        assertThat(executionResult).isNotNull
+        assertThat(executionResult.errors).isEmpty()
+        assertThat(executionResult.isDataPresent).isTrue
+        val data = executionResult.getData<Map<String, *>>()
+        assertThat(data).hasEntrySatisfying("size") { assertThat(it).isNotNull }
+    }
+
+    companion object {
+        @Language("GraphQL")
+        private val schema = """
+            type Query {
+                hello(name: String): String
+                size(list: [Int]): Int
+            }
+        """.trimIndent()
+
+        @Language("GraphQL")
+        private val simpleHelloQuery = """{ hello(name: "benchmark") }"""
+
+        private val numbersExecutionInput: ExecutionInput =
+            ExecutionInput.newExecutionInput("""query CalcSize(${"$"}numbers: [Int]) { size(list: ${"$"}numbers) }""")!!
+                .variables(mapOf("numbers" to (0..200).toList()))
+                .operationName("CalcSize")
+                .build()
+    }
+
+    @DgsComponent
+    open class BenchmarkedDataFetcher {
+
+        @DgsQuery(field = "hello")
+        fun hello(@InputArgument name: String): String {
+            return "Hello, $name"
+        }
+
+        @DgsQuery(field = "size")
+        fun size(@InputArgument list: List<Int>): Int {
+            return list.size
+        }
+    }
+}

--- a/graphql-dgs-spring-boot-micrometer/src/jmh/resources/logback.xml
+++ b/graphql-dgs-spring-boot-micrometer/src/jmh/resources/logback.xml
@@ -1,0 +1,41 @@
+
+<!--
+  ~ Copyright 2022 Netflix, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+
+    <logger name="graphql" level="warn" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="com.netflix" level="warn" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="error">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLCollatedMetricsTagsProvider.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLCollatedMetricsTagsProvider.kt
@@ -25,11 +25,12 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionPara
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Tags
+import java.util.*
 
-internal class DgsGraphQLCollatedMetricsTagsProvider(
-    private val contextualTagCustomizer: Collection<DgsContextualTagCustomizer>,
-    private val executionTagCustomizer: Collection<DgsExecutionTagCustomizer>,
-    private val fieldFetchTagCustomizer: Collection<DgsFieldFetchTagCustomizer>
+class DgsGraphQLCollatedMetricsTagsProvider(
+    private val contextualTagCustomizer: Collection<DgsContextualTagCustomizer> = Collections.emptyList(),
+    private val executionTagCustomizer: Collection<DgsExecutionTagCustomizer> = Collections.emptyList(),
+    private val fieldFetchTagCustomizer: Collection<DgsFieldFetchTagCustomizer> = Collections.emptyList()
 ) : DgsGraphQLMetricsTagsProvider {
 
     override fun getContextualTags(): Iterable<Tag> {

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/SpectatorLimitedTagMetricResolver.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/SpectatorLimitedTagMetricResolver.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Function
 
 /** [LimitedTagMetricResolver] backed by Spectator's Cardinality Limiters. */
-internal class SpectatorLimitedTagMetricResolver(
+class SpectatorLimitedTagMetricResolver(
     private val tagsProperties: DgsGraphQLMetricsProperties.TagsProperties
 ) : LimitedTagMetricResolver {
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherReference.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherReference.kt
@@ -19,7 +19,7 @@ package com.netflix.graphql.dgs.internal
 import org.springframework.core.annotation.MergedAnnotations
 import java.lang.reflect.Method
 
-data class DatafetcherReference(
+data class DataFetcherReference(
     val instance: Any,
     val method: Method,
     val annotations: MergedAnnotations,

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -85,13 +85,13 @@ class DgsSchemaProvider(
 
     private val dataFetcherInstrumentationEnabled = mutableMapOf<String, Boolean>()
 
-    private val dataFetchers = mutableListOf<DatafetcherReference>()
+    private val dataFetchers = mutableListOf<DataFetcherReference>()
 
     /**
-     * Returns an immutable list of [DatafetcherReference]s that were identified after the schema was loaded.
+     * Returns an immutable list of [DataFetcherReference]s that were identified after the schema was loaded.
      * The returned list will be unstable until the [schema] is fully loaded.
      */
-    fun resolvedDataFetchers(): List<DatafetcherReference> {
+    fun resolvedDataFetchers(): List<DataFetcherReference> {
         return schemaReadWriteLock.read {
             dataFetchers.toList()
         }
@@ -287,8 +287,7 @@ class DgsSchemaProvider(
         val field = dgsDataAnnotation.getString("field").ifEmpty { method.name }
         val parentType = dgsDataAnnotation.getString("parentType")
 
-        //
-        dataFetchers.add(DatafetcherReference(dgsComponent, method, mergedAnnotations, parentType, field))
+        dataFetchers.add(DataFetcherReference(dgsComponent, method, mergedAnnotations, parentType, field))
 
         val enableInstrumentation =
             if (method.isAnnotationPresent(DgsEnableDataFetcherInstrumentation::class.java)) {

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -57,7 +57,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
-import org.assertj.core.api.Assertions.LIST
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.InstanceOfAssertFactories
 import org.junit.jupiter.api.AfterEach
@@ -66,7 +65,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.beans.factory.getBeansWithAnnotation
 import org.springframework.context.ApplicationContext
 import org.springframework.core.convert.ConversionFailedException
 import org.springframework.http.MediaType


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This commit addresses the increased latencies observed on DGS 4.10.4, 5.0.0, 5.0.1.
We are also adding support for JMH benchmarks across modules of DGS, that said we are only focusing in this commit on `graphql-dgs-spring-boot-micrometer`. To run benchmarks you can just call `./gradlew graphql-dgs-spring-boot-micrometer:jmh`.


Fixes #1089 