### PR TITLE
fix: Use request as source for headers

### DIFF
--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/RequestHeadersDataFetcher.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/RequestHeadersDataFetcher.java
@@ -19,16 +19,35 @@ package com.netflix.graphql.dgs.example.shared.datafetcher;
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
+import com.netflix.graphql.dgs.context.DgsContext;
+import com.netflix.graphql.dgs.internal.DgsWebMvcRequestData;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.context.request.WebRequest;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @DgsComponent
 public class RequestHeadersDataFetcher {
     @DgsData(parentType = "Query", field = "headers")
     public String headers(DgsDataFetchingEnvironment dfe) {
-        HttpHeaders headers = dfe.getDgsContext().getRequestData().getHeaders();
+        DgsWebMvcRequestData requestData = ((DgsWebMvcRequestData) DgsContext.getRequestData(dfe));
+        if (requestData == null) {
+            return null;
+        }
+        WebRequest webRequest = requestData.getWebRequest();
+        if (webRequest == null) {
+            return null;
+        }
+        HttpHeaders headers = new HttpHeaders();
+        webRequest.getHeaderNames().forEachRemaining(headerName -> {
+            String [] headerValues = webRequest.getHeaderValues(headerName);
+            if (headerValues != null && headerValues.length > 0) {
+                headers.addAll(headerName, new ArrayList<>(Arrays.asList(headerValues)));
+            }
+        });
         return headers.toString();
     }
 

--- a/graphql-dgs-reactive/src/main/java/com/netflix/graphql/dgs/reactive/DgsReactiveQueryExecutor.java
+++ b/graphql-dgs-reactive/src/main/java/com/netflix/graphql/dgs/reactive/DgsReactiveQueryExecutor.java
@@ -20,7 +20,6 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.TypeRef;
 import graphql.ExecutionResult;
 import org.intellij.lang.annotations.Language;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import reactor.core.publisher.Mono;
@@ -46,7 +45,7 @@ public interface DgsReactiveQueryExecutor {
      * @return Returns a GraphQL {@link ExecutionResult}. This includes data and errors.
      */
     default Mono<ExecutionResult> execute(@Language("GraphQL") String query) {
-        return execute(query, null, null, null, null, null);
+        return execute(query, null, null, null, null);
     }
 
     /**
@@ -57,7 +56,7 @@ public interface DgsReactiveQueryExecutor {
      */
     default Mono<ExecutionResult> execute(@Language("GraphQL") String query,
                                           Map<String, Object> variables) {
-        return execute(query, variables, null, null, null, null);
+        return execute(query, variables, null, null, null);
     }
 
     /**
@@ -71,7 +70,7 @@ public interface DgsReactiveQueryExecutor {
     default Mono<ExecutionResult> execute(@Language("GraphQL") String query,
                                           Map<String, Object> variables,
                                           String operationName) {
-        return execute(query, variables, null, null, operationName, null);
+        return execute(query, variables, null, operationName, null);
     }
 
     /**
@@ -80,15 +79,15 @@ public interface DgsReactiveQueryExecutor {
      * @param extensions A map representing GraphQL extensions. This is made available in the
      *                   {@link com.netflix.graphql.dgs.internal.DgsRequestData} object on
      *                   {@link com.netflix.graphql.dgs.context.DgsContext}.
-     * @param headers    Request headers represented as a Spring Framework {@link HttpHeaders}
+     * @param serverHttpRequest A Spring {@link ServerHttpRequest} giving access to request details.
      * @return Returns a GraphQL {@link ExecutionResult}. This includes data and errors.
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
     default Mono<ExecutionResult> execute(@Language("GraphQL") String query,
                                           Map<String, Object> variables,
                                           Map<String, Object> extensions,
-                                          HttpHeaders headers) {
-        return execute(query, variables, extensions, headers, null, null);
+                                          ServerRequest serverHttpRequest) {
+        return execute(query, variables, extensions, null, serverHttpRequest);
     }
 
     /**
@@ -98,7 +97,6 @@ public interface DgsReactiveQueryExecutor {
      * @param variables         A map of variables
      * @param extensions        A map representing GraphQL extensions. This is made available in the {@link com.netflix.graphql.dgs.internal.DgsRequestData}
      *                          object on {@link com.netflix.graphql.dgs.context.DgsContext}.
-     * @param headers           Request headers represented as a Spring Framework {@link HttpHeaders}
      * @param operationName     Operation name
      * @param serverHttpRequest A Spring {@link ServerHttpRequest} giving access to request details.
      * @return Returns a GraphQL {@link ExecutionResult}. This includes data and errors.
@@ -108,7 +106,6 @@ public interface DgsReactiveQueryExecutor {
     Mono<ExecutionResult> execute(@Language("GraphQL") String query,
                                   Map<String, Object> variables,
                                   Map<String, Object> extensions,
-                                  HttpHeaders headers,
                                   String operationName,
                                   ServerRequest serverHttpRequest);
 

--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveGraphQLContextBuilder.kt
@@ -35,7 +35,7 @@ open class DefaultDgsReactiveGraphQLContextBuilder(
             dgsReactiveCustomContextBuilderWithRequest.get().build(
                 dgsRequestData?.extensions ?: mapOf(),
                 HttpHeaders.readOnlyHttpHeaders(
-                    dgsRequestData?.headers
+                    dgsRequestData?.serverRequest?.headers()?.asHttpHeaders()
                         ?: HttpHeaders()
                 ),
                 dgsRequestData?.serverRequest
@@ -66,6 +66,5 @@ open class DefaultDgsReactiveGraphQLContextBuilder(
  */
 data class DgsReactiveRequestData(
     override val extensions: Map<String, Any>? = emptyMap(),
-    override val headers: HttpHeaders? = HttpHeaders.readOnlyHttpHeaders(HttpHeaders()),
     val serverRequest: ServerRequest? = null,
 ) : DgsRequestData

--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
@@ -36,7 +36,6 @@ import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpHeaders
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.util.function.*
@@ -63,7 +62,6 @@ class DefaultDgsReactiveQueryExecutor(
         query: String?,
         variables: MutableMap<String, Any>?,
         extensions: MutableMap<String, Any>?,
-        headers: HttpHeaders?,
         operationName: String?,
         serverHttpRequest: ServerRequest?
     ): Mono<ExecutionResult> {
@@ -75,7 +73,7 @@ class DefaultDgsReactiveQueryExecutor(
                 else
                     schema.get()
             }
-            .zipWith(contextBuilder.build(DgsReactiveRequestData(extensions, headers, serverHttpRequest)))
+            .zipWith(contextBuilder.build(DgsReactiveRequestData(extensions, serverHttpRequest)))
             .flatMap { (gqlSchema, dgsContext) ->
                 Mono.fromCompletionStage(
                     BaseDgsQueryExecutor.baseExecute(

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/QueryExecutorTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/QueryExecutorTest.kt
@@ -28,7 +28,8 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner
 import org.springframework.http.HttpHeaders
-import org.springframework.util.LinkedMultiValueMap
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.ServletWebRequest
 
 class QueryExecutorTest {
     private val context = WebApplicationContextRunner()
@@ -45,11 +46,14 @@ class QueryExecutorTest {
 
     @Test
     fun queryWithHeaderNotThrowsException() {
-        val headers = LinkedMultiValueMap<String, String>()
-        headers.add(HttpHeaders.AUTHORIZATION, "test")
+        val webRequest = ServletWebRequest(
+            MockHttpServletRequest().apply {
+                addHeader(HttpHeaders.AUTHORIZATION, "test")
+            }
+        )
         context.withUserConfiguration(HelloDataFetcherConfig::class.java).run { ctx ->
             assertThat(ctx).getBean(DgsQueryExecutor::class.java).extracting {
-                it.executeAndGetDocumentContext("{ helloWithHeader }", mapOf(), HttpHeaders(headers))
+                it.executeAndGetDocumentContext("{ helloWithHeader }", mapOf(), webRequest)
             }
         }
     }

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DefaultDgsWebfluxHttpHandler.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/handlers/DefaultDgsWebfluxHttpHandler.kt
@@ -66,7 +66,6 @@ class DefaultDgsWebfluxHttpHandler(
                         queryInput.query,
                         queryInput.queryVariables,
                         queryInput.extensions,
-                        request.headers().asHttpHeaders(),
                         queryInput.operationName,
                         request
                     )

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfigurationTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfigurationTest.kt
@@ -245,7 +245,6 @@ class DgsWebMvcAutoConfigurationTest {
                     "{ hello }",
                     any(),
                     any(),
-                    any(),
                     null,
                     any()
                 )

--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -206,7 +206,6 @@ open class DgsRestController(
                     query,
                     queryVariables,
                     extensions,
-                    headers,
                     gqlOperationName,
                     webRequest
                 )

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsMultipartPostControllerTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsMultipartPostControllerTest.kt
@@ -76,7 +76,7 @@ class DgsMultipartPostControllerTest {
         val queryString = "mutation(${'$'}file: Upload!) {uploadFile(file: ${'$'}file)}"
         val variablesMap: MutableMap<String, Any> = Maps.newHashMap("file", file1)
 
-        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any(), any()) } returns(
+        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any()) } returns(
             ExecutionResultImpl.newExecutionResult().data(mapOf("Response" to "success")).build()
             )
         // HTTP Headers with only the expected content-type but no preflight
@@ -122,7 +122,7 @@ class DgsMultipartPostControllerTest {
         val queryString = "mutation(${'$'}file: Upload!) {uploadFile(file: ${'$'}file)}"
         val variablesMap: MutableMap<String, Any> = Maps.newHashMap("file", file1)
 
-        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any(), any()) } returns(
+        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any()) } returns(
             ExecutionResultImpl.newExecutionResult().data(mapOf("Response" to "success")).build()
             )
 
@@ -171,7 +171,7 @@ class DgsMultipartPostControllerTest {
         val queryInputMap = Maps.newHashMap<String, Any>("description", "test")
         queryInputMap["files"] = Lists.newArrayList(file1, file2)
 
-        every { dgsQueryExecutor.execute(queryString, mapOf("input" to queryInputMap), any(), any(), any(), any()) } returns(
+        every { dgsQueryExecutor.execute(queryString, mapOf("input" to queryInputMap), any(), any(), any()) } returns(
             ExecutionResultImpl.newExecutionResult().data(mapOf("Response" to "success")).build()
             )
 
@@ -216,7 +216,7 @@ class DgsMultipartPostControllerTest {
         val queryString = "mutation(${'$'}files: [Upload!]!) {uploadFile(files: ${'$'}files)}"
         val variablesMap: MutableMap<String, Any> = Maps.newHashMap("files", Lists.newArrayList(file1, file2))
 
-        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any(), any()) } returns(
+        every { dgsQueryExecutor.execute(queryString, variablesMap, any(), any(), any()) } returns(
             ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("Response", "success"))).build()
             )
 

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsRestControllerTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/DgsRestControllerTest.kt
@@ -67,7 +67,6 @@ class DgsRestControllerTest {
                 emptyMap(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("hello", "hello"))).build()
@@ -94,7 +93,6 @@ class DgsRestControllerTest {
             dgsQueryExecutor.execute(
                 queryString,
                 emptyMap(),
-                any(),
                 any(),
                 capture(capturedOperationName),
                 any()
@@ -125,7 +123,6 @@ class DgsRestControllerTest {
                 emptyMap(),
                 any(),
                 any(),
-                any(),
                 any()
             )
         } returns ExecutionResultImpl.newExecutionResult().data(mapOf(Pair("hello", "hello"))).build()
@@ -152,7 +149,6 @@ class DgsRestControllerTest {
             dgsQueryExecutor.execute(
                 queryString,
                 emptyMap(),
-                any(),
                 any(),
                 any(),
                 any()

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/RequestHeaderTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/RequestHeaderTest.kt
@@ -90,7 +90,7 @@ class RequestHeaderTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -130,7 +130,7 @@ class RequestHeaderTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -170,7 +170,7 @@ class RequestHeaderTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -209,7 +209,7 @@ class RequestHeaderTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -248,7 +248,7 @@ class RequestHeaderTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -287,7 +287,7 @@ class RequestHeaderTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), httpHeaders, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()

--- a/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/RequestParamTest.kt
+++ b/graphql-dgs-spring-webmvc/src/test/kotlin/com/netflix/graphql/dgs/mvc/RequestParamTest.kt
@@ -85,7 +85,7 @@ class RequestParamTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -122,7 +122,7 @@ class RequestParamTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()
@@ -159,7 +159,7 @@ class RequestParamTest {
 
         val executionResult = build.execute(
             ExecutionInput.newExecutionInput("""{hello}""")
-                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), null, request)))
+                .graphQLContext(DgsContext(null, DgsWebMvcRequestData(emptyMap(), request)))
         )
         Assertions.assertTrue(executionResult.isDataPresent)
         val data = executionResult.getData<Map<String, *>>()

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -42,4 +42,5 @@ dependencies {
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("com.graphql-java:graphql-java-extended-scalars")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+    testImplementation("javax.servlet:javax.servlet-api")
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
@@ -20,7 +20,6 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.TypeRef;
 import graphql.ExecutionResult;
 import org.intellij.lang.annotations.Language;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.context.request.WebRequest;
 
 import java.util.Collections;
@@ -42,7 +41,7 @@ public interface DgsQueryExecutor {
      * @return Returns a GraphQL {@link ExecutionResult}. This includes data and errors.
      */
     default ExecutionResult execute(@Language("GraphQL") String query) {
-        return execute(query, Collections.emptyMap(), null, null, null, null);
+        return execute(query, Collections.emptyMap(), null, null, null);
     }
 
     /**
@@ -53,7 +52,7 @@ public interface DgsQueryExecutor {
      */
     default ExecutionResult execute(@Language("GraphQL") String query,
                                     Map<String, Object> variables) {
-        return execute(query, variables, null, null, null, null);
+        return execute(query, variables, null, null, null);
     }
 
     /**
@@ -67,7 +66,7 @@ public interface DgsQueryExecutor {
     default ExecutionResult execute(@Language("GraphQL") String query,
                                     Map<String, Object> variables,
                                     String operationName) {
-        return execute(query, variables, null, null, operationName, null);
+        return execute(query, variables, null, operationName, null);
     }
 
     /**
@@ -81,8 +80,8 @@ public interface DgsQueryExecutor {
     default ExecutionResult execute(@Language("GraphQL") String query,
                                     Map<String, Object> variables,
                                     Map<String, Object> extensions,
-                                    HttpHeaders headers) {
-        return execute(query, variables, extensions, headers, null, null);
+                                    WebRequest webRequest) {
+        return execute(query, variables, extensions, null, webRequest);
     }
 
     /**
@@ -91,7 +90,6 @@ public interface DgsQueryExecutor {
      * @param query         The query string
      * @param variables     A map of variables
      * @param extensions    A map representing GraphQL extensions. This is made available in the {@link com.netflix.graphql.dgs.internal.DgsRequestData} object on {@link com.netflix.graphql.dgs.context.DgsContext}.
-     * @param headers       Request headers represented as a Spring Framework {@link HttpHeaders}
      * @param operationName Operation name
      * @param webRequest    A Spring {@link WebRequest} giving access to request details. Can cast to an environment specific class such as {@link org.springframework.web.context.request.ServletWebRequest}.
      * @return Returns a GraphQL {@link ExecutionResult}. This includes data and errors.
@@ -101,7 +99,6 @@ public interface DgsQueryExecutor {
     ExecutionResult execute(@Language("GraphQL") String query,
                             Map<String, Object> variables,
                             Map<String, Object> extensions,
-                            HttpHeaders headers,
                             String operationName,
                             WebRequest webRequest);
 
@@ -149,14 +146,14 @@ public interface DgsQueryExecutor {
      *
      * @param query    Query string
      * @param jsonPath JsonPath expression.
-     * @param headers  Spring {@link HttpHeaders}
+     * @param webRequest    A Spring {@link WebRequest} giving access to request details. Can cast to an environment specific class such as {@link org.springframework.web.context.request.ServletWebRequest}.
      * @param <T>      The type of primitive or map representation that should be returned.
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      */
     <T> T executeAndExtractJsonPath(@Language("GraphQL") String query,
                                     @Language("JSONPath") String jsonPath,
-                                    HttpHeaders headers);
+                                    WebRequest webRequest);
 
     /**
      * Executes a GraphQL query, parses the returned data, and return a {@link DocumentContext}.
@@ -186,13 +183,13 @@ public interface DgsQueryExecutor {
      *
      * @param query     Query string
      * @param variables A Map of variables
-     * @param headers   Spring {@link HttpHeaders}
+     * @param webRequest    A Spring {@link WebRequest} giving access to request details. Can cast to an environment specific class such as {@link org.springframework.web.context.request.ServletWebRequest}.
      * @return {@link DocumentContext} is a JsonPath type used to extract values from.
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
     DocumentContext executeAndGetDocumentContext(@Language("GraphQL") String query,
                                                  Map<String, Object> variables,
-                                                 HttpHeaders headers);
+                                                 WebRequest webRequest);
 
     /**
      * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
@@ -239,7 +236,7 @@ public interface DgsQueryExecutor {
      * @param jsonPath  JsonPath expression.
      * @param variables A Map of variables
      * @param clazz     The type to convert the extracted value to.
-     * @param headers   Request headers represented as a Spring Framework {@link HttpHeaders}
+     * @param webRequest    A Spring {@link WebRequest} giving access to request details. Can cast to an environment specific class such as {@link org.springframework.web.context.request.ServletWebRequest}.
      * @param <T>       The type that the extracted value should be converted to.
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
@@ -249,7 +246,7 @@ public interface DgsQueryExecutor {
                                             @Language("JSONPath") String jsonPath,
                                             Map<String, Object> variables,
                                             Class<T> clazz,
-                                            HttpHeaders headers);
+                                            WebRequest webRequest);
 
     /**
      * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
@@ -301,7 +298,7 @@ public interface DgsQueryExecutor {
      * @param jsonPath  JsonPath expression.
      * @param variables A Map of variables
      * @param typeRef   A JsonPath {@link TypeRef} representing the expected result type.
-     * @param headers   Request headers represented as a Spring Framework {@link HttpHeaders}
+     * @param webRequest    A Spring {@link WebRequest} giving access to request details. Can cast to an environment specific class such as {@link org.springframework.web.context.request.ServletWebRequest}.
      * @param <T>       The type that the extracted value should be converted to.
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
@@ -312,5 +309,5 @@ public interface DgsQueryExecutor {
                                             @Language("JSONPath") String jsonPath,
                                             Map<String, Object> variables,
                                             TypeRef<T> typeRef,
-                                            HttpHeaders headers);
+                                            WebRequest webRequest);
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsGraphQLContextBuilder.kt
@@ -40,7 +40,7 @@ open class DefaultDgsGraphQLContextBuilder(
             dgsCustomContextBuilderWithRequest.isPresent -> dgsCustomContextBuilderWithRequest.get().build(
                 dgsRequestData?.extensions ?: mapOf(),
                 HttpHeaders.readOnlyHttpHeaders(
-                    dgsRequestData?.headers
+                    dgsRequestData?.webRequest?.httpHeaders()
                         ?: HttpHeaders()
                 ),
                 dgsRequestData?.webRequest
@@ -57,6 +57,16 @@ open class DefaultDgsGraphQLContextBuilder(
         )
     }
 
+    private fun WebRequest.httpHeaders(): HttpHeaders {
+        val httpHeaders = HttpHeaders()
+        this.headerNames.forEach { headerName ->
+            this.getHeaderValues(headerName)?.toMutableList()?.also {
+                httpHeaders.addAll(headerName, it)
+            }
+        }
+        return httpHeaders
+    }
+
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(DefaultDgsGraphQLContextBuilder::class.java)
     }
@@ -70,7 +80,6 @@ data class DefaultRequestData(
 
 interface DgsRequestData {
     val extensions: Map<String, Any>?
-    val headers: HttpHeaders?
 }
 
 /**
@@ -80,6 +89,5 @@ interface DgsRequestData {
  */
 data class DgsWebMvcRequestData(
     override val extensions: Map<String, Any>? = null,
-    override val headers: HttpHeaders? = null,
     val webRequest: WebRequest? = null,
 ) : DgsRequestData

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
@@ -18,7 +18,12 @@ package com.netflix.graphql.dgs.internal
 
 import com.jayway.jsonpath.TypeRef
 import com.jayway.jsonpath.spi.mapper.MappingException
-import com.netflix.graphql.dgs.*
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsData
+import com.netflix.graphql.dgs.DgsDirective
+import com.netflix.graphql.dgs.DgsScalar
+import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.LocalDateTimeScalar
 import com.netflix.graphql.dgs.exceptions.DgsQueryExecutionDataExtractionException
 import com.netflix.graphql.dgs.exceptions.QueryException
 import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
@@ -37,7 +42,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.context.ApplicationContext
-import org.springframework.http.HttpHeaders
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.ServletWebRequest
 import java.time.LocalDateTime
 import java.util.*
 import java.util.function.Supplier
@@ -264,8 +270,11 @@ internal class DefaultDgsQueryExecutorTest {
 
     @Test
     fun extractJsonAsObjectTypeRefWithHeadersNotThrow() {
-        val httpHeaders = HttpHeaders()
-        httpHeaders.add("test", "headerValue")
+        val webRequest = ServletWebRequest(
+            MockHttpServletRequest().apply {
+                addHeader("test", "headerValue")
+            }
+        )
 
         val expectedMessage = "hello dgs"
         val message = dgsQueryExecutor.executeAndExtractJsonPathAsObject(
@@ -273,7 +282,7 @@ internal class DefaultDgsQueryExecutorTest {
             "data.echo",
             mapOf("message" to expectedMessage),
             object : TypeRef<String>() {},
-            httpHeaders
+            webRequest
         )
 
         assertThat(message).isEqualTo(expectedMessage)
@@ -294,8 +303,11 @@ internal class DefaultDgsQueryExecutorTest {
 
     @Test
     fun extractJsonAsObjectClazzWithHeadersNotThrow() {
-        val httpHeaders = HttpHeaders()
-        httpHeaders.add("test", "headerValue")
+        val webRequest = ServletWebRequest(
+            MockHttpServletRequest().apply {
+                addHeader("test", "headerValue")
+            }
+        )
 
         val expectedMessage = "hello dgs"
         val message = dgsQueryExecutor.executeAndExtractJsonPathAsObject(
@@ -303,7 +315,7 @@ internal class DefaultDgsQueryExecutorTest {
             "data.echo",
             mapOf("message" to expectedMessage),
             String::class.java,
-            httpHeaders
+            webRequest
         )
 
         assertThat(message).isEqualTo(expectedMessage)


### PR DESCRIPTION
After changes introduced in https://github.com/Netflix/dgs-framework/pull/1013 DgsQueryExecutor throws NPE. It does not use web layer, so request is missing. When custom request attributes eg. headers are needed they should be provided by specifically providing request which is not supported in all DgsExecutor methods. Also mixing using header in some parts and request in other parts is confusing. Request should be primary provider of headers and potentially other attributes which can be used to bind in DgsHandler.

fixes: https://github.com/Netflix/dgs-framework/issues/1105

Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Add posibility to add custom request to all `DgsQueryExecutor` methods.
`DgsContext` does not contain headers anymore, source for headers should be the request.


Alternatives considered
----

Move DefaultDgsGraphQLContextBuilder under interface or make `build` function open, so it would be possible to override it in custom implementations. It would be possible to use custom implementation in tests which would add a request. But this would work only for header not for other possible request params.


