### PR TITLE
Apply custom objectmapper toSpringResponse()

### DIFF
--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -227,8 +227,8 @@ open class DgsRestController(
         }
 
         return when (executionResult) {
-            is DgsExecutionResult -> executionResult.toSpringResponse()
-            else -> DgsExecutionResult.builder().executionResult(executionResult).build().toSpringResponse()
+            is DgsExecutionResult -> executionResult.toSpringResponse(mapper)
+            else -> DgsExecutionResult.builder().executionResult(executionResult).build().toSpringResponse(mapper)
         }
     }
 }


### PR DESCRIPTION
…ponse()

Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

DgsRestController fix (toSpringResponse() mapper args added)

Alternatives considered
----
https://netflix.github.io/dgs/advanced/custom-object-mapper/

```java
@Bean
@Qualifier("dgsObjectMapper")
public ObjectMapper dgsObjectMapper() {
  ObjectMapper customMapper = new ObjectMapper()
  customMapper.registerModule(JavaTimeModule());
  return customMapper;
}
```
I hope that the next setting will also be applied toSpringResponse() in objectMapper.

## Actual behavior
but customMapper not working.

```kotlin
@RestController
open class DgsRestController(
    open val dgsQueryExecutor: DgsQueryExecutor,
    open val mapper: ObjectMapper = jacksonObjectMapper(),
    open val dgsGraphQLRequestHeaderValidator: DgsGraphQLRequestHeaderValidator = DefaultDgsGraphQLRequestHeaderValidator()
) 
```

It seems to be caused by not handing over the received parameters toSpring Response()

ex) DgsRestController : 230
```kotlin
as-is -> is DgsExecutionResult -> executionResult.toSpringResponse()
to-be -> is DgsExecutionResult -> executionResult.toSpringResponse(mapper) 
```

## Steps to reproduce

_Note: A test case would be highly appreciated, but we understand that's not always possible_ 

_Describe alternative implementation you have considered_

