### PR TITLE
Pass MultipartFile class to StdSerializer base class in MultipartFileSerializer

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/MultipartFileSerializer.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/MultipartFileSerializer.kt
@@ -26,7 +26,7 @@ import java.io.IOException
 /**
  * This class is used only for logging purposes since we cannot serialize a MultipartFile to json otherwise.
  */
-class MultipartFileSerializer @JvmOverloads constructor(t: Class<MultipartFile>? = null) : StdSerializer<MultipartFile>(t) {
+class MultipartFileSerializer : StdSerializer<MultipartFile>(MultipartFile::class.java) {
 
     @Throws(IOException::class, JsonProcessingException::class)
     override fun serialize(


### PR DESCRIPTION
MultipartFileSerializer extends StdSerializer from Jackson, but was not passing in MultipartFile to the base class constructor, which meant calling handledType() would return null.

The consequence is that when registering the serializer, one would have to explicitly pass in the associated class; with this change, that is no longer necessary, and one can do the following:

```
jacksonObjectMapper().registerModule(SimpleModule().addSerializer(MultipartFileSerializer()))
```

Cherry-Picked dc94997b5f482e2821175ffc9063e678210a3b0d
