### PR TITLE
feat: adding pagination description

### DIFF
--- a/graphql-dgs-pagination/src/main/kotlin/com/netflix/graphql/dgs/pagination/DgsPaginationTypeDefinitionRegistry.kt
+++ b/graphql-dgs-pagination/src/main/kotlin/com/netflix/graphql/dgs/pagination/DgsPaginationTypeDefinitionRegistry.kt
@@ -32,8 +32,10 @@ class DgsPaginationTypeDefinitionRegistry {
 
         val typeDefinitionRegistry = TypeDefinitionRegistry()
         typeDefinitionRegistry.addAll(connectionTypes)
-        if (! schemaRegistry.directiveDefinitions.contains("connection")) {
-            val directive = DirectiveDefinition.newDirectiveDefinition().name("connection")
+        if (!schemaRegistry.directiveDefinitions.contains("connection")) {
+            val directive = DirectiveDefinition.newDirectiveDefinition()
+                .name("connection")
+                .description(createDescription("Connection"))
                 .directiveLocation(DirectiveLocation.newDirectiveLocation().name(Introspection.DirectiveLocation.OBJECT.name).build()).build()
             typeDefinitionRegistry.add(directive)
         }
@@ -60,26 +62,39 @@ class DgsPaginationTypeDefinitionRegistry {
     private fun createConnection(type: String): ObjectTypeDefinition {
         return ObjectTypeDefinition.newObjectTypeDefinition()
             .name(type + "Connection")
-            .fieldDefinition(FieldDefinition("edges", ListType(TypeName(type + "Edge"))))
-            .fieldDefinition(FieldDefinition("pageInfo", TypeName("PageInfo")))
+            .description(createDescription(type + " Connection"))
+            .fieldDefinition(createFieldDefinition("edges", ListType(TypeName(type + "Edge"))))
+            .fieldDefinition(createFieldDefinition("pageInfo", TypeName("PageInfo")))
             .build()
     }
 
     private fun createEdge(type: String): ObjectTypeDefinition {
         return ObjectTypeDefinition.newObjectTypeDefinition()
             .name(type + "Edge")
-            .fieldDefinition(FieldDefinition("cursor", TypeName("String")))
-            .fieldDefinition(FieldDefinition("node", TypeName(type)))
+            .description(createDescription(type + " Edge"))
+            .fieldDefinition(createFieldDefinition("cursor", TypeName("String")))
+            .fieldDefinition(createFieldDefinition("node", TypeName(type)))
             .build()
     }
 
     private fun createPageInfo(): ObjectTypeDefinition {
         return ObjectTypeDefinition.newObjectTypeDefinition()
             .name("PageInfo")
-            .fieldDefinition(FieldDefinition("hasPreviousPage", NonNullType(TypeName("Boolean"))))
-            .fieldDefinition(FieldDefinition("hasNextPage", NonNullType(TypeName("Boolean"))))
-            .fieldDefinition(FieldDefinition("startCursor", TypeName("String")))
-            .fieldDefinition(FieldDefinition("endCursor", TypeName("String")))
+            .description(createDescription("PageInfo"))
+            .fieldDefinition(createFieldDefinition("hasPreviousPage", NonNullType(TypeName("Boolean"))))
+            .fieldDefinition(createFieldDefinition("hasNextPage", NonNullType(TypeName("Boolean"))))
+            .fieldDefinition(createFieldDefinition("startCursor", TypeName("String")))
+            .fieldDefinition(createFieldDefinition("endCursor", TypeName("String")))
             .build()
+    }
+
+    private fun createFieldDefinition(name: String, type: Type<*>): FieldDefinition {
+        return FieldDefinition(name, type).transform {
+            it.description(createDescription("Field $name"))
+        }
+    }
+
+    private fun createDescription(content: String): Description {
+        return Description(content, SourceLocation.EMPTY, false)
     }
 }

--- a/graphql-dgs-pagination/src/test/kotlin/com/netflix/graphql/dgs/pagination/DgsPaginationTypeDefinitionRegistryTest.kt
+++ b/graphql-dgs-pagination/src/test/kotlin/com/netflix/graphql/dgs/pagination/DgsPaginationTypeDefinitionRegistryTest.kt
@@ -55,9 +55,12 @@ class DgsPaginationTypeDefinitionRegistryTest {
         assertThat(addedDirective).isNotNull
         assertThat(addedDirective!!.directiveLocations[0].name).isEqualTo(Introspection.DirectiveLocation.OBJECT.name)
 
-        assertThat(paginatedTypeRegistry.types()["MovieConnection"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["MovieEdge"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["PageInfo"]).isNotNull
+        val movieConnectionType = (paginatedTypeRegistry.types()["MovieConnection"] as ObjectTypeDefinition)
+        assertThat(movieConnectionType).isNotNull.extracting { it.description }.isNotNull
+        val movieEdgeType = (paginatedTypeRegistry.types()["MovieEdge"] as ObjectTypeDefinition)
+        assertThat(movieEdgeType).isNotNull.extracting { it.description }.isNotNull
+        val pageInfoType = (paginatedTypeRegistry.types()["PageInfo"] as ObjectTypeDefinition)
+        assertThat(pageInfoType).isNotNull.extracting { it.description }.isNotNull
 
         val movieConnection = (paginatedTypeRegistry.types()["MovieConnection"] as ObjectTypeDefinition)
         val edgesField = movieConnection.fieldDefinitions.find { it.name == "edges" } as FieldDefinition
@@ -105,8 +108,10 @@ class DgsPaginationTypeDefinitionRegistryTest {
         val typeRegistry = SchemaParser().parse(schema)
         val paginatedTypeRegistry = paginationTypeRegistry.registry(typeRegistry)
 
-        assertThat(paginatedTypeRegistry.types()["MovieConnection"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["MovieEdge"]).isNotNull
+        val movieConnectionType = (paginatedTypeRegistry.types()["MovieConnection"] as ObjectTypeDefinition)
+        assertThat(movieConnectionType).isNotNull.extracting { it.description }.isNotNull
+        val movieEdgeType = (paginatedTypeRegistry.types()["MovieEdge"] as ObjectTypeDefinition)
+        assertThat(movieEdgeType).isNotNull.extracting { it.description }.isNotNull
         assertThat(paginatedTypeRegistry.types()["PageInfo"]).isNull()
     }
 
@@ -132,11 +137,16 @@ class DgsPaginationTypeDefinitionRegistryTest {
         val typeRegistry = SchemaParser().parse(schema)
         val paginatedTypeRegistry = paginationTypeRegistry.registry(typeRegistry)
 
-        assertThat(paginatedTypeRegistry.types()["IMovieConnection"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["IMovieEdge"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["ScaryMovieConnection"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["ScaryMovieEdge"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["PageInfo"]).isNotNull
+        val movieConnectionType = (paginatedTypeRegistry.types()["IMovieConnection"] as ObjectTypeDefinition)
+        assertThat(movieConnectionType).isNotNull.extracting { it.description }.isNotNull
+        val movieEdgeType = (paginatedTypeRegistry.types()["IMovieEdge"] as ObjectTypeDefinition)
+        assertThat(movieEdgeType).isNotNull.extracting { it.description }.isNotNull
+        val scaryMovieConnectionType = (paginatedTypeRegistry.types()["ScaryMovieConnection"] as ObjectTypeDefinition)
+        assertThat(scaryMovieConnectionType).isNotNull.extracting { it.description }.isNotNull
+        val scaryMovieEdgeType = (paginatedTypeRegistry.types()["ScaryMovieEdge"] as ObjectTypeDefinition)
+        assertThat(scaryMovieEdgeType).isNotNull.extracting { it.description }.isNotNull
+        val pageInfoType = (paginatedTypeRegistry.types()["PageInfo"] as ObjectTypeDefinition)
+        assertThat(pageInfoType).isNotNull.extracting { it.description }.isNotNull
     }
 
     @Test
@@ -175,10 +185,15 @@ class DgsPaginationTypeDefinitionRegistryTest {
         val typeRegistry = SchemaParser().parse(schema)
         val paginatedTypeRegistry = paginationTypeRegistry.registry(typeRegistry)
 
-        assertThat(paginatedTypeRegistry.types()["IMovieConnection"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["IMovieEdge"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["ScaryMovieConnection"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["ScaryMovieEdge"]).isNotNull
-        assertThat(paginatedTypeRegistry.types()["PageInfo"]).isNotNull
+        val movieConnectionType = (paginatedTypeRegistry.types()["IMovieConnection"] as ObjectTypeDefinition)
+        assertThat(movieConnectionType).isNotNull.extracting { it.description }.isNotNull
+        val movieEdgeType = (paginatedTypeRegistry.types()["IMovieEdge"] as ObjectTypeDefinition)
+        assertThat(movieEdgeType).isNotNull.extracting { it.description }.isNotNull
+        val scaryMovieConnectionType = (paginatedTypeRegistry.types()["ScaryMovieConnection"] as ObjectTypeDefinition)
+        assertThat(scaryMovieConnectionType).isNotNull.extracting { it.description }.isNotNull
+        val scaryMovieEdgeType = (paginatedTypeRegistry.types()["ScaryMovieConnection"] as ObjectTypeDefinition)
+        assertThat(scaryMovieEdgeType).isNotNull.extracting { it.description }.isNotNull
+        val pageInfoType = (paginatedTypeRegistry.types()["ScaryMovieConnection"] as ObjectTypeDefinition)
+        assertThat(pageInfoType).isNotNull.extracting { it.description }.isNotNull
     }
 }


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider [creating a discussion](https://github.com/Netflix/dgs-framework/discussions/1127) on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
The [Relay Pagination](https://netflix.github.io/dgs/advanced/relay-pagination/) does not generate types with description.

```
type MessageConnection {
    edges: [MessageEdge]
    pageInfo: PageInfo
}

type MessageEdge {
    node: Message
    cursor: String
}

type PageInfo {
    hasPreviousPage: Boolean!
    hasNextPage: Boolean!
    startCursor: String
    endCursor: String
}
```

In my use case, I need to run a [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter) before to publish the schema to my GraphQL Schema Registry. Without these descriptions, I have been receiving some lint errors like [fields-have-descriptions](https://github.com/cjoudrey/graphql-schema-linter#fields-have-descriptions).

With this improvement, the output will be:

```
"MessageConnection"
type MessageConnection {
  "Field edges"
  edges: [MessageEdge]
  "Field pageInfo"
  pageInfo: PageInfo
}

"MessageEdge"
type MessageEdge {
    "Field node"
    node: Message
    "Field cursor"
    cursor: String
}

"PageInfo"
type PageInfo {
    "Field hasPreviousPage"
    hasPreviousPage: Boolean!
    "Field hasNextPage"
    hasNextPage: Boolean!
    "Field startCursor"
    startCursor: String
    "Field endCursor"
    endCursor: String
}
```


