### PR TITLE
BUG FIX (#1083): Complex InputArgument serialized as Optional List of Complex Type 

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/AbstractInputArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/AbstractInputArgumentResolver.kt
@@ -83,7 +83,8 @@ abstract class AbstractInputArgumentResolver(inputObjectMapper: InputObjectMappe
         }
 
         if (target.type == Optional::class.java) {
-            val elementType = TypeDescriptor.valueOf(target.resolvableType.getGeneric(0).toClass())
+            val generic = target.resolvableType.getGeneric(0)
+            val elementType = TypeDescriptor(generic, null, null)
             return Optional.ofNullable(convertValue(source, elementType))
         }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -62,7 +62,6 @@ import org.assertj.core.api.InstanceOfAssertFactories
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.context.ApplicationContext
@@ -477,7 +476,6 @@ internal class InputArgumentTest {
     }
 
     @Test
-    @Disabled("Reproduces Issue #1083")
     fun `@InputArgument on an optional list of input types, with input argument name`() {
         val schema = """
             type Query {
@@ -492,12 +490,15 @@ internal class InputArgumentTest {
         val fetcher = object {
             @DgsData(parentType = "Query", field = "hello")
             fun someFetcher(@InputArgument("person") person: Optional<List<Person>>): String {
-                assertThat(person)
-                    .isNotEmpty
+                val peopleNames = person
                     .get()
-                    .extracting { ls -> ls.map { it.name } }.asList()
+                    .map { it.name }
+
+                assertThat(peopleNames)
+                    .isNotEmpty
                     .containsOnly("tester 1", "tester 2")
-                return "Hello, ${person.get().joinToString(", ")}"
+
+                return "Hello, ${peopleNames.joinToString(", ")}"
             }
         }
 
@@ -515,7 +516,6 @@ internal class InputArgumentTest {
     }
 
     @Test
-    @Disabled("Reproduces Issue #1083")
     fun `@InputArgument on an optional list of input types, with no input argument name`() {
         val schema = """
             type Query {
@@ -530,12 +530,15 @@ internal class InputArgumentTest {
         val fetcher = object {
             @DgsData(parentType = "Query", field = "hello")
             fun someFetcher(@InputArgument person: Optional<List<Person>>): String {
-                assertThat(person)
-                    .isNotEmpty
+                val peopleNames = person
                     .get()
-                    .extracting { ls -> ls.map { it.name } }.asList()
+                    .map { it.name }
+
+                assertThat(peopleNames)
+                    .isNotEmpty
                     .containsOnly("tester 1", "tester 2")
-                return "Hello, ${person.get().joinToString(", ")}"
+
+                return "Hello, ${peopleNames.joinToString(", ")}"
             }
         }
 


### PR DESCRIPTION
Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [X] Make sure the PR doesn't introduce backward compatibility issues
- [X] Make sure to have sufficient test cases (pre-covered)

Pull Request type
----

- [X] Bugfix

Changes in this PR
----
fix for https://github.com/Netflix/dgs-framework/issues/1083

Bug: The type of the nested collection was getting unbounded to `List<*>` (from, say `List<Person>`) when `.toClass` was called on it so it triggered the exit condition on the recursion (since `List<Anything> == List<*>`)

Solution: Instead of calling `.toClass`, we should just use the constructor to create `TypeDescriptor` from `ResolveableType` and then Spring does all the heavy lifting 🥳🥳🥳

Also the test cases were a little off (they were printing the whole `Person` object not just name) but thanks for adding them, very helpful
