### PR TITLE
DGS BOM is expresses stronger version constraints for GraphQL Java

### DIFF
--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -48,17 +48,29 @@ dependencies {
     constraints {
         // GraphQL Platform
         api("com.graphql-java:graphql-java") {
-            version { require("19.2") }
+            version {
+                strictly("[19.2, 20[")
+                prefer("19.2")
+                reject("18.2")
+            }
+
         }
         api("com.graphql-java:graphql-java-extended-scalars") {
-            version { require("19.0") }
+            version {
+                 strictly("[19.0, 20[")
+                 prefer("19.0")
+                 reject("18.2")
+            }
         }
         api("com.graphql-java:graphql-java-extended-validation") {
             // The version below will work with Jakarta EE 8 and use Hibernate Validator 6.2.
-            version { require("19.1-hibernate-validator-6.2.0.Final") }
+            version { strictly("19.1-hibernate-validator-6.2.0.Final") }
         }
         api("com.apollographql.federation:federation-graphql-java-support") {
-            version { require("2.1.0") }
+            version {
+                strictly("[2.0, 2.2[")
+                prefer("2.1.0")
+            }
         }
         // ---
         api("com.jayway.jsonpath:json-path") {
@@ -74,7 +86,7 @@ dependencies {
         api("org.apache.logging.log4j:log4j-to-slf4j:2.19.0") {
             because("Refer to CVE-2021-44228; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228")
          }
-         api("org.apache.logging.log4j:log4j-api:2.18.0") {
+         api("org.apache.logging.log4j:log4j-api:2.19.0") {
             because("Refer to CVE-2021-44228; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228")
          }
     }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
The following BOM constraints will now be expressed

* `graphql-java` , strictly between `[19.2, 20)`, prefering `19.2` if no version is specified.
* `com.graphql-java:graphql-java-extended-scalars`, strictly between `[19.0, 20)` and will reject "18.2".
* `com.graphql-java:graphql-java-extended-validation`, strictly `19.1-hibernate-validator-6.2.0.Final`
* `com.apollographql.federation:federation-graphql-java-support`, strictly between `[2.0, 2.2)`, preferring `2.1.0`