### PR TITLE
Improve exception message for InvalidTypeResolverException

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -447,7 +447,7 @@ class DgsSchemaProvider(
                         val instance = env.getObject<Any>()
                         val resolvedType = env.schema.getObjectType(instance::class.java.simpleName)
                         resolvedType
-                            ?: throw InvalidTypeResolverException("The default type resolver could not find a suitable Java type for GraphQL type `${instance::class.java.simpleName}. Provide a @DgsTypeResolver.`")
+                            ?: throw InvalidTypeResolverException("The default type resolver could not find a suitable Java type for GraphQL interface type `${it}`. Provide a @DgsTypeResolver for ${instance::class.java.simpleName}.")
                     }
             )
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -449,7 +449,7 @@ class DgsSchemaProvider(
             .filter { (_, typeDef) -> typeDef is UnionTypeDefinition }
             .map { (name, _) -> name }
             .filter { it !in registeredTypeResolvers }
-       checkTypeResolverExists(unregisteredUnionTypes, runtimeWiringBuilder, "union")
+        checkTypeResolverExists(unregisteredUnionTypes, runtimeWiringBuilder, "union")
     }
 
     private fun checkTypeResolverExists(

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -447,7 +447,7 @@ class DgsSchemaProvider(
                         val instance = env.getObject<Any>()
                         val resolvedType = env.schema.getObjectType(instance::class.java.simpleName)
                         resolvedType
-                            ?: throw InvalidTypeResolverException("The default type resolver could not find a suitable Java type for GraphQL interface type `${it}`. Provide a @DgsTypeResolver for ${instance::class.java.simpleName}.")
+                            ?: throw InvalidTypeResolverException("The default type resolver could not find a suitable Java type for GraphQL interface type `$it`. Provide a @DgsTypeResolver for ${instance::class.java.simpleName}.")
                     }
             )
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -435,11 +435,28 @@ class DgsSchemaProvider(
 
         // Add a fallback type resolver for types that don't have a type resolver registered.
         // This works when the Java type has the same name as the GraphQL type.
-        val unregisteredTypes = mergedRegistry.types()
+        // Check for unregistered interface types
+        val unregisteredInterfaceTypes = mergedRegistry.types()
             .asSequence()
-            .filter { (_, typeDef) -> typeDef is InterfaceTypeDefinition || typeDef is UnionTypeDefinition }
+            .filter { (_, typeDef) -> typeDef is InterfaceTypeDefinition }
             .map { (name, _) -> name }
             .filter { it !in registeredTypeResolvers }
+        checkTypeResolverExists(unregisteredInterfaceTypes, runtimeWiringBuilder, "interface")
+
+        // Check for unregistered union types
+        val unregisteredUnionTypes = mergedRegistry.types()
+            .asSequence()
+            .filter { (_, typeDef) -> typeDef is UnionTypeDefinition }
+            .map { (name, _) -> name }
+            .filter { it !in registeredTypeResolvers }
+       checkTypeResolverExists(unregisteredUnionTypes, runtimeWiringBuilder, "union")
+    }
+
+    private fun checkTypeResolverExists(
+        unregisteredTypes: Sequence<String>,
+        runtimeWiringBuilder: RuntimeWiring.Builder,
+        typeName: String
+    ) {
         unregisteredTypes.forEach {
             runtimeWiringBuilder.type(
                 TypeRuntimeWiring.newTypeWiring(it)
@@ -447,7 +464,7 @@ class DgsSchemaProvider(
                         val instance = env.getObject<Any>()
                         val resolvedType = env.schema.getObjectType(instance::class.java.simpleName)
                         resolvedType
-                            ?: throw InvalidTypeResolverException("The default type resolver could not find a suitable Java type for GraphQL interface type `$it`. Provide a @DgsTypeResolver for ${instance::class.java.simpleName}.")
+                            ?: throw InvalidTypeResolverException("The default type resolver could not find a suitable Java type for GraphQL $typeName type `$it`. Provide a @DgsTypeResolver for `${instance::class.java.simpleName}`.")
                     }
             )
         }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -39,7 +39,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe): **Improve exception message for InvalidTypeResolverException**

Changes in this PR
----
Improve exception message for InvalidTypeResolverException

_Describe the new behavior from this PR, and why it's needed_
Issue [#312](https://github.com/Netflix/dgs-framework/issues/312)

Alternatives considered
----

1. Provide GraphQL interface type in exception message
2. Provide `ObjectNode` which needs to be mapped by type resolver

