### PR TITLE
Make session security context available for both WebSocket protocols

### DIFF
--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandler.kt
@@ -55,7 +55,6 @@ class WebsocketGraphQLWSProtocolHandler(private val dgsQueryExecutor: DgsQueryEx
 
     public override fun handleTextMessage(session: WebSocketSession, message: TextMessage) {
         val (type, payload, id) = objectMapper.readValue(message.payload, OperationMessage::class.java)
-        loadSecurityContextFromSession(session)
         when (type) {
             GQL_CONNECTION_INIT -> {
                 logger.info("Initialized connection for {}", session.id)
@@ -85,15 +84,6 @@ class WebsocketGraphQLWSProtocolHandler(private val dgsQueryExecutor: DgsQueryEx
                 session.close()
             }
             else -> session.sendMessage(TextMessage(objectMapper.writeValueAsBytes(OperationMessage("error"))))
-        }
-    }
-
-    private fun loadSecurityContextFromSession(session: WebSocketSession) {
-        if (springSecurityAvailable) {
-            val securityContext = session.attributes["SPRING_SECURITY_CONTEXT"] as? SecurityContext
-            if (securityContext != null) {
-                SecurityContextHolder.setContext(securityContext)
-            }
         }
     }
 
@@ -162,12 +152,5 @@ class WebsocketGraphQLWSProtocolHandler(private val dgsQueryExecutor: DgsQueryEx
     private companion object {
         val logger = LoggerFactory.getLogger(WebsocketGraphQLWSProtocolHandler::class.java)
         val objectMapper = jacksonObjectMapper()
-
-        private val springSecurityAvailable: Boolean by lazy {
-            ClassUtils.isPresent(
-                "org.springframework.security.core.context.SecurityContextHolder",
-                WebsocketGraphQLWSProtocolHandler::class.java.classLoader
-            )
-        }
     }
 }

--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandler.kt
@@ -25,9 +25,6 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
-import org.springframework.security.core.context.SecurityContext
-import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.util.ClassUtils
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Initial Issue see: https://github.com/Netflix/dgs-framework/pull/814 - This fixes a bug where we do not receive the SecurityContext when using `WebsocketGraphQlTransportWSProtocoll`. The logic which is used in `WebsocketGraphQLWSProtocolHandler` where the SecurityContext is loaded from the session, should be called regardless of which protocol is used. So i moved the logic up again to `DgsWebSocketHandler` where it was before so it gets called

Alternatives considered
----

