### PR TITLE
[regresion] Allow Spock Stubs to be used as Data Fetchers

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -267,7 +267,7 @@ class DgsSchemaProvider(
                     val filteredMergedAnnotations =
                         mergedAnnotations
                             .stream(DgsData::class.java)
-                            .filter { (it.source as Method).declaringClass == method.declaringClass }
+                            .filter { AopUtils.getTargetClass((it.source as Method).declaringClass) == AopUtils.getTargetClass(method.declaringClass) }
                             .collect(Collectors.toList())
                     filteredMergedAnnotations.forEach { dgsDataAnnotation ->
                         registerDataFetcher(


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Commit 6fbce099 introduced a regression that will prevent Spock Stubs to be used as Data Fetchers.