### PR TITLE
WebClientGraphQLClient RequestBodyUriCustomizer

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomMonoGraphQLClient.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.client
 
+import org.intellij.lang.annotations.Language
 import reactor.core.publisher.Mono
 
 /**
@@ -23,17 +24,20 @@ import reactor.core.publisher.Mono
  * The user is responsible for doing the actual HTTP request, making this pluggable with any HTTP client.
  * For a more convenient option, use [WebClientGraphQLClient] instead.
  */
-class CustomMonoGraphQLClient(private val url: String, private val monoRequestExecutor: MonoRequestExecutor) : MonoGraphQLClient {
-    override fun reactiveExecuteQuery(query: String): Mono<GraphQLResponse> {
+class CustomMonoGraphQLClient(
+    private val url: String,
+    private val monoRequestExecutor: MonoRequestExecutor
+) : MonoGraphQLClient {
+    override fun reactiveExecuteQuery(@Language("graphql") query: String): Mono<GraphQLResponse> {
         return reactiveExecuteQuery(query, emptyMap(), null)
     }
 
-    override fun reactiveExecuteQuery(query: String, variables: Map<String, Any>): Mono<GraphQLResponse> {
+    override fun reactiveExecuteQuery(@Language("graphql") query: String, variables: Map<String, Any>): Mono<GraphQLResponse> {
         return reactiveExecuteQuery(query, variables, null)
     }
 
     override fun reactiveExecuteQuery(
-        query: String,
+        @Language("graphql") query: String,
         variables: Map<String, Any>,
         operationName: String?
     ): Mono<GraphQLResponse> {

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClientException.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClientException.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+
+/**
+ * A transport level exception (e.g. a failed connection). This does *not* represent successful GraphQL responses that contain errors.
+ */
+class GraphQLClientException(
+    statusCode: Int,
+    url: String,
+    response: String,
+    request: String
+) :
+    ResponseStatusException(
+        HttpStatus.valueOf(statusCode),
+        "GraphQL server $url responded with status code $statusCode: '$response'. The request sent to the server was \n$request"
+    )

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClients.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClients.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.util.ClassUtils
+
+internal object GraphQLClients {
+
+    internal val objectMapper: ObjectMapper =
+        if (ClassUtils.isPresent("com.fasterxml.jackson.module.kotlin.KotlinModule\$Builder", this::class.java.classLoader)) {
+            ObjectMapper().registerModule(KotlinModule.Builder().nullIsSameAsDefault(true).build())
+        } else ObjectMapper().registerKotlinModule()
+
+    internal val defaultHeaders: HttpHeaders = HttpHeaders.readOnlyHttpHeaders(
+        HttpHeaders().apply {
+            accept = listOf(MediaType.APPLICATION_JSON)
+            contentType = MediaType.APPLICATION_JSON
+        }
+    )
+
+    fun handleResponse(response: HttpResponse, requestBody: String, url: String): GraphQLResponse {
+        val (statusCode, body) = response
+        val headers = response.headers
+        if (statusCode !in 200..299) {
+            throw GraphQLClientException(statusCode, url, body ?: "", requestBody)
+        }
+
+        return GraphQLResponse(body ?: "", headers)
+    }
+}

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/HttpResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/HttpResponse.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+data class HttpResponse(
+    val statusCode: Int,
+    val body: String?,
+    val headers: Map<String, List<String>>
+) {
+    constructor(statusCode: Int, body: String?) : this(statusCode, body, emptyMap())
+}

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/MonoGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/MonoGraphQLClient.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+import org.intellij.lang.annotations.Language
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+import java.util.function.Consumer
+
+/**
+ * GraphQL client interface for reactive clients.
+ */
+interface MonoGraphQLClient {
+    /**
+     * A reactive call to execute a query and parse its result.
+     * Don't forget to subscribe() to actually send the query!
+     * @param query The query string. Note that you can use [code generation](https://netflix.github.io/dgs/generating-code-from-schema/#generating-query-apis-for-external-services) for a type safe query!
+     * @return A [Mono] of [GraphQLResponse] parses the response and gives easy access to data and errors.
+     */
+    fun reactiveExecuteQuery(
+        @Language("graphql") query: String
+    ): Mono<GraphQLResponse>
+
+    /**
+     * A reactive call to execute a query and parse its result.
+     * Don't forget to subscribe() to actually send the query!
+     * @param query The query string. Note that you can use [code generation](https://netflix.github.io/dgs/generating-code-from-schema/#generating-query-apis-for-external-services) for a type safe query!
+     * @param variables A map of input variables
+     * @return A [Mono] of [GraphQLResponse] parses the response and gives easy access to data and errors.
+     */
+    fun reactiveExecuteQuery(
+        @Language("graphql") query: String,
+        variables: Map<String, Any>
+    ): Mono<GraphQLResponse>
+
+    /**
+     * A reactive call to execute a query and parse its result.
+     * Don't forget to subscribe() to actually send the query!
+     * @param query The query string. Note that you can use [code generation](https://netflix.github.io/dgs/generating-code-from-schema/#generating-query-apis-for-external-services) for a type safe query!
+     * @param variables A map of input variables
+     * @param operationName Name of the operation
+     * @return A [Mono] of [GraphQLResponse] parses the response and gives easy access to data and errors.
+     */
+    fun reactiveExecuteQuery(
+        @Language("graphql") query: String,
+        variables: Map<String, Any>,
+        operationName: String?
+    ): Mono<GraphQLResponse>
+
+    @Deprecated(
+        "The RequestExecutor should be provided while creating the implementation. Use CustomGraphQLClient/CustomMonoGraphQLClient instead.",
+        ReplaceWith("Example: new CustomGraphQLClient(url, requestExecutor);")
+    )
+    fun reactiveExecuteQuery(
+        query: String,
+        variables: Map<String, Any>,
+        requestExecutor: MonoRequestExecutor
+    ): Mono<GraphQLResponse> = throw UnsupportedOperationException()
+
+    @Deprecated(
+        "The RequestExecutor should be provided while creating the implementation. Use CustomGraphQLClient/CustomMonoGraphQLClient instead.",
+        ReplaceWith("Example: new CustomGraphQLClient(url, requestExecutor);")
+    )
+    fun reactiveExecuteQuery(
+        query: String,
+        variables: Map<String, Any>,
+        operationName: String?,
+        requestExecutor: MonoRequestExecutor
+    ): Mono<GraphQLResponse> = throw UnsupportedOperationException()
+
+    companion object {
+        @JvmStatic
+        fun createCustomReactive(
+            @Language("url") url: String,
+            requestExecutor: MonoRequestExecutor
+        ) = CustomMonoGraphQLClient(url, requestExecutor)
+
+        @JvmStatic
+        fun createWithWebClient(webClient: WebClient) = WebClientGraphQLClient(webClient)
+
+        @JvmStatic
+        fun createWithWebClient(
+            webClient: WebClient,
+            headersConsumer: Consumer<HttpHeaders>
+        ) = WebClientGraphQLClient(webClient, headersConsumer)
+    }
+}

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/MonoRequestExecutor.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/MonoRequestExecutor.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+import reactor.core.publisher.Mono
+
+@FunctionalInterface
+/**
+ * Code responsible for executing the HTTP request for a GraphQL query.
+ * Typically provided as a lambda.  Reactive version (Mono)
+ * @param url The URL the client was configured with
+ * @param headers A map of headers. The client sets some default headers such as Accept and Content-Type.
+ * @param body The request body
+ * @returns Mono<HttpResponse> which is a representation of the HTTP status code and the response body as a String.
+ */
+fun interface MonoRequestExecutor {
+    fun execute(url: String, headers: Map<String, List<String>>, body: String): Mono<HttpResponse>
+}

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/ReactiveGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/ReactiveGraphQLClient.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+import reactor.core.publisher.Flux
+
+/**
+ * GraphQL client interface for reactive clients that support multiple results such as subscriptions.
+ */
+interface ReactiveGraphQLClient {
+    /**
+     * @param query The query string. Note that you can use [code generation](https://netflix.github.io/dgs/generating-code-from-schema/#generating-query-apis-for-external-services) for a type safe query!
+     * @param variables A map of input variables
+     * @return A [Flux] of [GraphQLResponse]. [GraphQLResponse] parses the response and gives easy access to data and errors.
+     */
+    fun reactiveExecuteQuery(
+        query: String,
+        variables: Map<String, Any>
+    ): Flux<GraphQLResponse>
+
+    /**
+     * @param query The query string. Note that you can use [code generation](https://netflix.github.io/dgs/generating-code-from-schema/#generating-query-apis-for-external-services) for a type safe query!
+     * @param variables A map of input variables
+     * @param operationName Operation name
+     * @return A [Flux] of [GraphQLResponse]. [GraphQLResponse] parses the response and gives easy access to data and errors.
+     */
+    fun reactiveExecuteQuery(
+        query: String,
+        variables: Map<String, Any>,
+        operationName: String?
+    ): Flux<GraphQLResponse>
+}

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/Request.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/Request.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+internal data class Request(val query: String, val variables: Map<String, Any>, val operationName: String?)

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/RequestExecutor.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/RequestExecutor.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.client
+
+@FunctionalInterface
+/**
+ * Code responsible for executing the HTTP request for a GraphQL query.
+ * Typically provided as a lambda.
+ * @param url The URL the client was configured with
+ * @param headers A map of headers. The client sets some default headers such as Accept and Content-Type.
+ * @param body The request body
+ * @returns HttpResponse which is a representation of the HTTP status code and the response body as a String.
+ */
+fun interface RequestExecutor {
+    fun execute(url: String, headers: Map<String, List<String>>, body: String): HttpResponse
+}

--- a/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
+++ b/graphql-dgs-client/src/test/java/com/netflix/graphql/client/GraphQLResponseJavaTest.java
@@ -21,9 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.*;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 import static java.util.Collections.emptyMap;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
@@ -21,21 +21,29 @@ import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.DgsTypeDefinitionRegistry
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration
 import com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcAutoConfiguration
-import graphql.language.FieldDefinition
-import graphql.language.ObjectTypeDefinition
-import graphql.language.TypeName
+import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
-import org.junit.jupiter.api.BeforeEach
+import io.netty.handler.logging.LogLevel
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import reactor.netty.transport.logging.AdvancedByteBufFormat
 import reactor.test.StepVerifier
 
+@Suppress("GraphQLUnresolvedReference")
 @SpringBootTest(
-    classes = [DgsAutoConfiguration::class, DgsWebMvcAutoConfiguration::class, WebClientGraphQLClientTest.TestApp::class],
+    classes = [
+        DgsAutoConfiguration::class,
+        DgsWebMvcAutoConfiguration::class,
+        WebClientGraphQLClientTest.TestApp::class
+    ],
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
 class WebClientGraphQLClientTest {
@@ -43,15 +51,10 @@ class WebClientGraphQLClientTest {
     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     @LocalServerPort
     lateinit var port: Integer
-    lateinit var client: WebClientGraphQLClient
-
-    @BeforeEach
-    fun setup() {
-        client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql"))
-    }
 
     @Test
     fun `Successful graphql response`() {
+        val client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql"))
         val result = client.reactiveExecuteQuery("{hello}").map { r -> r.extractValue<String>("hello") }
 
         StepVerifier.create(result)
@@ -61,9 +64,10 @@ class WebClientGraphQLClientTest {
 
     @Test
     fun `Extra header can be provided`() {
-        client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql")) { headers ->
-            headers.add("myheader", "test")
-        }
+        val client =
+            MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql")) { headers ->
+                headers.add("myheader", "test")
+            }
         val result = client.reactiveExecuteQuery("{withHeader}").map { r -> r.extractValue<String>("withHeader") }
 
         StepVerifier.create(result)
@@ -72,7 +76,41 @@ class WebClientGraphQLClientTest {
     }
 
     @Test
+    fun `Request parameters can be added, per request`() {
+        val httpClient: HttpClient = HttpClient
+            .create()
+            .wiretap(
+                "reactor.netty.http.client.HttpClient",
+                LogLevel.INFO,
+                AdvancedByteBufFormat.TEXTUAL
+            )
+
+        val webClient =
+            WebClient.builder()
+                .clientConnector(ReactorClientHttpConnector(httpClient))
+                .baseUrl("http://localhost:$port/graphql")
+                .build()
+
+        val client = MonoGraphQLClient.createWithWebClient(webClient)
+        val result = client.reactiveExecuteQuery(
+            query = "{ withUriParam }",
+            requestBodyUriCustomizer = {
+                it.uri { uriBuilder ->
+                    uriBuilder
+                        .queryParam("q1", "one")
+                        .build()
+                }
+            }
+        ).map { r -> r.extractValue<String>("withUriParam") }
+
+        StepVerifier.create(result)
+            .expectNext("Parameter q1: one")
+            .verifyComplete()
+    }
+
+    @Test
     fun `Graphql errors should be handled`() {
+        val client = MonoGraphQLClient.createWithWebClient(WebClient.create("http://localhost:$port/graphql"))
         val errors = client.reactiveExecuteQuery("{error}").map { r -> r.errors }
 
         StepVerifier.create(errors)
@@ -100,27 +138,25 @@ class WebClientGraphQLClientTest {
                 return "Header value: $myheader"
             }
 
+            @DgsQuery
+            fun withUriParam(@RequestParam("q1") param: String): String {
+                return "Parameter q1: $param"
+            }
+
             @DgsTypeDefinitionRegistry
             fun typeDefinitionRegistry(): TypeDefinitionRegistry {
-                val newRegistry = TypeDefinitionRegistry()
-                newRegistry.add(
-                    ObjectTypeDefinition.newObjectTypeDefinition().name("Query")
-                        .fieldDefinition(
-                            FieldDefinition.newFieldDefinition()
-                                .name("hello")
-                                .type(TypeName("String")).build()
-                        ).fieldDefinition(
-                            FieldDefinition.newFieldDefinition()
-                                .name("withHeader")
-                                .type(TypeName("String")).build()
-                        ).fieldDefinition(
-                            FieldDefinition.newFieldDefinition()
-                                .name("error")
-                                .type(TypeName("String")).build()
-                        )
-                        .build()
-                )
-                return newRegistry
+                val schemaParser = SchemaParser()
+
+                @Language("graphql")
+                val gqlSchema = """
+                type Query{
+                    hello: String 
+                    withHeader: String
+                    withUriParam: String
+                    error: String
+                }
+                """.trimMargin()
+                return schemaParser.parse(gqlSchema)
             }
         }
     }

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -937,7 +937,7 @@ class MicrometerServletSmokeTest {
             val executor = ThreadPoolTaskExecutor()
             executor.corePoolSize = 1
             executor.maxPoolSize = 1
-            executor.threadNamePrefix = "${MicrometerServletSmokeTest::class.java.simpleName}-test-"
+            executor.setThreadNamePrefix("${MicrometerServletSmokeTest::class.java.simpleName}-test-")
             executor.setQueueCapacity(10)
             executor.initialize()
             return executor


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

The WebClientGraphQLClient now offers a mechanism to customize the URI and Header parameters per request. This is done by allowing the user to define a `RequestBodyUriCustomizer`, a functional interface, that will receive a `WebClient.RequestBodyUriSpec` and return a  `RequestBodySpecwichiBody`.

The customization of the `WebClient.RequestBodyUriSpec` happens before the `WebClientGraphQLClient` will apply the `headerConsumer` and serialize the GraphQL Request as the body.

Example
```
val result = client.reactiveExecuteQuery(
    query = "{ hello(name: \"foo\")  }",
    requestBodyUriCustomizer = {
        it.uri { uriBuilder -> uriBuilder.queryParam("q1", "one").build() }
    }
)
```