### PR TITLE
Input argument without @InputArgument("input") stopped working

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/jmh/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentationBenchmark.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/jmh/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentationBenchmark.kt
@@ -78,7 +78,7 @@ open class DgsGraphQLMetricsInstrumentationBenchmark {
                 listOf(
                     InputArgumentResolver(DefaultInputObjectMapper()),
                     DataFetchingEnvironmentArgumentResolver(),
-                    FallbackEnvironmentArgumentResolver()
+                    FallbackEnvironmentArgumentResolver(DefaultInputObjectMapper())
                 )
             )
         )

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -21,6 +21,7 @@ import com.netflix.graphql.dgs.DgsData
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.graphql.dgs.DgsDataLoaderRegistryConsumer
 import com.netflix.graphql.dgs.DgsEnableDataFetcherInstrumentation
+import com.netflix.graphql.dgs.DgsMutation
 import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.DgsTypeDefinitionRegistry
 import com.netflix.graphql.dgs.InputArgument
@@ -845,39 +846,39 @@ class MicrometerServletSmokeTest {
                 return "some insignificance"
             }
 
-            @DgsData(parentType = "Mutation", field = "buzz")
+            @DgsMutation
             fun buzz(): String {
                 return "buzz"
             }
 
-            @DgsData(parentType = "Query", field = "transform")
+            @DgsQuery
             fun transform(@InputArgument input: List<String>): List<Map<String, String>> {
                 return input.mapIndexed { i, v -> mapOf("index" to "$i", "value" to v) }
             }
 
-            @DgsData(parentType = "Query", field = "triggerInternalFailure")
+            @DgsQuery
             fun triggerInternalFailure(): String {
                 throw IllegalStateException("Exception triggered.")
             }
 
-            @DgsData(parentType = "Query", field = "triggerBadRequestFailure")
+            @DgsQuery
             fun triggerBadRequestFailure(): String {
                 throw DgsBadRequestException("Exception triggered.")
             }
 
-            @DgsData(parentType = "Query", field = "triggerCustomFailure")
+            @DgsQuery
             fun triggerCustomFailure(): String {
                 throw CustomException("Exception triggered.")
             }
 
-            @DgsData(parentType = "StringTransformation", field = "upperCased")
+            @DgsData(parentType = "StringTransformation")
             fun upperCased(dfe: DataFetchingEnvironment): CompletableFuture<String>? {
                 val dataLoader = dfe.getDataLoader<String, String>("upperCaseLoader")
                 val input = dfe.getSource<Map<String, String>>()
                 return dataLoader.load(input.getOrDefault("value", ""))
             }
 
-            @DgsData(parentType = "StringTransformation", field = "reversed")
+            @DgsData(parentType = "StringTransformation")
             fun reversed(dfe: DataFetchingEnvironment): CompletableFuture<String>? {
                 val dataLoader = dfe.getDataLoader<String, String>("reverser")
                 val input = dfe.getSource<Map<String, String>>()
@@ -925,7 +926,7 @@ class MicrometerServletSmokeTest {
             val executor = ThreadPoolTaskExecutor()
             executor.corePoolSize = 1
             executor.maxPoolSize = 1
-            executor.setThreadNamePrefix("${MicrometerServletSmokeTest::class.java.simpleName}-test-")
+            executor.threadNamePrefix = "${MicrometerServletSmokeTest::class.java.simpleName}-test-"
             executor.setQueueCapacity(10)
             executor.initialize()
             return executor

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -24,10 +24,6 @@ import com.netflix.graphql.dgs.exceptions.DefaultDataFetcherExceptionHandler
 import com.netflix.graphql.dgs.internal.*
 import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor.ReloadSchemaIndicator
 import com.netflix.graphql.dgs.internal.method.ArgumentResolver
-import com.netflix.graphql.dgs.internal.method.ContinuationArgumentResolver
-import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentResolver
-import com.netflix.graphql.dgs.internal.method.FallbackEnvironmentArgumentResolver
-import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
 import com.netflix.graphql.dgs.internal.method.MethodDataFetcherFactory
 import com.netflix.graphql.dgs.scalars.UploadScalar
 import com.netflix.graphql.mocking.MockProvider
@@ -68,7 +64,7 @@ import kotlin.streams.toList
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
 @Configuration
 @EnableConfigurationProperties(DgsConfigurationProperties::class)
-@ImportAutoConfiguration(classes = [JacksonAutoConfiguration::class])
+@ImportAutoConfiguration(classes = [JacksonAutoConfiguration::class, DgsInputArgumentConfiguration::class])
 open class DgsAutoConfiguration(
     private val configProps: DgsConfigurationProperties
 ) {
@@ -244,26 +240,5 @@ open class DgsAutoConfiguration(
     @Bean
     open fun methodDataFetcherFactory(argumentResolvers: ObjectProvider<ArgumentResolver>): MethodDataFetcherFactory {
         return MethodDataFetcherFactory(argumentResolvers.orderedStream().toList())
-    }
-
-    @Bean
-    open fun inputArgumentResolver(inputObjectMapper: ObjectProvider<InputObjectMapper>): ArgumentResolver {
-        val mapper = inputObjectMapper.ifAvailable ?: DefaultInputObjectMapper()
-        return InputArgumentResolver(mapper)
-    }
-
-    @Bean
-    open fun dataFetchingEnvironmentArgumentResolver(): ArgumentResolver {
-        return DataFetchingEnvironmentArgumentResolver()
-    }
-
-    @Bean
-    open fun coroutineArgumentResolver(): ArgumentResolver {
-        return ContinuationArgumentResolver()
-    }
-
-    @Bean
-    open fun fallbackEnvironmentArgumentResolver(): ArgumentResolver {
-        return FallbackEnvironmentArgumentResolver()
     }
 }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsInputArgumentConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsInputArgumentConfiguration.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.autoconfig
+
+import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
+import com.netflix.graphql.dgs.internal.InputObjectMapper
+import com.netflix.graphql.dgs.internal.method.*
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class DgsInputArgumentConfiguration {
+    @Bean
+    open fun inputArgumentResolver(inputObjectMapper: InputObjectMapper): ArgumentResolver {
+        return InputArgumentResolver(inputObjectMapper)
+    }
+
+    @Bean
+    open fun dataFetchingEnvironmentArgumentResolver(): ArgumentResolver {
+        return DataFetchingEnvironmentArgumentResolver()
+    }
+
+    @Bean
+    open fun coroutineArgumentResolver(): ArgumentResolver {
+        return ContinuationArgumentResolver()
+    }
+
+    @Bean
+    open fun fallbackEnvironmentArgumentResolver(inputObjectMapper: InputObjectMapper): ArgumentResolver {
+        return FallbackEnvironmentArgumentResolver(inputObjectMapper)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    open fun defaultInputObjectMapper(): InputObjectMapper {
+        return DefaultInputObjectMapper()
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfigurationTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfigurationTest.kt
@@ -24,6 +24,11 @@ import com.netflix.graphql.dgs.autoconfig.testcomponents.DataFetcherWithInputObj
 import com.netflix.graphql.dgs.autoconfig.testcomponents.DataLoaderConfig
 import com.netflix.graphql.dgs.autoconfig.testcomponents.HelloDataFetcherConfig
 import com.netflix.graphql.dgs.exceptions.NoSchemaFoundException
+import com.netflix.graphql.dgs.internal.InputObjectMapper
+import com.netflix.graphql.dgs.internal.method.ContinuationArgumentResolver
+import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.FallbackEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
@@ -128,6 +133,17 @@ class DgsAutoConfigurationTest {
                 )
                 assertThat(json).isEqualTo("hello")
             }
+        }
+    }
+
+    @Test
+    fun `DGS Input Argument beans are available`() {
+        context.run { ctx ->
+            assertThat(ctx).getBean("defaultInputObjectMapper", InputObjectMapper::class.java).isNotNull
+            assertThat(ctx).getBean("inputArgumentResolver", InputArgumentResolver::class.java).isNotNull
+            assertThat(ctx).getBean("dataFetchingEnvironmentArgumentResolver", DataFetchingEnvironmentArgumentResolver::class.java).isNotNull
+            assertThat(ctx).getBean("coroutineArgumentResolver", ContinuationArgumentResolver::class.java).isNotNull
+            assertThat(ctx).getBean("fallbackEnvironmentArgumentResolver", FallbackEnvironmentArgumentResolver::class.java).isNotNull
         }
     }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/AbstractInputArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/AbstractInputArgumentResolver.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.method
+
+import com.netflix.graphql.dgs.exceptions.DgsInvalidInputArgumentException
+import com.netflix.graphql.dgs.internal.InputObjectMapper
+import graphql.schema.DataFetchingEnvironment
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.core.MethodParameter
+import org.springframework.core.convert.TypeDescriptor
+import org.springframework.core.convert.support.DefaultConversionService
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+abstract class AbstractInputArgumentResolver(inputObjectMapper: InputObjectMapper) : ArgumentResolver {
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(AbstractInputArgumentResolver::class.java)
+    }
+
+    private val conversionService = DefaultConversionService()
+    private val argumentNameCache: ConcurrentMap<MethodParameter, String> = ConcurrentHashMap()
+
+    init {
+        conversionService.addConverter(InputObjectMapperConverter(inputObjectMapper))
+    }
+
+    override fun resolveArgument(parameter: MethodParameter, dfe: DataFetchingEnvironment): Any? {
+        val argumentName = getArgumentName(parameter)
+        val value = dfe.getArgument<Any?>(argumentName)
+
+        val typeDescriptor = TypeDescriptor(parameter)
+        val convertedValue = convertValue(value, typeDescriptor)
+
+        if (convertedValue == null && dfe.fieldDefinition.arguments.none { it.name == argumentName }) {
+            logger.warn(
+                "Unknown argument '{}'",
+                argumentName
+            )
+        }
+
+        return convertedValue
+    }
+
+    protected abstract fun resolveArgumentName(parameter: MethodParameter): String?
+
+    private fun getArgumentName(parameter: MethodParameter): String? {
+        val cachedName = argumentNameCache[parameter]
+        if (cachedName != null) {
+            return cachedName
+        }
+        val name = resolveArgumentName(parameter)
+        argumentNameCache[parameter] = name
+        return name
+    }
+
+    private fun convertValue(source: Any?, target: TypeDescriptor): Any? {
+        if (source == null) {
+            return when (target.type) {
+                Optional::class.java -> Optional.empty<Any?>()
+                else -> null
+            }
+        }
+
+        if (target.resolvableType.isInstance(source)) {
+            return source
+        }
+
+        if (target.type == Optional::class.java) {
+            val elementType = TypeDescriptor.valueOf(target.resolvableType.getGeneric(0).toClass())
+            return Optional.ofNullable(convertValue(source, elementType))
+        }
+
+        val sourceType = TypeDescriptor.forObject(source)
+        if (conversionService.canConvert(sourceType, target)) {
+            return conversionService.convert(source, sourceType, target)
+        }
+
+        throw DgsInvalidInputArgumentException("Unable to convert from ${source.javaClass} to ${target.type}")
+    }
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/FallbackEnvironmentArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/FallbackEnvironmentArgumentResolver.kt
@@ -16,12 +16,11 @@
 
 package com.netflix.graphql.dgs.internal.method
 
+import com.netflix.graphql.dgs.internal.InputObjectMapper
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.core.MethodParameter
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
-import org.springframework.core.convert.support.DefaultConversionService
-import org.springframework.util.ClassUtils
 
 /**
  * Resolves arguments based on the name by looking for any matching
@@ -29,19 +28,15 @@ import org.springframework.util.ClassUtils
  * a fallback if no other resolvers can handle the argument.
  */
 @Order(Ordered.LOWEST_PRECEDENCE)
-class FallbackEnvironmentArgumentResolver : ArgumentResolver {
-
-    private val conversionService = DefaultConversionService()
+class FallbackEnvironmentArgumentResolver(
+    inputObjectMapper: InputObjectMapper
+) : AbstractInputArgumentResolver(inputObjectMapper) {
 
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.parameterName != null
     }
 
-    override fun resolveArgument(parameter: MethodParameter, dfe: DataFetchingEnvironment): Any? {
-        val value = dfe.getArgument<Any?>(parameter.parameterName)
-        if (ClassUtils.isAssignableValue(parameter.parameterType, value)) {
-            return value
-        }
-        return conversionService.convert(value, parameter.parameterType)
+    override fun resolveArgumentName(parameter: MethodParameter): String? {
+        return parameter.parameterName
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/InputArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/InputArgumentResolver.kt
@@ -17,21 +17,9 @@
 package com.netflix.graphql.dgs.internal.method
 
 import com.netflix.graphql.dgs.InputArgument
-import com.netflix.graphql.dgs.exceptions.DgsInvalidInputArgumentException
 import com.netflix.graphql.dgs.internal.InputObjectMapper
-import graphql.schema.DataFetchingEnvironment
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.core.KotlinDetector
 import org.springframework.core.MethodParameter
 import org.springframework.core.annotation.MergedAnnotation
-import org.springframework.core.convert.TypeDescriptor
-import org.springframework.core.convert.converter.ConditionalGenericConverter
-import org.springframework.core.convert.converter.GenericConverter
-import org.springframework.core.convert.support.DefaultConversionService
-import java.util.Optional
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentMap
 
 /**
  * Resolves method arguments annotated with [InputArgument].
@@ -40,103 +28,22 @@ import java.util.concurrent.ConcurrentMap
  */
 class InputArgumentResolver(
     inputObjectMapper: InputObjectMapper
-) : ArgumentResolver {
-
-    companion object {
-        private val logger: Logger = LoggerFactory.getLogger(InputArgumentResolver::class.java)
-    }
-
-    private val argumentNameCache: ConcurrentMap<MethodParameter, String> = ConcurrentHashMap()
-    private val conversionService = DefaultConversionService()
-
-    init {
-        conversionService.addConverter(ObjectMapperConverter(inputObjectMapper))
-    }
-
-    private class ObjectMapperConverter(private val inputObjectMapper: InputObjectMapper) : ConditionalGenericConverter {
-        override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> {
-            return setOf(GenericConverter.ConvertiblePair(Map::class.java, Any::class.java))
-        }
-
-        override fun matches(sourceType: TypeDescriptor, targetType: TypeDescriptor): Boolean {
-            return sourceType.isMap && !targetType.isMap
-        }
-
-        override fun convert(source: Any?, sourceType: TypeDescriptor, targetType: TypeDescriptor): Any {
-            @Suppress("unchecked_cast")
-            val mapInput = source as Map<String, *>
-            return if (KotlinDetector.isKotlinType(targetType.type)) {
-                inputObjectMapper.mapToKotlinObject(mapInput, targetType.type.kotlin)
-            } else {
-                inputObjectMapper.mapToJavaObject(mapInput, targetType.type)
-            }
-        }
-    }
+) : AbstractInputArgumentResolver(inputObjectMapper) {
 
     override fun supportsParameter(parameter: MethodParameter): Boolean {
         return parameter.hasParameterAnnotation(InputArgument::class.java)
     }
 
-    override fun resolveArgument(parameter: MethodParameter, dfe: DataFetchingEnvironment): Any? {
-        val argumentName = getArgumentName(parameter)
-        val value: Any? = dfe.getArgument(argumentName)
-
-        val typeDescriptor = TypeDescriptor(parameter)
-
-        val convertedValue = convertValue(value, typeDescriptor)
-
-        if (convertedValue == null && dfe.fieldDefinition.arguments.none { it.name == argumentName }) {
-            logger.warn(
-                "Unknown argument '{}'",
-                argumentName
-            )
-        }
-
-        return convertedValue
-    }
-
-    private fun getArgumentName(parameter: MethodParameter): String {
-        val cachedName = argumentNameCache[parameter]
-        if (cachedName != null) {
-            return cachedName
-        }
-
+    override fun resolveArgumentName(parameter: MethodParameter): String? {
         val annotation = parameter.getParameterAnnotation(InputArgument::class.java)
             ?: throw IllegalArgumentException("Unsupported parameter type [${parameter.parameterType.name}]. supportsParameter should be called first.")
 
         val mergedAnnotation = MergedAnnotation.from(annotation).synthesize()
 
-        val name = mergedAnnotation.name.ifBlank { parameter.parameterName }
+        return mergedAnnotation.name.ifBlank { parameter.parameterName }
             ?: throw IllegalArgumentException(
                 "Name for argument of type [${parameter.nestedParameterType.name}}" +
                     " not specified, and parameter name information not found in class file either."
             )
-        argumentNameCache[parameter] = name
-        return name
-    }
-
-    private fun convertValue(source: Any?, target: TypeDescriptor): Any? {
-        if (source == null) {
-            return when (target.type) {
-                Optional::class.java -> Optional.empty<Any?>()
-                else -> null
-            }
-        }
-
-        if (target.resolvableType.isInstance(source)) {
-            return source
-        }
-
-        if (target.type == Optional::class.java) {
-            val elementType = TypeDescriptor.valueOf(target.resolvableType.getGeneric(0).toClass())
-            return Optional.ofNullable(convertValue(source, elementType))
-        }
-
-        val sourceType = TypeDescriptor.forObject(source)
-        if (conversionService.canConvert(sourceType, target)) {
-            return conversionService.convert(source, sourceType, target)
-        }
-
-        throw DgsInvalidInputArgumentException("Unable to convert from ${source.javaClass} to ${target.type}")
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/InputObjectMapperConverter.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/InputObjectMapperConverter.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.method
+
+import com.netflix.graphql.dgs.internal.InputObjectMapper
+import org.springframework.core.KotlinDetector
+import org.springframework.core.convert.TypeDescriptor
+import org.springframework.core.convert.converter.ConditionalGenericConverter
+import org.springframework.core.convert.converter.GenericConverter
+
+internal class InputObjectMapperConverter(private val inputObjectMapper: InputObjectMapper) : ConditionalGenericConverter {
+    override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> {
+        return setOf(GenericConverter.ConvertiblePair(Map::class.java, Any::class.java))
+    }
+
+    override fun matches(sourceType: TypeDescriptor, targetType: TypeDescriptor): Boolean {
+        return sourceType.isMap && !targetType.isMap
+    }
+
+    override fun convert(source: Any?, sourceType: TypeDescriptor, targetType: TypeDescriptor): Any {
+        @Suppress("unchecked_cast")
+        val mapInput = source as Map<String, *>
+        return if (KotlinDetector.isKotlinType(targetType.type)) {
+            inputObjectMapper.mapToKotlinObject(mapInput, targetType.type.kotlin)
+        } else {
+            inputObjectMapper.mapToJavaObject(mapInput, targetType.type)
+        }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CoroutineDataFetcherTest.kt
@@ -58,7 +58,7 @@ class CoroutineDataFetcherTest {
                 argumentResolvers = listOf(
                     InputArgumentResolver(DefaultInputObjectMapper()),
                     ContinuationArgumentResolver(),
-                    FallbackEnvironmentArgumentResolver()
+                    FallbackEnvironmentArgumentResolver(DefaultInputObjectMapper())
                 )
             ),
             dataFetcherResultProcessors = listOf(stubDataFetcherResultProcessor)

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandlerTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandlerTest.kt
@@ -41,7 +41,7 @@ internal class DefaultDataFetcherExceptionHandlerTest {
     fun securityError() {
         every { dataFetcherExceptionHandlerParameters.exception }.returns(AccessDeniedException("Denied"))
 
-        val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
+        val result = DefaultDataFetcherExceptionHandler().handleException(dataFetcherExceptionHandlerParameters).get()
         assertThat(result.errors.size).isEqualTo(1)
 
         val extensions = result.errors[0].extensions
@@ -55,7 +55,7 @@ internal class DefaultDataFetcherExceptionHandlerTest {
     fun normalError() {
         every { dataFetcherExceptionHandlerParameters.exception }.returns(RuntimeException("Something broke"))
 
-        val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
+        val result = DefaultDataFetcherExceptionHandler().handleException(dataFetcherExceptionHandlerParameters).get()
         assertThat(result.errors.size).isEqualTo(1)
 
         val extensions = result.errors[0].extensions
@@ -69,7 +69,7 @@ internal class DefaultDataFetcherExceptionHandlerTest {
     fun normalErrorWithSpecialCharacterString() {
         every { dataFetcherExceptionHandlerParameters.exception }.returns(RuntimeException("/bgt_budgetingProject/specificPass: not a PassId: bdgt%3Apass%2F3"))
 
-        val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
+        val result = DefaultDataFetcherExceptionHandler().handleException(dataFetcherExceptionHandlerParameters).get()
         assertThat(result.errors.size).isEqualTo(1)
 
         val extensions = result.errors[0].extensions
@@ -83,7 +83,7 @@ internal class DefaultDataFetcherExceptionHandlerTest {
     fun entityNotFoundException() {
         every { dataFetcherExceptionHandlerParameters.exception }.returns(DgsEntityNotFoundException("Movie with movieId '1' was not found"))
 
-        val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
+        val result = DefaultDataFetcherExceptionHandler().handleException(dataFetcherExceptionHandlerParameters).get()
         assertThat(result.errors.size).isEqualTo(1)
 
         val extensions = result.errors[0].extensions
@@ -97,7 +97,7 @@ internal class DefaultDataFetcherExceptionHandlerTest {
     fun badRequestException() {
         every { dataFetcherExceptionHandlerParameters.exception }.returns(DgsBadRequestException("Malformed movie request"))
 
-        val result = DefaultDataFetcherExceptionHandler().onException(dataFetcherExceptionHandlerParameters)
+        val result = DefaultDataFetcherExceptionHandler().handleException(dataFetcherExceptionHandlerParameters).get()
         assertThat(result.errors.size).isEqualTo(1)
 
         val extensions = result.errors[0].extensions


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Back port of PR #1102  to 4.10.x

Input argument without @InputArgument("input") stopped working
> Fix #1071
> This commit addresses the regression bug where, input arguments without the `@InputArgument` annotation were not
> being resolved.