### PR TITLE
Add duplicate data fetcher validation

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -289,6 +289,11 @@ class DgsSchemaProvider(
         val field = dgsDataAnnotation.getString("field").ifEmpty { method.name }
         val parentType = dgsDataAnnotation.getString("parentType")
 
+        if (dataFetchers.any { it.parentType == parentType && it.field == field }) {
+            logger.error("Duplicate data fetchers registered for $parentType.$field")
+            throw InvalidDgsConfigurationException("Duplicate data fetchers registered for $parentType.$field")
+        }
+
         dataFetchers.add(DataFetcherReference(dgsComponent, method, mergedAnnotations, parentType, field))
 
         val enableInstrumentation =


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

During a refactor, my team recently introduced a bug to our GraphQL service by accidentally using a `@DgsData` annotation for the same field twice. I thought this might be a good validation to add when registering data fetchers to prevent undefined behavior. Throwing an `InvalidDgsConfigurationException` may affect backwards compatibility, so I'll defer to the team on whether this is acceptable! 

