### PR TITLE
Addressing DgsGraphQLMetricsInstrumentation Latency increase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 
 # Gradle
 /build/
+/out/
 # Also covers /buildSrc/build/
 /*/build/
+/*/out/
 /.gradle/
 /buildSrc/.gradle/
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,10 @@ group = "com.netflix.graphql.dgs"
 
 plugins {
     `java-library`
-    id("nebula.netflixoss") version "10.6.0"
     id("nebula.dependency-recommender") version "11.0.0"
+    id("nebula.netflixoss") version "10.6.0"
     id("org.jmailen.kotlinter") version "3.10.0"
+    id("me.champeau.jmh") version "0.6.6"
     kotlin("jvm") version Versions.KOTLIN_VERSION
     kotlin("kapt") version Versions.KOTLIN_VERSION
     idea
@@ -76,6 +77,7 @@ configure(subprojects.filterNot { it in internalBomModules }) {
         plugin("kotlin")
         plugin("kotlin-kapt")
         plugin("org.jmailen.kotlinter")
+        plugin("me.champeau.jmh")
     }
 
     /**
@@ -92,6 +94,8 @@ configure(subprojects.filterNot { it in internalBomModules }) {
     }
 
     val springBootVersion = extra["sb.version"] as String
+    val jmhVersion = "1.35"
+
     dependencies {
         // Apply the BOM to applicable subprojects.
         api(platform(project(":graphql-dgs-platform")))
@@ -103,6 +107,13 @@ configure(subprojects.filterNot { it in internalBomModules }) {
         kapt("org.springframework.boot:spring-boot-autoconfigure-processor:${springBootVersion}")
         // Produce Config Metadata for properties used in Spring Boot for Kotlin
         kapt("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")
+
+        // Sets sets the JMH version to use across modules.
+        // Please refer to the following links for further reference.
+        // * https://github.com/melix/jmh-gradle-plugin
+        // * https://openjdk.java.net/projects/code-tools/jmh/
+        jmh("org.openjdk.jmh:jmh-core:${jmhVersion}")
+        jmh("org.openjdk.jmh:jmh-generator-annprocess:${jmhVersion}")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test") {
             exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
@@ -122,6 +133,20 @@ configure(subprojects.filterNot { it in internalBomModules }) {
                 "$projectDir/src/main/resources"
             )
         }
+    }
+
+    jmh {
+        includeTests.set(true)
+        jmhTimeout.set("5s")
+        timeUnit.set("ms")
+        warmupIterations.set(2)
+        iterations.set(2)
+        fork.set(2)
+        duplicateClassesStrategy.set(DuplicatesStrategy.EXCLUDE)
+    }
+
+    tasks.withType<Jar>() {
+        duplicatesStrategy = DuplicatesStrategy.WARN
     }
 
     tasks.withType<JavaCompile>().configureEach {

--- a/graphql-dgs-spring-boot-micrometer/src/jmh/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentationBenchmark.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/jmh/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentationBenchmark.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.metrics.micrometer
+
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsQuery
+import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.FallbackEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
+import com.netflix.graphql.dgs.internal.method.MethodDataFetcherFactory
+import graphql.ExecutionInput
+import graphql.GraphQL
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.mock.env.MockEnvironment
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(value = [ Mode.Throughput, Mode.AverageTime ])
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+open class DgsGraphQLMetricsInstrumentationBenchmark {
+
+    private lateinit var applicationContext: AnnotationConfigApplicationContext
+
+    private lateinit var graphql: GraphQL
+
+    @Setup
+    @BeforeEach
+    open fun setup() {
+        val mockEnvironment = MockEnvironment()
+
+        applicationContext = AnnotationConfigApplicationContext()
+        applicationContext.environment = mockEnvironment
+        applicationContext.register(BenchmarkedDataFetcher::class.java)
+        applicationContext.refresh()
+        applicationContext.start()
+
+        val provider = DgsSchemaProvider(
+            applicationContext = applicationContext,
+            federationResolver = Optional.empty(),
+            existingTypeDefinitionRegistry = Optional.empty(),
+            methodDataFetcherFactory = MethodDataFetcherFactory(
+                listOf(
+                    InputArgumentResolver(DefaultInputObjectMapper()),
+                    DataFetchingEnvironmentArgumentResolver(),
+                    FallbackEnvironmentArgumentResolver()
+                )
+            )
+        )
+
+        val simpleMeter = SimpleMeterRegistry()
+        val properties = DgsGraphQLMetricsProperties()
+        val metricsInstrumentation = DgsGraphQLMetricsInstrumentation(
+            schemaProvider = provider,
+            registrySupplier = { simpleMeter },
+            tagsProvider = DgsGraphQLCollatedMetricsTagsProvider(),
+            properties = properties,
+            limitedTagMetricResolver = SpectatorLimitedTagMetricResolver(properties.tags)
+        )
+
+        graphql = GraphQL.newGraphQL(provider.schema(schema)).instrumentation(metricsInstrumentation).build()
+    }
+
+    @AfterEach
+    @TearDown
+    fun destroy() {
+        applicationContext.stop()
+    }
+
+    @Benchmark
+    @Test
+    open fun helloGraphQLQuery() {
+        val executionResult = graphql.execute(simpleHelloQuery)
+        assertThat(executionResult).isNotNull
+        assertThat(executionResult.errors).isEmpty()
+        assertThat(executionResult.isDataPresent).isTrue
+        val data = executionResult.getData<Map<String, *>>()
+        assertThat(data).hasEntrySatisfying("hello") {
+            assertThat(it).isInstanceOf(String::class.java).asString().isNotEmpty()
+        }
+    }
+
+    @Benchmark
+    @Test
+    open fun numbers() {
+        val executionResult = graphql.execute(numbersExecutionInput)
+        assertThat(executionResult).isNotNull
+        assertThat(executionResult.errors).isEmpty()
+        assertThat(executionResult.isDataPresent).isTrue
+        val data = executionResult.getData<Map<String, *>>()
+        assertThat(data).hasEntrySatisfying("size") { assertThat(it).isNotNull }
+    }
+
+    companion object {
+        @Language("GraphQL")
+        private val schema = """
+            type Query {
+                hello(name: String): String
+                size(list: [Int]): Int
+            }
+        """.trimIndent()
+
+        @Language("GraphQL")
+        private val simpleHelloQuery = """{ hello(name: "benchmark") }"""
+
+        private val numbersExecutionInput: ExecutionInput =
+            ExecutionInput.newExecutionInput("""query CalcSize(${"$"}numbers: [Int]) { size(list: ${"$"}numbers) }""")!!
+                .variables(mapOf("numbers" to (0..200).toList()))
+                .operationName("CalcSize")
+                .build()
+    }
+
+    @DgsComponent
+    open class BenchmarkedDataFetcher {
+
+        @DgsQuery(field = "hello")
+        fun hello(@InputArgument name: String): String {
+            return "Hello, $name"
+        }
+
+        @DgsQuery(field = "size")
+        fun size(@InputArgument list: List<Int>): Int {
+            return list.size
+        }
+    }
+}

--- a/graphql-dgs-spring-boot-micrometer/src/jmh/resources/logback.xml
+++ b/graphql-dgs-spring-boot-micrometer/src/jmh/resources/logback.xml
@@ -1,0 +1,41 @@
+
+<!--
+  ~ Copyright 2022 Netflix, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+
+    <logger name="graphql" level="warn" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <logger name="com.netflix" level="warn" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="error">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLCollatedMetricsTagsProvider.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLCollatedMetricsTagsProvider.kt
@@ -25,11 +25,12 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionPara
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Tags
+import java.util.*
 
-internal class DgsGraphQLCollatedMetricsTagsProvider(
-    private val contextualTagCustomizer: Collection<DgsContextualTagCustomizer>,
-    private val executionTagCustomizer: Collection<DgsExecutionTagCustomizer>,
-    private val fieldFetchTagCustomizer: Collection<DgsFieldFetchTagCustomizer>
+class DgsGraphQLCollatedMetricsTagsProvider(
+    private val contextualTagCustomizer: Collection<DgsContextualTagCustomizer> = Collections.emptyList(),
+    private val executionTagCustomizer: Collection<DgsExecutionTagCustomizer> = Collections.emptyList(),
+    private val fieldFetchTagCustomizer: Collection<DgsFieldFetchTagCustomizer> = Collections.emptyList()
 ) : DgsGraphQLMetricsTagsProvider {
 
     override fun getContextualTags(): Iterable<Tag> {

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/SpectatorLimitedTagMetricResolver.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/SpectatorLimitedTagMetricResolver.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Function
 
 /** [LimitedTagMetricResolver] backed by Spectator's Cardinality Limiters. */
-internal class SpectatorLimitedTagMetricResolver(
+class SpectatorLimitedTagMetricResolver(
     private val tagsProperties: DgsGraphQLMetricsProperties.TagsProperties
 ) : LimitedTagMetricResolver {
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherReference.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherReference.kt
@@ -19,7 +19,7 @@ package com.netflix.graphql.dgs.internal
 import org.springframework.core.annotation.MergedAnnotations
 import java.lang.reflect.Method
 
-data class DatafetcherReference(
+data class DataFetcherReference(
     val instance: Any,
     val method: Method,
     val annotations: MergedAnnotations,

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -79,7 +79,7 @@ class DgsSchemaProvider(
 ) {
 
     val dataFetcherInstrumentationEnabled = mutableMapOf<String, Boolean>()
-    private val dataFetchers = mutableListOf<DatafetcherReference>()
+    private val dataFetchers = mutableListOf<DataFetcherReference>()
 
     fun schema(
         @Language("GraphQL") schema: String? = null,
@@ -249,7 +249,8 @@ class DgsSchemaProvider(
     ) {
         val field = dgsDataAnnotation.getString("field").ifEmpty { method.name }
         val parentType = dgsDataAnnotation.getString("parentType")
-        dataFetchers.add(DatafetcherReference(dgsComponent, method, mergedAnnotations, parentType, field))
+
+        dataFetchers.add(DataFetcherReference(dgsComponent, method, mergedAnnotations, parentType, field))
 
         val enableInstrumentation =
             if (method.isAnnotationPresent(DgsEnableDataFetcherInstrumentation::class.java)) {


### PR DESCRIPTION
This commit addresses the increased latencies observed on DGS 4.10.4, 5.0.0, 5.0.1. We are also adding support for JMH benchmarks across modules of DGS, that said we are only focusing in this commit on `graphql-dgs-spring-boot-micrometer`.

Cherry-Picked from 9ff74f0980321fe7f7eba2258a12bb075228c0f2