### PR TITLE
Issue #1110: Add @Inherited to annotation type declarations

### DIFF
--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsCodeRegistry.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsCodeRegistry.java
@@ -17,9 +17,11 @@
 package com.netflix.graphql.dgs;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 
 /**
  * Annotation to mark a method a provider of a CodeRegistry, which is a programmatic way of creating a schema.
@@ -27,5 +29,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface DgsCodeRegistry {
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsComponent.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsComponent.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -33,5 +34,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Component
 @Qualifier("dgs")
+@Inherited
 public @interface DgsComponent {
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
@@ -20,6 +20,7 @@ import com.netflix.graphql.dgs.internal.utils.DataLoaderNameUtil;
 import org.springframework.stereotype.Component;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -32,6 +33,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Component
+@Inherited
 public @interface DgsDataLoader {
 
     /**

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDirective.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDirective.java
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs;
 import org.springframework.stereotype.Component;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,6 +30,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Component
+@Inherited
 public @interface DgsDirective {
     String name() default "";
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsMutation.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsMutation.java
@@ -21,6 +21,7 @@ import java.lang.annotation.*;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @DgsData(parentType = "Mutation")
+@Inherited
 public @interface DgsMutation {
     String field() default "";
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQuery.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQuery.java
@@ -21,6 +21,7 @@ import java.lang.annotation.*;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @DgsData(parentType = "Query")
+@Inherited
 public @interface DgsQuery {
     String field() default "";
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsRuntimeWiring.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsRuntimeWiring.java
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,5 +29,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface DgsRuntimeWiring {
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsScalar.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsScalar.java
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs;
 import org.springframework.stereotype.Component;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -30,6 +31,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Component
+@Inherited
 public @interface DgsScalar {
     String name();
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsTypeDefinitionRegistry.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsTypeDefinitionRegistry.java
@@ -16,15 +16,15 @@
 
 package com.netflix.graphql.dgs;
 
-import graphql.schema.idl.TypeDefinitionRegistry;
-
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface DgsTypeDefinitionRegistry {
 
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsTypeResolver.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsTypeResolver.java
@@ -17,12 +17,14 @@
 package com.netflix.graphql.dgs;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface DgsTypeResolver {
     String name();
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/InputArgument.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/InputArgument.java
@@ -19,12 +19,14 @@ package com.netflix.graphql.dgs;
 import org.springframework.core.annotation.AliasFor;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface InputArgument {
     @AliasFor("name")
     String value() default "";

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/Internal.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/Internal.java
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -23,11 +24,11 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.ElementType.FIELD;
 
-
 /**
  * This represents code considered internal to the DGS framework and therefore its API is not stable between releases.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {CONSTRUCTOR, METHOD, TYPE, FIELD})
+@Inherited
 public @interface Internal {
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/OpenDirective.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/OpenDirective.kt
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs;
+package com.netflix.graphql.dgs
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.idl.SchemaDirectiveWiring
+import graphql.schema.idl.SchemaDirectiveWiringEnvironment
 
-@Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
-@DgsData(parentType = "Subscription")
-@Inherited
-public @interface DgsSubscription {
-    String field() default "";
+/**
+ *  An `@DgsDirective` example for test purpose.
+ */
+@DgsDirective
+open class OpenDirective : SchemaDirectiveWiring {
+    override fun onField(env: SchemaDirectiveWiringEnvironment<GraphQLFieldDefinition>): GraphQLFieldDefinition {
+        return env.element
+    }
 }


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
---
- #1110
- Allow components annotated with `Dgs*` annotations proxies/subclasses to inherit these annotations.

Alternatives considered
---
- Use Spring [AnnotationUtils](https://docs.spring.io/spring-framework/docs/3.1.x/javadoc-api/org/springframework/core/annotation/AnnotationUtils.html)

