### PR TITLE
Move to net.datafaker:javafaker :1.6.0 to avoid the snakeyaml 1.30-android issue

### DIFF
--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -362,7 +362,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1133,7 +1133,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -570,7 +570,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1114,7 +1114,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1610,7 +1610,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -574,7 +574,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1140,7 +1140,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1664,7 +1664,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -363,7 +363,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -783,7 +783,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1102,7 +1102,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -360,7 +360,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -786,7 +786,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1174,7 +1174,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -360,7 +360,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -786,7 +786,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1174,7 +1174,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-mocking/build.gradle.kts
+++ b/graphql-dgs-mocking/build.gradle.kts
@@ -16,6 +16,6 @@
 
 dependencies {
     api("com.graphql-java:graphql-java")
-    implementation("net.datafaker:datafaker:1.4.0")
+    implementation("net.datafaker:datafaker:1.6.0")
     implementation("org.slf4j:slf4j-api")
 }

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -36,7 +36,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -102,7 +102,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -149,7 +149,7 @@
             "locked": "1.13.2"
         },
         "net.datafaker:datafaker": {
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -420,7 +420,7 @@
             "project": true
         },
         "net.datafaker:datafaker": {
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -478,7 +478,7 @@
             "locked": "1.13.2"
         },
         "net.datafaker:datafaker": {
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -519,7 +519,7 @@
             "locked": "1.13.2"
         },
         "net.datafaker:datafaker": {
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -267,7 +267,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -637,7 +637,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -868,7 +868,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -314,7 +314,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -704,7 +704,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -994,7 +994,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -542,7 +542,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -983,7 +983,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1401,7 +1401,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -330,7 +330,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -718,7 +718,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -994,7 +994,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -450,7 +450,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -934,7 +934,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1335,7 +1335,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -374,7 +374,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -805,7 +805,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1157,7 +1157,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -326,7 +326,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -728,7 +728,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1021,7 +1021,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -288,7 +288,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -655,7 +655,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -895,7 +895,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -317,7 +317,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -730,7 +730,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1015,7 +1015,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -326,7 +326,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -720,7 +720,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1002,7 +1002,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -335,7 +335,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -740,7 +740,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1029,7 +1029,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -332,7 +332,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -720,7 +720,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1002,7 +1002,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -477,7 +477,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -972,7 +972,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [
@@ -1390,7 +1390,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.apache.commons:commons-lang3": {
             "firstLevelTransitive": [

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -283,7 +283,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -614,7 +614,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -833,7 +833,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.4.0"
+            "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Addressing the following error due to javafaker depending on snakeyaml-1.30-android.jar
```
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find snakeyaml-1.30-android.jar (org.yaml:snakeyaml:1.30).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/org/yaml/snakeyaml/1.30/snakeyaml-1.30-android.jar
```