### PR TITLE
feature: Add configurable GraphiQl title property

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebfluxConfigurationProperties.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebfluxConfigurationProperties.kt
@@ -36,7 +36,9 @@ class DgsWebfluxConfigurationProperties(
      */
     data class DgsGraphiQLConfigurationProperties(
         /** Path to the GraphiQL endpoint without trailing slash. */
-        @DefaultValue("/graphiql") var path: String = "/graphiql"
+        @DefaultValue("/graphiql") var path: String = "/graphiql",
+        /** GraphiQL title */
+        @DefaultValue("Simple GraphiQL Example") var title: String = "Simple GraphiQL Example"
     )
     /**
      * Configuration properties for the schema-json endpoint.

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphiQlConfigurer.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphiQlConfigurer.kt
@@ -32,17 +32,17 @@ import java.nio.charset.StandardCharsets
 class GraphiQlConfigurer(private val configProps: DgsWebfluxConfigurationProperties) : WebFluxConfigurer {
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
         val graphqlPath = configProps.path
+        val graphiQLTitle = configProps.graphiql.title
         registry
             .addResourceHandler(configProps.graphiql.path + "/**")
             .addResourceLocations("classpath:/static/graphiql/")
             .resourceChain(true)
             .addResolver(PathResourceResolver())
-            .addTransformer(TokenReplacingTransformer("<DGS_GRAPHQL_PATH>", graphqlPath, configProps))
+            .addTransformer(TokenReplacingTransformer(mapOf("<DGS_GRAPHQL_PATH>" to graphqlPath, "<DGS_GRAPHIQL_TITLE>" to graphiQLTitle), configProps))
     }
 
     class TokenReplacingTransformer(
-        private val replaceToken: String,
-        private val replaceValue: String,
+        private val replaceMap: Map<String, String>,
         private val configProps: DgsWebfluxConfigurationProperties
     ) :
         ResourceTransformer {
@@ -54,11 +54,12 @@ class GraphiQlConfigurer(private val configProps: DgsWebfluxConfigurationPropert
             transformerChain: ResourceTransformerChain
         ): Mono<Resource> {
             if (exchange.request.uri.toASCIIString().endsWith(configProps.graphiql.path + "/index.html")) {
-                val content = resource.inputStream.bufferedReader().use(BufferedReader::readText)
+                var content = resource.inputStream.bufferedReader().use(BufferedReader::readText)
+                replaceMap.forEach { content = content.replace(it.key, it.value) }
                 return Mono.just(
                     TransformedResource(
                         resource,
-                        content.replace(replaceToken, replaceValue).toByteArray(
+                        content.toByteArray(
                             StandardCharsets.UTF_8
                         )
                     )

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/static/graphiql/index.html
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/static/graphiql/index.html
@@ -16,7 +16,7 @@
 
 <html>
 <head>
-    <title>Simple GraphiQL Example</title>
+    <title><DGS_GRAPHIQL_TITLE></title>
     <link href="https://unpkg.com/graphiql@1.5.12/graphiql.min.css" rel="stylesheet" />
 </head>
 <body style="margin: 0;">

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphiQlCustomTitle.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphiQlCustomTitle.kt
@@ -26,31 +26,22 @@ import org.springframework.web.reactive.config.EnableWebFlux
 
 @AutoConfigureWebTestClient
 @EnableWebFlux
-@SpringBootTest(classes = [DgsWebFluxAutoConfiguration::class, DgsAutoConfiguration::class, WebRequestTestWithCustomEndpoint.ExampleImplementation::class])
-class GraphiQlUI {
+@SpringBootTest(
+    classes = [DgsWebFluxAutoConfiguration::class, DgsAutoConfiguration::class, WebRequestTestWithCustomEndpoint.ExampleImplementation::class],
+    properties = ["dgs.graphql.graphiql.title=Custom GraphiQL Title"]
+)
+class GraphiQlCustomTitle {
     @Autowired
     lateinit var webTestClient: WebTestClient
 
     @Test
-    fun `GraphiQL should be availble`() {
-        webTestClient.get().uri("/graphiql/index.html").exchange()
-            .expectStatus().isOk
-    }
-
-    @Test
-    fun `graphiql should redirect to correct page`() {
-        webTestClient.get().uri("/graphiql").exchange()
-            .expectStatus().isPermanentRedirect
-    }
-
-    @Test
-    fun `graphiql title should be default`() {
+    fun customGraphiQlTitle() {
         webTestClient.get().uri("/graphiql/index.html")
             .exchange()
             .expectStatus()
             .isOk
             .expectBody()
             .toString()
-            .contains("Simple GraphiQL Example")
+            .contains("Custom GraphiQL Title")
     }
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
@@ -39,7 +39,9 @@ data class DgsWebMvcConfigurationProperties(
      */
     data class DgsGraphiQLConfigurationProperties(
         /** Path to the GraphiQL endpoint without trailing slash. */
-        @DefaultValue("/graphiql") var path: String = "/graphiql"
+        @DefaultValue("/graphiql") var path: String = "/graphiql",
+        /** GraphiQL title */
+        @DefaultValue("Simple GraphiQL Example") var title: String = "Simple GraphiQL Example"
     )
     /**
      * Configuration properties for the schema-json endpoint.

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLConfigurer.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLConfigurer.kt
@@ -31,7 +31,7 @@ import org.springframework.web.servlet.resource.ResourceTransformerChain
 import org.springframework.web.servlet.resource.TransformedResource
 import java.io.BufferedReader
 import java.io.IOException
-import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.charset.StandardCharsets
 import javax.servlet.ServletContext
 import javax.servlet.http.HttpServletRequest
 
@@ -57,10 +57,10 @@ open class GraphiQLConfigurer(
             .setCachePeriod(3600)
             .resourceChain(true)
             .addResolver(PathResourceResolver())
-            .addTransformer(TokenReplacingTransformer("<DGS_GRAPHQL_PATH>", graphqlPath))
+            .addTransformer(TokenReplacingTransformer(mapOf("<DGS_GRAPHQL_PATH>" to graphqlPath, "<DGS_GRAPHIQL_TITLE>" to configProps.graphiql.title)))
     }
 
-    class TokenReplacingTransformer(private val replaceToken: String, private val replaceValue: String) :
+    class TokenReplacingTransformer(private val replaceMap: Map<String, String>) :
         ResourceTransformer {
 
         @Throws(IOException::class)
@@ -70,8 +70,9 @@ open class GraphiQLConfigurer(
             transformerChain: ResourceTransformerChain
         ): Resource {
             if (request.requestURI.orEmpty().endsWith(PATH_TO_GRAPHIQL_INDEX_HTML)) {
-                val content = resource.inputStream.bufferedReader().use(BufferedReader::readText)
-                return TransformedResource(resource, content.replace(replaceToken, replaceValue).toByteArray(UTF_8))
+                var content = resource.inputStream.bufferedReader().use(BufferedReader::readText)
+                replaceMap.forEach { content = content.replace(it.key, it.value) }
+                return TransformedResource(resource, content.toByteArray(StandardCharsets.UTF_8))
             }
             return resource
         }

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,6 +17,12 @@
       "type": "java.lang.Boolean",
       "description": "Enables recommended GDS GraphQL HTTP Header validation rules.",
       "defaultValue": "true"
+    },
+    {
+      "name": "dgs.graphql.graphiql.title",
+      "type": "java.lang.String",
+      "description": "Customize the GraphiQL title",
+      "defaultValue": "Simple GraphiQL Example"
     }
   ]
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/static/graphiql/index.html
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/static/graphiql/index.html
@@ -16,7 +16,7 @@
 
 <html>
 <head>
-    <title>Simple GraphiQL Example</title>
+    <title><DGS_GRAPHIQL_TITLE></title>
     <link href="https://unpkg.com/graphiql@1.5.12/graphiql.min.css" rel="stylesheet" />
 </head>
 <body style="margin: 0;">

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesTest.kt
@@ -50,6 +50,18 @@ class DgsWebMvcConfigurationPropertiesTest {
     }
 
     @Test
+    fun graphiQLTitleDefault() {
+        val properties = bind("dgs.graphql.graphiql.title", "Simple GraphiQL Example")
+        assertThat(properties.graphiql.title).isEqualTo("Simple GraphiQL Example")
+    }
+
+    @Test
+    fun graphiQLTitleCustom() {
+        val properties = bind("dgs.graphql.graphiql.title", "Custom GraphiQL Example")
+        assertThat(properties.graphiql.title).isEqualTo("Custom GraphiQL Example")
+    }
+
+    @Test
     fun schemaJsonPathDefault() {
         val properties = bind(Collections.emptyMap())
         assertThat(properties.schemaJson.path).isEqualTo("/schema.json")
@@ -66,10 +78,12 @@ class DgsWebMvcConfigurationPropertiesTest {
         val propertyValues: MutableMap<String?, String?> = HashMap()
         propertyValues["dgs.graphql.path"] = "/private/gql"
         propertyValues["dgs.graphql.graphiql.path"] = "/private/giql"
+        propertyValues["dgs.graphql.graphiql.title"] = "Simple GraphiQL Example"
         propertyValues["dgs.graphql.schema-json.path"] = "/private/sj"
         val properties = bind(propertyValues)
         assertThat(properties.path).isEqualTo("/private/gql")
         assertThat(properties.graphiql.path).isEqualTo("/private/giql")
+        assertThat(properties.graphiql.title).isEqualTo("Simple GraphiQL Example")
         assertThat(properties.schemaJson.path).isEqualTo("/private/sj")
     }
 

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLTitleConfigWithCustomGraphiQLTitleTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLTitleConfigWithCustomGraphiQLTitleTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.autoconfigure
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["dgs.graphql.graphiql.title=Custom GraphiQL Title"]
+)
+class GraphiQLTitleConfigWithCustomGraphiQLTitleTest(@Autowired val restTemplate: TestRestTemplate) {
+
+    @Test
+    fun customGraphiQLTitle() {
+        val entity = restTemplate.getForEntity(
+            "/graphiql",
+            String::class.java
+        )
+        assertTrue(entity.statusCode.is2xxSuccessful)
+        Assertions.assertThat(entity.body).isNotNull.contains("Custom GraphiQL Title")
+    }
+}

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLTitleConfigWithDefaultGraphiQLTitleTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLTitleConfigWithDefaultGraphiQLTitleTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.autoconfigure
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class GraphiQLTitleConfigWithDefaultGraphiQLTitleTest(@Autowired val restTemplate: TestRestTemplate) {
+
+    @Test
+    fun defaultGraphiQLTitle() {
+        val entity = restTemplate.getForEntity(
+            "/graphiql",
+            String::class.java
+        )
+        assertTrue(entity.statusCode.is2xxSuccessful)
+        Assertions.assertThat(entity.body).isNotNull.contains("Simple GraphiQL Example")
+    }
+}


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This PR is the feature that `add configuration property to be able to change GraphiQl title`
Both support `webmvc` and `webflux`

https://github.com/Netflix/dgs-framework/issues/602

Alternatives considered
----

1. Add configuration 
2. When requesting `graphiql` endpoint, replace the placeholder of title
