### PR TITLE
feat: customise the subscription endpoint

### DIFF
--- a/graphql-dgs-subscriptions-websockets-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/build.gradle.kts
@@ -20,6 +20,5 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework:spring-websocket")
-    implementation("jakarta.annotation:jakarta.annotation-api")
 
 }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/build.gradle.kts
@@ -20,4 +20,6 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework:spring-websocket")
+    implementation("jakarta.annotation:jakarta.annotation-api")
+
 }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketAutoConfig.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketAutoConfig.kt
@@ -18,6 +18,7 @@ package com.netflix.graphql.dgs.subscriptions.websockets
 
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.socket.WebSocketHandler
@@ -29,6 +30,7 @@ import org.springframework.web.socket.server.support.DefaultHandshakeHandler
 
 @Configuration
 @ConditionalOnWebApplication
+@EnableConfigurationProperties(DgsWebSocketConfigurationProperties::class)
 open class DgsWebSocketAutoConfig {
     @Bean
     open fun webSocketHandler(@Suppress("SpringJavaInjectionPointsAutowiringInspection") dgsQueryExecutor: DgsQueryExecutor): WebSocketHandler {
@@ -39,12 +41,13 @@ open class DgsWebSocketAutoConfig {
     @EnableWebSocket
     internal open class WebSocketConfig(
         @Suppress("SpringJavaInjectionPointsAutowiringInspection") private val webSocketHandler: WebSocketHandler,
-        private val handshakeInterceptor: HandshakeInterceptor
+        private val handshakeInterceptor: HandshakeInterceptor,
+        private val configProps: DgsWebSocketConfigurationProperties
     ) : WebSocketConfigurer {
 
         override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
             val handshakeHandler = DefaultHandshakeHandler()
-            registry.addHandler(webSocketHandler, "/subscriptions").setHandshakeHandler(handshakeHandler)
+            registry.addHandler(webSocketHandler, configProps.path).setHandshakeHandler(handshakeHandler)
                 .addInterceptors(handshakeInterceptor)
                 .setAllowedOrigins("*")
         }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketConfigurationProperties.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketConfigurationProperties.kt
@@ -38,5 +38,4 @@ data class DgsWebSocketConfigurationProperties(
             throw IllegalArgumentException("$pathProperty must start with '/' and not end with '/' but was '$path'")
         }
     }
-
 }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketConfigurationProperties.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketConfigurationProperties.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.subscriptions.websockets
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.bind.DefaultValue
+import javax.annotation.PostConstruct
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "dgs.graphql.websocket")
+@Suppress("ConfigurationProperties")
+data class DgsWebSocketConfigurationProperties(
+    @DefaultValue("/subscriptions") var path: String = "/subscriptions"
+) {
+
+    @PostConstruct
+    fun validatePaths() {
+        validatePath(this.path, "dgs.graphql.websocket.path")
+    }
+
+    private fun validatePath(path: String, pathProperty: String) {
+        if (path != "/" && (!path.startsWith("/") || path.endsWith("/"))) {
+            throw IllegalArgumentException("$pathProperty must start with '/' and not end with '/' but was '$path'")
+        }
+    }
+
+}

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/autoconfigure/DgsWebSocketConfigurationPropertiesTest.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/autoconfigure/DgsWebSocketConfigurationPropertiesTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.subscriptions.websockets.autoconfigure
+
+import com.netflix.graphql.dgs.subscriptions.websockets.DgsWebSocketConfigurationProperties
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+import java.util.*
+
+class DgsWebSocketConfigurationPropertiesTest {
+
+    @Test
+    fun graphQLPathDefault() {
+        val properties = bind(Collections.emptyMap())
+        Assertions.assertThat(properties.path).isEqualTo("/subscriptions")
+    }
+
+    @Test
+    fun graphQLPathCustom() {
+        val properties = bind("dgs.graphql.websocket.path", "/private/subscriptions")
+        Assertions.assertThat(properties.path).isEqualTo("/private/subscriptions")
+    }
+
+    private fun bind(name: String, value: String): DgsWebSocketConfigurationProperties {
+        return bind(Collections.singletonMap(name, value))
+    }
+
+    private fun bind(map: Map<String?, String?>): DgsWebSocketConfigurationProperties {
+        val source: ConfigurationPropertySource = MapConfigurationPropertySource(map)
+        return Binder(source).bindOrCreate("dgs.graphql.websocket", DgsWebSocketConfigurationProperties::class.java)
+    }
+
+}

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/autoconfigure/DgsWebSocketConfigurationPropertiesTest.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/autoconfigure/DgsWebSocketConfigurationPropertiesTest.kt
@@ -27,13 +27,13 @@ import java.util.*
 class DgsWebSocketConfigurationPropertiesTest {
 
     @Test
-    fun graphQLPathDefault() {
+    fun websocketPathDefault() {
         val properties = bind(Collections.emptyMap())
         Assertions.assertThat(properties.path).isEqualTo("/subscriptions")
     }
 
     @Test
-    fun graphQLPathCustom() {
+    fun websocketPathCustom() {
         val properties = bind("dgs.graphql.websocket.path", "/private/subscriptions")
         Assertions.assertThat(properties.path).isEqualTo("/private/subscriptions")
     }
@@ -46,5 +46,4 @@ class DgsWebSocketConfigurationPropertiesTest {
         val source: ConfigurationPropertySource = MapConfigurationPropertySource(map)
         return Binder(source).bindOrCreate("dgs.graphql.websocket", DgsWebSocketConfigurationProperties::class.java)
     }
-
 }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/autoconfigure/DgsWebSocketConfigurationPropertiesValidationTest.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/autoconfigure/DgsWebSocketConfigurationPropertiesValidationTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.subscriptions.websockets.autoconfigure
+
+import com.netflix.graphql.dgs.subscriptions.websockets.DgsWebSocketConfigurationProperties
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+
+class DgsWebSocketConfigurationPropertiesValidationTest {
+
+    private val context = ApplicationContextRunner().withConfiguration(
+        AutoConfigurations.of(
+            MockConfigPropsAutoConfiguration::class.java
+        )
+    )!!
+
+    @Test
+    fun webSocketValidCustomPath() {
+        context
+            .withPropertyValues("dgs.graphql.websocket.path: /pws")
+            .run { ctx ->
+                Assertions.assertThat(ctx).hasNotFailed()
+            }
+    }
+
+    @Test
+    fun graphiqlControllerInvalidCustomPathEndsWithSlash() {
+        context
+            .withPropertyValues("dgs.graphql.websocket.path: /pws/")
+            .run { ctx ->
+                Assertions.assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("dgs.graphql.websocket.path must start with '/' and not end with '/'")
+            }
+    }
+
+
+    @Configuration
+    @EnableConfigurationProperties(DgsWebSocketConfigurationProperties::class)
+    open class MockConfigPropsAutoConfiguration
+}

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/autoconfigure/DgsWebSocketConfigurationPropertiesValidationTest.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/autoconfigure/DgsWebSocketConfigurationPropertiesValidationTest.kt
@@ -42,14 +42,14 @@ class DgsWebSocketConfigurationPropertiesValidationTest {
     }
 
     @Test
-    fun graphiqlControllerInvalidCustomPathEndsWithSlash() {
+    fun websocketInvalidCustomPathEndsWithSlash() {
         context
             .withPropertyValues("dgs.graphql.websocket.path: /pws/")
             .run { ctx ->
-                Assertions.assertThat(ctx).hasFailed().failure.getRootCause().hasMessageContaining("dgs.graphql.websocket.path must start with '/' and not end with '/'")
+                Assertions.assertThat(ctx).hasFailed()
+                    .failure.rootCause.hasMessageContaining("dgs.graphql.websocket.path must start with '/' and not end with '/'")
             }
     }
-
 
     @Configuration
     @EnableConfigurationProperties(DgsWebSocketConfigurationProperties::class)


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

add `dgs.graphql.websocket.path` to customise the subscription endpoint
Issue #906

Alternatives considered
----


