### PR TITLE
Use registered dataloader name (instead of annotation's name) consistently.

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -62,21 +62,21 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
 
         val dataLoaderRegistry = DataLoaderRegistry()
         batchLoaders.forEach {
-            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, dataLoaderRegistry))
+            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, it.name, dataLoaderRegistry))
         }
         mappedBatchLoaders.forEach {
-            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, dataLoaderRegistry))
+            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, it.name, dataLoaderRegistry))
         }
         batchLoadersWithContext.forEach {
             dataLoaderRegistry.register(
                 it.name,
-                createDataLoader(it.theLoader, it.annotation, contextSupplier, dataLoaderRegistry)
+                createDataLoader(it.theLoader, it.annotation, it.name, contextSupplier, dataLoaderRegistry)
             )
         }
         mappedBatchLoadersWithContext.forEach {
             dataLoaderRegistry.register(
                 it.name,
-                createDataLoader(it.theLoader, it.annotation, contextSupplier, dataLoaderRegistry)
+                createDataLoader(it.theLoader, it.annotation, it.name, contextSupplier, dataLoaderRegistry)
             )
         }
 
@@ -127,6 +127,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         dataLoaders.values.forEach { dgsComponent ->
             val javaClass = AopUtils.getTargetClass(dgsComponent)
             val annotation = javaClass.getAnnotation(DgsDataLoader::class.java)
+
             fun <T : Any> createHolder(t: T): LoaderHolder<T> =
                 LoaderHolder(t, annotation, DataLoaderNameUtil.getDataLoaderName(javaClass, annotation))
             when (dgsComponent) {
@@ -142,6 +143,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
     private fun createDataLoader(
         batchLoader: BatchLoader<*, *>,
         dgsDataLoader: DgsDataLoader,
+        dataLoaderName: String,
         dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<*, *> {
         val options = dataLoaderOptions(dgsDataLoader)
@@ -150,13 +152,14 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
             batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
-        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
+        val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName)
         return DataLoaderFactory.newDataLoader(extendedBatchLoader, options)
     }
 
     private fun createDataLoader(
         batchLoader: MappedBatchLoader<*, *>,
         dgsDataLoader: DgsDataLoader,
+        dataLoaderName: String,
         dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<*, *> {
         val options = dataLoaderOptions(dgsDataLoader)
@@ -164,7 +167,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         if (batchLoader is DgsDataLoaderRegistryConsumer) {
             batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
-        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
+        val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName)
 
         return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options)
     }
@@ -172,6 +175,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
     private fun <T> createDataLoader(
         batchLoader: BatchLoaderWithContext<*, *>,
         dgsDataLoader: DgsDataLoader,
+        dataLoaderName: String,
         supplier: Supplier<T>,
         dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<*, *> {
@@ -182,13 +186,14 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
             batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
-        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
+        val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName)
         return DataLoaderFactory.newDataLoader(extendedBatchLoader, options)
     }
 
     private fun <T> createDataLoader(
         batchLoader: MappedBatchLoaderWithContext<*, *>,
         dgsDataLoader: DgsDataLoader,
+        dataLoaderName: String,
         supplier: Supplier<T>,
         dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<*, *> {
@@ -199,7 +204,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
             batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
         }
 
-        val extendedBatchLoader = wrappedDataLoader(batchLoader, dgsDataLoader.name)
+        val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName)
         return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options)
     }
 


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
This PR fixes an issue with data loaders that are not explicitly named. We have logic to infer the name based on the class name when the `@DgsDataLoader` is used without an explicit name argument, with the default set to `NETFLIX_DGS_DATALOADER_NAME`.  When we wrap the data loader with instrumentation, the code was incorrectly using the annotations name value instead of the inferred class name, in cases where 2 data loaders were present without an explicit name. We ended up with 2 data loaders with the same name and they were invoked erroneously with incorrectly keys.
