### PR TITLE
Have the ability to turn off the BigDecimal and BigInteger extended scalars

### DIFF
--- a/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
+++ b/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
@@ -21,10 +21,13 @@ import com.netflix.graphql.dgs.DgsRuntimeWiring
 import graphql.scalars.ExtendedScalars
 import graphql.schema.GraphQLScalarType
 import graphql.schema.idl.RuntimeWiring
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.ConfigurationCondition
 
 @ConditionalOnClass(graphql.scalars.ExtendedScalars::class)
 @ConditionalOnProperty(
@@ -108,12 +111,77 @@ open class DgsExtendedScalarsAutoConfiguration {
                         // Others
                         ExtendedScalars.GraphQLLong,
                         ExtendedScalars.GraphQLShort,
-                        ExtendedScalars.GraphQLByte,
-                        ExtendedScalars.GraphQLBigDecimal,
-                        ExtendedScalars.GraphQLBigInteger
+                        ExtendedScalars.GraphQLByte
                     )
                 }
             }
+        }
+
+        @Conditional(OnBigDecimalAndNumbers::class)
+        @Configuration(proxyBeanMethods = false)
+        open class BigDecimalAutoConfiguration {
+            @Bean
+            open fun bigDecimalExtendedScalarsRegistrar(): ExtendedScalarRegistrar {
+                return object : AbstractExtendedScalarRegistrar() {
+                    override fun getScalars(): List<GraphQLScalarType> {
+                        return listOf(
+                            // Others
+                            ExtendedScalars.GraphQLBigDecimal
+                        )
+                    }
+                }
+            }
+        }
+
+        open class OnBigDecimalAndNumbers :
+            AllNestedConditions(ConfigurationCondition.ConfigurationPhase.PARSE_CONFIGURATION) {
+            @ConditionalOnProperty(
+                prefix = "dgs.graphql.extensions.scalars.numbers.",
+                name = ["enabled"],
+                havingValue = "true",
+                matchIfMissing = true
+            )
+            open class OnNumbers
+
+            @ConditionalOnProperty(
+                prefix = "dgs.graphql.extensions.scalars.numbers.bigdecimal",
+                name = ["enabled"],
+                havingValue = "true",
+                matchIfMissing = true
+            )
+            open class OnBigDecimal
+        }
+
+        @Conditional(OnBigIntegerAndNumbers::class)
+        @Configuration(proxyBeanMethods = false)
+        open class BigIntegerAutoConfiguration {
+            @Bean
+            open fun bigIntegerExtendedScalarsRegistrar(): ExtendedScalarRegistrar {
+                return object : AbstractExtendedScalarRegistrar() {
+                    override fun getScalars(): List<GraphQLScalarType> {
+                        return listOf(ExtendedScalars.GraphQLBigInteger)
+                    }
+                }
+            }
+        }
+
+        open class OnBigIntegerAndNumbers :
+            AllNestedConditions(ConfigurationCondition.ConfigurationPhase.PARSE_CONFIGURATION) {
+            @ConditionalOnProperty(
+                prefix = "dgs.graphql.extensions.scalars.numbers.",
+                name = ["enabled"],
+                havingValue = "true",
+                matchIfMissing = true
+            )
+            open class OnNumbers
+
+            @ConditionalOnProperty(
+                prefix = "dgs.graphql.extensions.scalars.numbers.biginteger",
+                name = ["enabled"],
+                havingValue = "true",
+                matchIfMissing = true
+            )
+            open class OnBigInteger
         }
     }
 

--- a/graphql-dgs-extended-scalars/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-extended-scalars/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -19,7 +19,17 @@
     {
       "name": "dgs.graphql.extensions.scalars.numbers.enabled",
       "type": "java.lang.Boolean",
-      "description": "Enabled by default, if dgs.graphql.extensions.scalars.enabled is enabled, will register all numeric scalar extensions such as PositiveInt, NegativeInt, etc."
+      "description": "Enabled by default, will register all numeric scalar extensions such as PositiveInt, NegativeInt, etc."
+    },
+    {
+      "name": "dgs.graphql.extensions.scalars.numbers.bigdecimal.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enabled by default, can be used to disable the BigDecimal scalar; it requires dgs.graphql.extensions.scalars.numbers.enabled to be enabled as well."
+    },
+    {
+      "name": "dgs.graphql.extensions.scalars.numbers.biginteger.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enabled by default, can be used to disable the BigInteger scalar; it requires dgs.graphql.extensions.scalars.numbers.enabled to be enabled as well."
     },
     {
       "name": "dgs.graphql.extensions.scalars.chars.enabled",

--- a/graphql-dgs-extended-scalars/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfigurationTests.kt
+++ b/graphql-dgs-extended-scalars/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfigurationTests.kt
@@ -35,6 +35,8 @@ internal class DgsExtendedScalarsAutoConfigurationTests {
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.CharsExtendedScalarsAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration::class.java)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration.BigDecimalAutoConfiguration::class.java)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration.BigIntegerAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.ObjectsExtendedScalarsAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.TimeExtendedScalarsAutoConfiguration::class.java)
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration.IDsExtendedScalarsAutoConfiguration::class.java)
@@ -84,6 +86,36 @@ internal class DgsExtendedScalarsAutoConfigurationTests {
                 .hasSingleBean(DgsExtendedScalarsAutoConfiguration::class.java)
             assertThat(context)
                 .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration::class.java)
+                .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration.BigDecimalAutoConfiguration::class.java)
+                .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration.BigIntegerAutoConfiguration::class.java)
+        }
+    }
+
+    @Test
+    fun `The BigDecimal scalar can be disabled`() {
+        context.withPropertyValues(
+            "dgs.graphql.extensions.scalars.numbers.bigdecimal.enabled=false"
+        ).run { context ->
+            assertThat(context)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration::class.java)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration::class.java)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration.BigIntegerAutoConfiguration::class.java)
+            assertThat(context)
+                .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration.BigDecimalAutoConfiguration::class.java)
+        }
+    }
+
+    @Test
+    fun `The BigInteger scalar can be disabled`() {
+        context.withPropertyValues(
+            "dgs.graphql.extensions.scalars.numbers.biginteger.enabled=false"
+        ).run { context ->
+            assertThat(context)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration::class.java)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration::class.java)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration.BigDecimalAutoConfiguration::class.java)
+            assertThat(context)
+                .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.NumbersExtendedScalarsAutoConfiguration.BigIntegerAutoConfiguration::class.java)
         }
     }
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This commit enables developers to turn off the BigDecimal and/or BigInteger Extended Scalars. This is done via the

* dgs.graphql.extensions.scalars.numbers.bigdecimal.enabled
* dgs.graphql.extensions.scalars.numbers.biginteger.enabled


Alternatives considered
----

Provide a more generic auto-configuraiton setup that allows developers to enable/disable extended scalars by name.

