### PR TITLE
add null safety to type resolver

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -434,9 +434,13 @@ class DgsSchemaProvider(
                         runtimeWiringBuilder.type(
                             TypeRuntimeWiring.newTypeWiring(annotation.name)
                                 .typeResolver { env: TypeResolutionEnvironment ->
-                                    val typeName =
-                                        ReflectionUtils.invokeMethod(method, dgsComponent, env.getObject()) as String
-                                    env.schema.getObjectType(typeName)
+                                    val typeName: String? =
+                                        ReflectionUtils.invokeMethod(method, dgsComponent, env.getObject()) as String?
+                                    if (typeName != null) {
+                                        env.schema.getObjectType(typeName)
+                                    } else {
+                                        null
+                                    }
                                 }
                         )
                     }


### PR DESCRIPTION
Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
My DGS serves a lot of abstract types. Sometimes type resolvers are missing, or are incomplete. This results in `null` being returned here:
```
ReflectionUtils.invokeMethod(method, dgsComponent, env.getObject()) as String
```
and an NPE:

```
Caused by: java.lang.NullPointerException: null cannot be cast to non-null type kotlin.String
	at com.netflix.graphql.dgs.internal.DgsSchemaProvider.findTypeResolvers$lambda$30$lambda$29$lambda$28(DgsSchemaProvider.kt:438)
	at graphql.execution.ResolveType.resolveAbstractType(ResolveType.java:64)
	at graphql.execution.ResolveType.resolveTypeForUnion(ResolveType.java:60)
	at graphql.execution.ResolveType.resolveType(ResolveType.java:40)
	at graphql.execution.ExecutionStrategy.resolveType(ExecutionStrategy.java:698)
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:456)
	at graphql.execution.ExecutionStrategy.completeField(ExecutionStrategy.java:407)
	at graphql.execution.ExecutionStrategy.lambda$resolveFieldWithInfo$1(ExecutionStrategy.java:213)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
```

This addresses this null pointer exception.

Alternatives considered
----

_Describe alternative implementation you have considered_

I've also made the required changes to not return null, but we should also not throw an NPE.