### PR TITLE
Avoid using deprecated instrumentation parameters for metrics.

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLCollatedMetricsTagsProvider.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLCollatedMetricsTagsProvider.kt
@@ -38,14 +38,19 @@ class DgsGraphQLCollatedMetricsTagsProvider(
     }
 
     override fun getExecutionTags(
+        state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
         parameters: InstrumentationExecutionParameters,
         result: ExecutionResult,
         exception: Throwable?
     ): Iterable<Tag> {
-        return Tags.of(executionTagCustomizer.flatMap { it.getExecutionTags(parameters, result, exception) })
+        return Tags.of(executionTagCustomizer.flatMap { it.getExecutionTags(state, parameters, result, exception) })
     }
 
-    override fun getFieldFetchTags(parameters: InstrumentationFieldFetchParameters, exception: Throwable?): Iterable<Tag> {
-        return Tags.of(fieldFetchTagCustomizer.flatMap { it.getFieldFetchTags(parameters, exception) })
+    override fun getFieldFetchTags(
+        state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
+        parameters: InstrumentationFieldFetchParameters,
+        exception: Throwable?
+    ): Iterable<Tag> {
+        return Tags.of(fieldFetchTagCustomizer.flatMap { it.getFieldFetchTags(state, parameters, exception) })
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -77,7 +77,7 @@ class DgsGraphQLMetricsInstrumentation(
                     properties.autotime
                         .builder(GqlMetric.QUERY.key)
                         .tags(tagsProvider.getContextualTags())
-                        .tags(tagsProvider.getExecutionTags(parameters, result, exc))
+                        .tags(tagsProvider.getExecutionTags(miState, parameters, result, exc))
                         .tags(miState.tags())
                 )
             }
@@ -93,7 +93,7 @@ class DgsGraphQLMetricsInstrumentation(
         val tags =
             Tags.empty()
                 .and(tagsProvider.getContextualTags())
-                .and(tagsProvider.getExecutionTags(parameters, executionResult, null))
+                .and(tagsProvider.getExecutionTags(miState, parameters, executionResult, null))
                 .and(miState.tags())
 
         ErrorUtils
@@ -143,17 +143,18 @@ class DgsGraphQLMetricsInstrumentation(
                         recordDataFetcherMetrics(
                             registry,
                             sampler,
+                            miState,
                             parameters,
                             error,
                             baseTags
                         )
                     }
                 } else {
-                    recordDataFetcherMetrics(registry, sampler, parameters, null, baseTags)
+                    recordDataFetcherMetrics(registry, sampler, miState, parameters, null, baseTags)
                 }
                 result
             } catch (throwable: Throwable) {
-                recordDataFetcherMetrics(registry, sampler, parameters, throwable, baseTags)
+                recordDataFetcherMetrics(registry, sampler, miState, parameters, throwable, baseTags)
                 throw throwable
             }
         }
@@ -197,13 +198,14 @@ class DgsGraphQLMetricsInstrumentation(
     private fun recordDataFetcherMetrics(
         registry: MeterRegistry,
         timerSampler: Timer.Sample,
+        state: MetricsInstrumentationState,
         parameters: InstrumentationFieldFetchParameters,
         error: Throwable?,
         baseTags: Iterable<Tag>
     ) {
         val recordedTags = Tags
             .of(baseTags)
-            .and(tagsProvider.getFieldFetchTags(parameters, error))
+            .and(tagsProvider.getFieldFetchTags(state, parameters, error))
 
         timerSampler.stop(
             properties

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/DgsExecutionTagCustomizer.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/DgsExecutionTagCustomizer.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.metrics.micrometer.tagging
 
+import com.netflix.graphql.dgs.metrics.micrometer.DgsGraphQLMetricsInstrumentation
 import graphql.ExecutionResult
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import io.micrometer.core.instrument.Tag
@@ -24,6 +25,7 @@ import io.micrometer.core.instrument.Tag
 fun interface DgsExecutionTagCustomizer {
 
     fun getExecutionTags(
+        state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
         parameters: InstrumentationExecutionParameters,
         result: ExecutionResult,
         exception: Throwable?

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/DgsFieldFetchTagCustomizer.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/DgsFieldFetchTagCustomizer.kt
@@ -16,11 +16,16 @@
 
 package com.netflix.graphql.dgs.metrics.micrometer.tagging
 
+import com.netflix.graphql.dgs.metrics.micrometer.DgsGraphQLMetricsInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
 import io.micrometer.core.instrument.Tag
 
 @FunctionalInterface
 fun interface DgsFieldFetchTagCustomizer {
 
-    fun getFieldFetchTags(parameters: InstrumentationFieldFetchParameters, error: Throwable?): Iterable<Tag>
+    fun getFieldFetchTags(
+        state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
+        parameters: InstrumentationFieldFetchParameters,
+        error: Throwable?
+    ): Iterable<Tag>
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/DgsGraphQLMetricsTagsProvider.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/DgsGraphQLMetricsTagsProvider.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.metrics.micrometer.tagging
 
+import com.netflix.graphql.dgs.metrics.micrometer.DgsGraphQLMetricsInstrumentation
 import graphql.ExecutionResult
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
@@ -27,10 +28,15 @@ interface DgsGraphQLMetricsTagsProvider {
     fun getContextualTags(): Iterable<Tag> = Tags.empty()
 
     fun getExecutionTags(
+        state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
         parameters: InstrumentationExecutionParameters,
         result: ExecutionResult,
         exception: Throwable?
     ): Iterable<Tag> = Tags.empty()
 
-    fun getFieldFetchTags(parameters: InstrumentationFieldFetchParameters, exception: Throwable?): Iterable<Tag> = Tags.empty()
+    fun getFieldFetchTags(
+        state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
+        parameters: InstrumentationFieldFetchParameters,
+        exception: Throwable?
+    ): Iterable<Tag> = Tags.empty()
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/SimpleGqlOutcomeTagCustomizer.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/SimpleGqlOutcomeTagCustomizer.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.metrics.micrometer.tagging
 
 import com.netflix.graphql.dgs.metrics.DgsMetrics.CommonTags.*
+import com.netflix.graphql.dgs.metrics.micrometer.DgsGraphQLMetricsInstrumentation
 import graphql.ExecutionResult
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
@@ -26,6 +27,7 @@ import io.micrometer.core.instrument.Tags
 class SimpleGqlOutcomeTagCustomizer : DgsExecutionTagCustomizer, DgsFieldFetchTagCustomizer {
 
     override fun getExecutionTags(
+        state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
         parameters: InstrumentationExecutionParameters,
         result: ExecutionResult,
         exception: Throwable?
@@ -38,6 +40,7 @@ class SimpleGqlOutcomeTagCustomizer : DgsExecutionTagCustomizer, DgsFieldFetchTa
     }
 
     override fun getFieldFetchTags(
+        state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
         parameters: InstrumentationFieldFetchParameters,
         error: Throwable?
     ): Iterable<Tag> {

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -792,12 +792,12 @@ class MicrometerServletSmokeTest {
 
         @Bean
         open fun executionTagCustomizer(): DgsExecutionTagCustomizer {
-            return DgsExecutionTagCustomizer { _, _, _ -> Tags.of("execution-tag", "foo") }
+            return DgsExecutionTagCustomizer { _, _, _, _ -> Tags.of("execution-tag", "foo") }
         }
 
         @Bean
         open fun fieldFetchTagCustomizer(): DgsFieldFetchTagCustomizer {
-            return DgsFieldFetchTagCustomizer { _, _ -> Tags.of("field-fetch-tag", "foo") }
+            return DgsFieldFetchTagCustomizer { _, _, _ -> Tags.of("field-fetch-tag", "foo") }
         }
     }
 


### PR DESCRIPTION

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
These fixes are needed to ensure things work when we have ChainedInstrumentation classes, since the type would be a ChainedInstrumentationState that cannot be cast to MetricsInstrumentationState.