### PR TITLE
Allow filtering of DgsComponents in DgsSchemaProvider

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -79,6 +79,7 @@ class DgsSchemaProvider(
     private val entityFetcherRegistry: EntityFetcherRegistry = EntityFetcherRegistry(),
     private val defaultDataFetcherFactory: Optional<DataFetcherFactory<*>> = Optional.empty(),
     private val methodDataFetcherFactory: MethodDataFetcherFactory,
+    private val componentFilter: (Any) -> Boolean = { true }
 ) {
 
     private val schemaReadWriteLock = ReentrantReadWriteLock()
@@ -123,7 +124,8 @@ class DgsSchemaProvider(
 
     private fun computeSchema(schema: String? = null, fieldVisibility: GraphqlFieldVisibility): GraphQLSchema {
         val startTime = System.currentTimeMillis()
-        val dgsComponents = applicationContext.getBeansWithAnnotation(DgsComponent::class.java).values
+        val dgsComponents =
+            applicationContext.getBeansWithAnnotation(DgsComponent::class.java).values.filter(componentFilter)
         val hasDynamicTypeRegistry =
             dgsComponents.any { it.javaClass.methods.any { m -> m.isAnnotationPresent(DgsTypeDefinitionRegistry::class.java) } }
 


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
In our project we have (we know this is not ideal, but it would a pretty massive undertaking to fix) multiple schemas. A service in our system can provide subgraphs in multiple schemas. 

In order to do this, we have written a custom `QueryExecutor` that will delegate to the correct schema depending on the value of a header set by the gateway. However, we need to load the different schemas separately. We currently have an annotation on the component itself that decides which schema it belongs to, What we need is the ability to tell the `DgsSchemaProvider` to not load all classes, which we today are doing with a fork of `DgsSchemaProvider` which uses a filter. 

This PR makes it possible to pass the filter to the `DgsSchemaProvider` instead, such that DGS can accommodate the use case of having multiple schemas in one service.

Alternatives considered
----

_Describe alternative implementation you have considered_
This PR was sufficiently simple that we did not consider any other solution that was as simple. Happy to hear suggestions tho!
