### PR TITLE
Update to Spring boot 3 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 17
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
@@ -59,14 +59,14 @@ jobs:
       - name: Clone dgs-examples-java
         uses: actions/checkout@v3.1.0
         with:
-          repository: Netflix/dgs-examples-java-2.7
-          path: build/examples/dgs-examples-java-2.7
+          repository: Netflix/dgs-examples-java
+          path: build/examples/dgs-examples-java
 
       - name: Clone dgs-examples-kotlin
         uses: actions/checkout@v3.1.0
         with:
-          repository: Netflix/dgs-examples-kotlin-2.7
-          path: build/examples/dgs-examples-kotlin-2.7
+          repository: Netflix/dgs-examples-kotlin
+          path: build/examples/dgs-examples-kotlin
 
       - name: Build Examples
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,11 @@ group = "com.netflix.graphql.dgs"
 plugins {
     `java-library`
     id("nebula.dependency-recommender") version "11.0.0"
+
     id("nebula.netflixoss") version "11.1.1"
     id("org.jmailen.kotlinter") version "3.11.1"
     id("me.champeau.jmh") version "0.6.6"
+
     kotlin("jvm") version Versions.KOTLIN_VERSION
     kotlin("kapt") version Versions.KOTLIN_VERSION
     idea
@@ -48,17 +50,18 @@ allprojects {
     // We are attempting to define the versions of the artifacts closest to the
     // place they are referenced such that dependabot can easily pick them up
     // and suggest an upgrade. The only exception currently are those defined
-    // in buildSrc, most likley because the variables are used in plugins as well
+    // in buildSrc, most likely because the variables are used in plugins as well
     // as dependencies. e.g. KOTLIN_VERSION
-    extra["sb.version"] = "2.7.5"
+    extra["sb.version"] = "3.0.0"
     val springBootVersion = extra["sb.version"] as String
 
     dependencyRecommendations {
         mavenBom(mapOf("module" to "org.jetbrains.kotlin:kotlin-bom:${Versions.KOTLIN_VERSION}"))
-        mavenBom(mapOf("module" to "org.springframework:spring-framework-bom:5.3.23"))
+
+        mavenBom(mapOf("module" to "org.springframework:spring-framework-bom:6.0.3"))
         mavenBom(mapOf("module" to "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
-        mavenBom(mapOf("module" to "org.springframework.security:spring-security-bom:5.7.4"))
-        mavenBom(mapOf("module" to "org.springframework.cloud:spring-cloud-dependencies:2021.0.3"))
+        mavenBom(mapOf("module" to "org.springframework.security:spring-security-bom:6.0.1"))
+        mavenBom(mapOf("module" to "org.springframework.cloud:spring-cloud-dependencies:2022.0.0"))
         mavenBom(mapOf("module" to "com.fasterxml.jackson:jackson-bom:2.13.4"))
     }
 }
@@ -108,7 +111,7 @@ configure(subprojects.filterNot { it in internalBomModules }) {
         // Produce Config Metadata for properties used in Spring Boot for Kotlin
         kapt("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")
 
-        // Sets sets the JMH version to use across modules.
+        // Sets the JMH version to use across modules.
         // Please refer to the following links for further reference.
         // * https://github.com/melix/jmh-gradle-plugin
         // * https://openjdk.java.net/projects/code-tools/jmh/
@@ -123,7 +126,7 @@ configure(subprojects.filterNot { it in internalBomModules }) {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(8))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
     }
 
@@ -164,7 +167,7 @@ configure(subprojects.filterNot { it in internalBomModules }) {
              * Ref. https://kotlinlang.org/docs/kotlin-reference.pdf
              */
             freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all-compatibility"
-            jvmTarget = "1.8"
+            jvmTarget = "17"
         }
     }
 

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -26,7 +26,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -62,7 +62,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -87,7 +87,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -127,7 +127,7 @@
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -156,7 +156,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -179,7 +179,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -199,7 +199,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -225,7 +225,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -251,7 +251,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -285,7 +285,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -308,7 +308,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -328,7 +328,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -348,7 +348,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -371,7 +371,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -391,7 +391,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -419,7 +419,7 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,22 +1,22 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "apiDependenciesMetadata": {
@@ -26,25 +26,25 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "implementationDependenciesMetadata": {
@@ -62,22 +62,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhApiDependenciesMetadata": {
@@ -87,13 +87,13 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.29"
@@ -102,16 +102,16 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -127,13 +127,13 @@
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.29"
@@ -142,64 +142,64 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -211,21 +211,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -237,21 +237,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -263,16 +263,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -285,7 +285,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -294,122 +294,122 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testImplementationDependenciesMetadata": {
@@ -419,25 +419,25 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -30,22 +30,57 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -66,7 +101,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -75,25 +110,25 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -109,22 +144,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -132,22 +167,57 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -168,7 +238,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -177,7 +247,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -189,22 +259,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -218,16 +288,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -237,13 +340,39 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -341,22 +470,26 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -378,7 +511,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -394,7 +527,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -427,7 +560,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -435,44 +568,44 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-test": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -483,10 +616,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
@@ -494,7 +627,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
@@ -502,87 +635,87 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -594,21 +727,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -620,21 +753,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -646,16 +779,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -668,7 +801,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -677,56 +810,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -734,22 +867,57 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -770,7 +938,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -779,51 +947,51 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -831,22 +999,57 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -922,13 +1125,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -945,37 +1152,37 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-test": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -989,16 +1196,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1008,13 +1248,39 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1112,22 +1378,26 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1149,7 +1419,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1165,7 +1435,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1189,7 +1459,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -1197,44 +1467,44 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-test": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1245,10 +1515,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
@@ -1256,7 +1526,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
@@ -1264,7 +1534,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -30,33 +30,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.14.1"
@@ -71,16 +45,7 @@
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -144,7 +109,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -167,33 +132,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.14.1"
@@ -208,16 +147,7 @@
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -288,49 +218,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -340,39 +237,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -470,11 +341,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -672,7 +539,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -695,7 +562,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -715,7 +582,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -741,7 +608,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -767,7 +634,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -801,7 +668,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -824,7 +691,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -844,7 +711,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -867,33 +734,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.14.1"
@@ -908,16 +749,7 @@
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -976,7 +808,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -999,33 +831,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.14.1"
@@ -1040,16 +846,7 @@
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1125,11 +922,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.1"
@@ -1196,49 +989,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1248,39 +1008,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1378,11 +1112,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClientTest.kt
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/CustomReactiveGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/CustomReactiveGraphQLClientTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.toEntity
 import reactor.test.StepVerifier

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/SSESubscriptionGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/SSESubscriptionGraphQLClientTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Flux

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebClientGraphQLClientTest.kt
@@ -28,7 +28,7 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClientWithDGSServerTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/WebSocketGraphQLClientWithDGSServerTest.kt
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient
 import reactor.test.StepVerifier
 

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -31,10 +31,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -143,7 +164,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -163,25 +184,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -197,22 +218,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -221,10 +242,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -333,7 +375,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -353,7 +395,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -365,22 +407,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -395,26 +437,74 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -424,16 +514,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -545,26 +668,30 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -586,7 +713,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -603,7 +730,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -637,16 +764,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-pagination"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
@@ -654,32 +781,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -689,7 +816,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
@@ -697,93 +824,93 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -795,21 +922,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -821,21 +948,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -847,16 +974,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -869,7 +996,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -878,56 +1005,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -942,26 +1069,74 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -971,16 +1146,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1095,20 +1303,20 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1130,7 +1338,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1147,7 +1355,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1172,16 +1380,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-pagination"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
@@ -1189,29 +1397,29 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1221,7 +1429,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
@@ -1229,33 +1437,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -1264,10 +1472,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1373,13 +1602,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1399,28 +1632,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1435,26 +1668,74 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1464,16 +1745,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1585,26 +1899,30 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1626,7 +1944,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1643,7 +1961,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1668,16 +1986,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-pagination"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
@@ -1685,32 +2003,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1720,7 +2038,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
@@ -1728,13 +2046,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -31,31 +31,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -218,7 +197,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -242,31 +221,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -437,74 +395,26 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -514,49 +424,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -668,11 +545,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -867,7 +740,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -890,7 +763,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -910,7 +783,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -936,7 +809,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -962,7 +835,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -996,7 +869,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1019,7 +892,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1039,7 +912,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1069,74 +942,26 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1146,49 +971,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1448,7 +1240,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1472,31 +1264,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1602,11 +1373,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1668,74 +1435,26 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1745,49 +1464,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1899,11 +1585,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -31,31 +31,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -222,7 +201,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -246,31 +225,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -445,74 +403,26 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -522,49 +432,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
@@ -706,22 +583,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "1.10.0-M3"
-=======
-            "locked": "1.10.0"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "1.10.2"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -743,11 +608,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-            "locked": "1.12.12"
-=======
             "locked": "1.12.19"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -879,23 +740,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "6.0.0-M5"
-=======
-            "locked": "6.0.0-RC3"
->>>>>>> 42b769e2 (feat: bumps spring framework to final RC.)
-=======
-            "locked": "6.0.0-RC4"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
-            "locked": "6.0.2"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
-=======
             "locked": "6.0.3"
->>>>>>> 505b6c24 (feat: bumps spring versions and removes milestone repository.)
         },
         "org.springframework:spring-framework-bom": {
             "locked": "6.0.3"
@@ -966,7 +811,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -989,7 +834,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1009,7 +854,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -1035,7 +880,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -1061,7 +906,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -1095,7 +940,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1118,7 +963,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1138,7 +983,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1168,74 +1013,26 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1245,49 +1042,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
@@ -1429,15 +1193,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "1.10.0-M3"
-=======
-            "locked": "1.10.0"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "1.10.2"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1456,11 +1212,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-            "locked": "1.12.12"
-=======
             "locked": "1.12.19"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1577,23 +1329,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "6.0.0-M5"
-=======
-            "locked": "6.0.0-RC3"
->>>>>>> 42b769e2 (feat: bumps spring framework to final RC.)
-=======
-            "locked": "6.0.0-RC4"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
-            "locked": "6.0.2"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
-=======
             "locked": "6.0.3"
->>>>>>> 505b6c24 (feat: bumps spring versions and removes milestone repository.)
         },
         "org.springframework:spring-framework-bom": {
             "locked": "6.0.3"
@@ -1632,7 +1368,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1656,31 +1392,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1789,11 +1504,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1862,74 +1573,26 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1939,49 +1602,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
@@ -2123,22 +1753,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "1.10.0-M3"
-=======
-            "locked": "1.10.0"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "1.10.2"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -2160,11 +1778,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-            "locked": "1.12.12"
-=======
             "locked": "1.12.19"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -2287,23 +1901,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "6.0.0-M5"
-=======
-            "locked": "6.0.0-RC3"
->>>>>>> 42b769e2 (feat: bumps spring framework to final RC.)
-=======
-            "locked": "6.0.0-RC4"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
-            "locked": "6.0.2"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
-=======
             "locked": "6.0.3"
->>>>>>> 505b6c24 (feat: bumps spring versions and removes milestone repository.)
         },
         "org.springframework:spring-framework-bom": {
             "locked": "6.0.3"

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -31,13 +31,34 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -146,7 +167,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -167,25 +188,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -201,22 +222,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -225,13 +246,34 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -340,7 +382,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -361,7 +403,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -373,22 +415,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -403,26 +445,74 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -432,22 +522,55 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -583,32 +706,48 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.9.5"
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "1.10.0-M3"
+=======
+            "locked": "1.10.0"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "1.10.2"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.bytebuddy:byte-buddy": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.12.18"
+<<<<<<< HEAD
+            "locked": "1.12.12"
+=======
+            "locked": "1.12.19"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -623,14 +762,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -649,7 +788,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -682,7 +821,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -690,60 +829,76 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-context-support": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "5.3.23"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "6.0.0-M5"
+=======
+            "locked": "6.0.0-RC3"
+>>>>>>> 42b769e2 (feat: bumps spring framework to final RC.)
+=======
+            "locked": "6.0.0-RC4"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "6.0.2"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+=======
+            "locked": "6.0.3"
+>>>>>>> 505b6c24 (feat: bumps spring versions and removes milestone repository.)
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -754,19 +909,19 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
@@ -774,87 +929,87 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -866,21 +1021,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -892,21 +1047,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -918,16 +1073,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -940,7 +1095,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -949,56 +1104,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -1013,26 +1168,74 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1042,22 +1245,55 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1193,26 +1429,38 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.9.5"
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "1.10.0-M3"
+=======
+            "locked": "1.10.0"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "1.10.2"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.bytebuddy:byte-buddy": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.12.18"
+<<<<<<< HEAD
+            "locked": "1.12.12"
+=======
+            "locked": "1.12.19"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1227,14 +1475,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1253,7 +1501,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1277,7 +1525,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -1285,54 +1533,70 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-context-support": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "5.3.23"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "6.0.0-M5"
+=======
+            "locked": "6.0.0-RC3"
+>>>>>>> 42b769e2 (feat: bumps spring framework to final RC.)
+=======
+            "locked": "6.0.0-RC4"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "6.0.2"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+=======
+            "locked": "6.0.3"
+>>>>>>> 505b6c24 (feat: bumps spring versions and removes milestone repository.)
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1343,19 +1607,19 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
@@ -1363,27 +1627,27 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -1392,13 +1656,34 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1504,16 +1789,20 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1534,31 +1823,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1573,26 +1862,74 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1602,22 +1939,55 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1753,32 +2123,48 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.9.5"
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "1.10.0-M3"
+=======
+            "locked": "1.10.0"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "1.10.2"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.bytebuddy:byte-buddy": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.12.18"
+<<<<<<< HEAD
+            "locked": "1.12.12"
+=======
+            "locked": "1.12.19"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1793,14 +2179,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1819,7 +2205,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1843,7 +2229,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
@@ -1851,60 +2237,76 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-context-support": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "5.3.23"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "6.0.0-M5"
+=======
+            "locked": "6.0.0-RC3"
+>>>>>>> 42b769e2 (feat: bumps spring framework to final RC.)
+=======
+            "locked": "6.0.0-RC4"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "6.0.2"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+=======
+            "locked": "6.0.3"
+>>>>>>> 505b6c24 (feat: bumps spring versions and removes milestone repository.)
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1915,19 +2317,19 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
@@ -1935,7 +2337,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/WithCookie.java
+++ b/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/WithCookie.java
@@ -33,7 +33,7 @@ public class WithCookie {
     public String updateCookie(@InputArgument String value, DgsDataFetchingEnvironment dfe) {
         DgsWebMvcRequestData requestData = (DgsWebMvcRequestData) dfe.getDgsContext().getRequestData();
         ServletWebRequest webRequest = (ServletWebRequest) requestData.getWebRequest();
-        javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie("mydgscookie", value);
+        jakarta.servlet.http.Cookie cookie = new jakarta.servlet.http.Cookie("mydgscookie", value);
         webRequest.getResponse().addCookie(cookie);
 
         return value;

--- a/graphql-dgs-example-java/src/test/java/subsciption/integrationtest/SubscriptionIntegrationTest.java
+++ b/graphql-dgs-example-java/src/test/java/subsciption/integrationtest/SubscriptionIntegrationTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -1,36 +1,57 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -90,7 +111,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -104,25 +125,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -138,30 +159,51 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -221,7 +263,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -235,7 +277,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -247,22 +289,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -273,23 +315,68 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -351,13 +438,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -379,7 +470,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -390,7 +481,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -423,40 +514,40 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-pagination"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -464,87 +555,87 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -556,21 +647,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -582,21 +673,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -608,16 +699,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -630,7 +721,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -639,56 +730,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -699,23 +790,68 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -777,7 +913,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -799,7 +935,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -810,7 +946,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -834,37 +970,37 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-pagination"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -872,35 +1008,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -960,13 +1117,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -980,28 +1141,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1012,23 +1173,68 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.13.4.2"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1090,13 +1296,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1118,7 +1328,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1129,7 +1339,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1153,40 +1363,40 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-pagination"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1194,7 +1404,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,31 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-databind": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -159,7 +138,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -179,31 +158,10 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-databind": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -315,68 +273,23 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -438,11 +351,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
@@ -592,7 +501,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -615,7 +524,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -635,7 +544,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -661,7 +570,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -687,7 +596,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -721,7 +630,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -744,7 +653,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -764,7 +673,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -790,68 +699,23 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1013,7 +877,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1033,31 +897,10 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-databind": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1117,11 +960,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
@@ -1173,68 +1012,23 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1296,11 +1090,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"

--- a/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/HelloDataFetcherTest.java
+++ b/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/HelloDataFetcherTest.java
@@ -61,9 +61,9 @@ class HelloDataFetcherTest {
             queryExecutor.executeAndExtractJsonPath("{greeting}", "data.greeting");
             fail("Exception should have been thrown");
         } catch (QueryException ex) {
-            assertThat(ex.getMessage())
-                    .contains("Validation error (FieldUndefined@[greeting]) : Field 'greeting' in type 'Query' is undefined");
-            assertThat(ex.getErrors()).hasSize(1);
+
+            assertThat(ex.getMessage()).contains("Validation error (FieldUndefined@[greeting]) : Field 'greeting' in type 'Query' is undefined");
+            assertThat(ex.getErrors().size()).isEqualTo(1);
         }
     }
 

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -1,33 +1,33 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -78,22 +78,22 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -109,27 +109,27 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -180,7 +180,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -192,19 +192,19 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -219,20 +219,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -241,16 +277,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -342,19 +411,23 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -376,7 +449,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -390,7 +463,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -423,50 +496,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -475,105 +548,105 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -585,21 +658,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -611,21 +684,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -637,16 +710,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -659,7 +732,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -668,56 +741,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -731,16 +804,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -795,7 +901,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -803,7 +909,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -827,54 +933,54 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -883,10 +989,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -977,13 +1104,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1000,25 +1131,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1033,20 +1164,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1055,16 +1222,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1156,19 +1356,23 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1190,7 +1394,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1204,7 +1408,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1228,50 +1432,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1280,25 +1484,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -109,7 +109,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -129,7 +129,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -219,56 +219,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -277,49 +241,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -411,11 +342,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -603,7 +530,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -626,7 +553,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -646,7 +573,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -672,7 +599,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -698,7 +625,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -732,7 +659,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -755,7 +682,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -775,7 +702,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -804,49 +731,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -965,7 +859,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -989,31 +883,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1104,11 +977,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1164,56 +1033,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1222,49 +1055,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1356,11 +1156,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
+++ b/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
@@ -21,6 +21,7 @@ import com.netflix.graphql.dgs.DgsRuntimeWiring
 import graphql.scalars.ExtendedScalars
 import graphql.schema.GraphQLScalarType
 import graphql.schema.idl.RuntimeWiring
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -36,7 +37,7 @@ import org.springframework.context.annotation.ConfigurationCondition
     havingValue = "true",
     matchIfMissing = true
 )
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 open class DgsExtendedScalarsAutoConfiguration {
 
     @ConditionalOnProperty(

--- a/graphql-dgs-extended-scalars/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-extended-scalars/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration

--- a/graphql-dgs-extended-scalars/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-extended-scalars/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -1,33 +1,33 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -78,22 +78,22 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -109,27 +109,27 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -180,7 +180,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -192,19 +192,19 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -219,20 +219,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -241,16 +277,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -342,19 +411,23 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -376,7 +449,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -390,7 +463,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -423,50 +496,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -475,105 +548,105 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -585,21 +658,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -611,21 +684,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -637,16 +710,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -659,7 +732,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -668,56 +741,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -731,16 +804,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -795,7 +901,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -803,7 +909,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -827,54 +933,54 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -883,10 +989,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -977,13 +1104,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1000,25 +1131,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1033,20 +1164,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1055,16 +1222,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1156,19 +1356,23 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1190,7 +1394,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1204,7 +1408,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1228,50 +1432,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1280,25 +1484,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -38,7 +38,7 @@
             "locked": "19.2"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "19.1-hibernate-validator-6.2.0.Final"
+            "locked": "19.1"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -109,7 +109,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -129,7 +129,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -140,7 +140,7 @@
             "locked": "19.2"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "19.1-hibernate-validator-6.2.0.Final"
+            "locked": "19.1"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -219,56 +219,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -277,49 +241,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -332,7 +263,7 @@
             "locked": "19.2"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "19.1-hibernate-validator-6.2.0.Final"
+            "locked": "19.1"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -411,11 +342,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -603,7 +530,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -626,7 +553,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -646,7 +573,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -672,7 +599,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -698,7 +625,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -732,7 +659,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -755,7 +682,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -775,7 +702,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -804,49 +731,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -857,7 +751,7 @@
             "locked": "19.2"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "19.1-hibernate-validator-6.2.0.Final"
+            "locked": "19.1"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -965,7 +859,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -989,31 +883,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1025,7 +898,7 @@
             "locked": "19.2"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "19.1-hibernate-validator-6.2.0.Final"
+            "locked": "19.1"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -1104,11 +977,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1164,56 +1033,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1222,49 +1055,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1277,7 +1077,7 @@
             "locked": "19.2"
         },
         "com.graphql-java:graphql-java-extended-validation": {
-            "locked": "19.1-hibernate-validator-6.2.0.Final"
+            "locked": "19.1"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -1356,11 +1156,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-validation/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedValidationAutoConfiguration.kt
+++ b/graphql-dgs-extended-validation/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedValidationAutoConfiguration.kt
@@ -22,10 +22,10 @@ import graphql.schema.idl.RuntimeWiring
 import graphql.validation.rules.ValidationRules
 import graphql.validation.schemawiring.ValidationSchemaWiring
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 
 @ConditionalOnClass(graphql.validation.rules.ValidationRules::class)
 @ConditionalOnProperty(
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Configuration
     havingValue = "true",
     matchIfMissing = true
 )
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 open class DgsExtendedValidationAutoConfiguration {
 
     @Bean

--- a/graphql-dgs-extended-validation/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-extended-validation/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.graphql.dgs.autoconfig.DgsExtendedValidationAutoConfiguration

--- a/graphql-dgs-extended-validation/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-extended-validation/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.graphql.dgs.autoconfig.DgsExtendedValidationAutoConfiguration

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -1,33 +1,33 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -42,22 +42,22 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -73,27 +73,27 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -108,7 +108,7 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -120,24 +120,24 @@
             "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -146,7 +146,11 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "locked": "1.6.0"
@@ -155,7 +159,7 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -167,102 +171,102 @@
             "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -274,21 +278,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -300,21 +304,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -326,16 +330,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -348,7 +352,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -357,61 +361,61 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -426,47 +430,47 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -475,7 +479,11 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "locked": "1.6.0"
@@ -484,30 +492,30 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -516,7 +524,11 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "locked": "1.6.0"
@@ -525,25 +537,25 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -73,7 +73,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -93,7 +93,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -137,7 +137,7 @@
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -146,11 +146,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "locked": "1.6.0"
@@ -223,7 +219,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -246,7 +242,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -266,7 +262,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -292,7 +288,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -318,7 +314,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -352,7 +348,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -375,7 +371,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -395,7 +391,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -415,7 +411,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -450,7 +446,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -470,7 +466,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -479,11 +475,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "locked": "1.6.0"
@@ -515,7 +507,7 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -524,11 +516,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "locked": "1.6.0"

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -1,33 +1,33 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -75,22 +75,22 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -106,27 +106,27 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -174,7 +174,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -186,19 +186,19 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -212,16 +212,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -261,7 +294,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.0.0"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -276,7 +319,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -284,7 +327,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -317,117 +360,117 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -439,21 +482,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -465,21 +508,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -491,16 +534,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -513,7 +556,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -522,56 +565,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -585,16 +628,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -646,7 +722,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -654,7 +730,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -678,59 +754,59 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -770,7 +846,11 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -781,25 +861,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -813,16 +893,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -862,7 +975,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.0.0"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -877,7 +1000,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -885,7 +1008,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -909,37 +1032,37 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -106,7 +106,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -126,7 +126,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -212,49 +212,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -294,17 +261,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.0.0"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -427,7 +384,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -450,7 +407,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -470,7 +427,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -496,7 +453,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -522,7 +479,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -556,7 +513,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -579,7 +536,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -599,7 +556,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -628,49 +585,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -786,7 +710,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -806,7 +730,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -846,11 +770,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -893,49 +813,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -975,17 +862,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.0.0"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-pagination/src/main/kotlin/com/netflix/graphql/dgs/pagination/DgsPaginationAutoConfiguration.kt
+++ b/graphql-dgs-pagination/src/main/kotlin/com/netflix/graphql/dgs/pagination/DgsPaginationAutoConfiguration.kt
@@ -16,10 +16,10 @@
 
 package com.netflix.graphql.dgs.pagination
 
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 
-@Configuration
+@AutoConfiguration
 open class DgsPaginationAutoConfiguration {
     @Bean
     open fun dgsPaginationTypeDefinitionRegistry(): DgsPaginationTypeDefinitionRegistry {

--- a/graphql-dgs-pagination/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-pagination/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.graphql.dgs.pagination.DgsPaginationAutoConfiguration

--- a/graphql-dgs-pagination/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-pagination/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.graphql.dgs.pagination.DgsPaginationAutoConfiguration

--- a/graphql-dgs-platform-dependencies/dependencies.lock
+++ b/graphql-dgs-platform-dependencies/dependencies.lock
@@ -6,7 +6,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-platform-dependencies/dependencies.lock
+++ b/graphql-dgs-platform-dependencies/dependencies.lock
@@ -6,22 +6,22 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -48,12 +48,16 @@ dependencies {
     constraints {
         // GraphQL Platform
         api("com.graphql-java:graphql-java") {
+<<<<<<< HEAD
             version {
                 strictly("[19.2, 20[")
                 prefer("19.2")
                 reject("18.2")
             }
 
+=======
+            version { require("19.2") }
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         }
         api("com.graphql-java:graphql-java-extended-scalars") {
             version {

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -48,16 +48,12 @@ dependencies {
     constraints {
         // GraphQL Platform
         api("com.graphql-java:graphql-java") {
-<<<<<<< HEAD
             version {
                 strictly("[19.2, 20[")
                 prefer("19.2")
                 reject("18.2")
             }
 
-=======
-            version { require("19.2") }
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         }
         api("com.graphql-java:graphql-java-extended-scalars") {
             version {
@@ -67,8 +63,7 @@ dependencies {
             }
         }
         api("com.graphql-java:graphql-java-extended-validation") {
-            // The version below will work with Jakarta EE 8 and use Hibernate Validator 6.2.
-            version { strictly("19.1-hibernate-validator-6.2.0.Final") }
+            version { strictly("19.1") }
         }
         api("com.apollographql.federation:federation-graphql-java-support") {
             version {

--- a/graphql-dgs-platform/dependencies.lock
+++ b/graphql-dgs-platform/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-platform/dependencies.lock
+++ b/graphql-dgs-platform/dependencies.lock
@@ -1,22 +1,22 @@
 {
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,31 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -139,7 +118,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -159,31 +138,10 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -278,50 +236,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -377,11 +302,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.0"
@@ -527,7 +448,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -550,7 +471,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -570,7 +491,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -596,7 +517,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -622,7 +543,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -656,7 +577,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -679,7 +600,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -699,7 +620,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -728,49 +649,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -892,7 +780,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -912,31 +800,10 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -992,11 +859,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.0"
@@ -1053,50 +916,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1152,11 +982,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.0"

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -1,36 +1,57 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -70,7 +91,7 @@
             "project": true
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -81,28 +102,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -118,30 +139,51 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -181,7 +223,7 @@
             "project": true
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -192,7 +234,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
@@ -207,22 +249,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -236,17 +278,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -302,13 +377,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -330,7 +409,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -340,7 +419,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -373,34 +452,34 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -408,90 +487,90 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -503,21 +582,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -529,21 +608,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -555,16 +634,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -577,7 +656,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -586,56 +665,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -649,16 +728,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -698,7 +810,7 @@
             "project": true
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -713,7 +825,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -721,7 +833,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -745,65 +857,86 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -859,13 +992,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -878,31 +1015,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -916,17 +1053,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -982,13 +1152,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1010,7 +1184,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1020,7 +1194,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1044,34 +1218,34 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1079,10 +1253,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -31,13 +31,34 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -131,16 +152,16 @@
             "locked": "1.15"
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.9.5"
+            "locked": "1.10.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.12.18"
+            "locked": "1.12.19"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -157,28 +178,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context-support": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -194,22 +215,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -218,13 +239,34 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -318,16 +360,16 @@
             "locked": "1.15"
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.9.5"
+            "locked": "1.10.2"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.12.18"
+            "locked": "1.12.19"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -344,7 +386,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -356,25 +398,25 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context-support": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -389,20 +431,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -411,19 +489,52 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -518,25 +629,29 @@
             "locked": "1.15"
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.9.5"
+            "locked": "1.10.2"
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.12.18"
+            "locked": "1.12.19"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -551,14 +666,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -572,7 +687,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -605,53 +720,53 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-context-support": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -660,105 +775,105 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -770,21 +885,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -796,21 +911,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -822,16 +937,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -844,7 +959,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -853,56 +968,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -916,19 +1031,52 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -974,10 +1122,10 @@
             "locked": "1.15"
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.9.5"
+            "locked": "1.10.2"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.12.18"
+            "locked": "1.12.19"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -986,13 +1134,13 @@
             "locked": "1.6.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1000,7 +1148,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1024,54 +1172,54 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-context-support": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -1080,13 +1228,34 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1180,19 +1349,23 @@
             "locked": "1.15"
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.9.5"
+            "locked": "1.10.2"
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.12.18"
+            "locked": "1.12.19"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1209,31 +1382,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context-support": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1248,20 +1421,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1270,19 +1479,52 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1377,25 +1619,29 @@
             "locked": "1.15"
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.9.5"
+            "locked": "1.10.2"
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.12.18"
+            "locked": "1.12.19"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1410,14 +1656,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1431,7 +1677,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1455,53 +1701,53 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-context-support": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1510,25 +1756,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -31,31 +31,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -215,7 +194,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -239,31 +218,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -431,56 +389,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -489,49 +411,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -632,11 +521,7 @@
             "locked": "1.10.2"
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -830,7 +715,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -853,7 +738,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -873,7 +758,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -899,7 +784,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -925,7 +810,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -959,7 +844,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -982,7 +867,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1002,7 +887,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1031,49 +916,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1204,7 +1056,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1228,31 +1080,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1352,11 +1183,7 @@
             "locked": "1.10.2"
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1421,56 +1248,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1479,49 +1270,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1622,11 +1380,7 @@
             "locked": "1.10.2"
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsProperties.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsProperties.kt
@@ -1,6 +1,7 @@
 package com.netflix.graphql.dgs.metrics.micrometer
 
 import org.springframework.boot.actuate.autoconfigure.metrics.AutoTimeProperties
+import org.springframework.boot.actuate.autoconfigure.metrics.PropertiesAutoTimer
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.boot.context.properties.bind.DefaultValue
@@ -8,8 +9,10 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 @ConfigurationProperties("management.metrics.dgs-graphql")
 data class DgsGraphQLMetricsProperties(
     /** Auto-timed queries settings. */
+    var autotimeProperties: AutoTimeProperties = AutoTimeProperties(),
+    /** Auto-timer. */
     @NestedConfigurationProperty
-    var autotime: AutoTimeProperties = AutoTimeProperties(),
+    var autotime: PropertiesAutoTimer = PropertiesAutoTimer(autotimeProperties),
     /** Settings that can be used to limit some of the tag metrics used by DGS. */
     @NestedConfigurationProperty
     var tags: TagsProperties = TagsProperties()

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMicrometerAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMicrometerAutoConfiguration.kt
@@ -12,7 +12,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration
-import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -26,9 +26,8 @@ import java.util.*
  * [Auto-configuration][org.springframework.boot.autoconfigure.EnableAutoConfiguration] for instrumentation of Spring GraphQL
  * endpoints.
  */
-@AutoConfigureAfter(CompositeMeterRegistryAutoConfiguration::class)
 @ConditionalOnClass(MetricsAutoConfiguration::class, MeterRegistry::class)
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = [CompositeMeterRegistryAutoConfiguration::class])
 @ConditionalOnProperty(prefix = AUTO_CONF_PREFIX, name = ["enabled"], havingValue = "true", matchIfMissing = true)
 open class DgsGraphQLMicrometerAutoConfiguration {
 

--- a/graphql-dgs-spring-boot-micrometer/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-spring-boot-micrometer/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.graphql.dgs.metrics.micrometer.DgsGraphQLMicrometerAutoConfiguration

--- a/graphql-dgs-spring-boot-micrometer/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-spring-boot-micrometer/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.graphql.dgs.metrics.micrometer.DgsGraphQLMicrometerAutoConfiguration

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsPropertiesTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsPropertiesTest.kt
@@ -36,8 +36,8 @@ internal class DgsGraphQLMetricsPropertiesTest {
 
             assertThat(props).isNotNull
             assertThat(props.autotime.isEnabled).isTrue
-            assertThat(props.autotime.percentiles).isNull()
-            assertThat(props.autotime.isPercentilesHistogram).isFalse
+            assertThat(props.autotimeProperties.percentiles).isNull()
+            assertThat(props.autotimeProperties.isPercentilesHistogram).isFalse
 
             assertThat(props.tags).isNotNull
             assertThat(props.tags.limiter.kind).isEqualTo(DgsGraphQLMetricsProperties.CardinalityLimiterKind.FIRST)

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,11 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-            "locked": "2.13.2"
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -134,7 +130,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -154,11 +150,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-            "locked": "2.13.2"
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -268,50 +260,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -362,11 +321,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
@@ -501,7 +456,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -524,7 +479,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -544,7 +499,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -570,7 +525,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -596,7 +551,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -630,7 +585,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -653,7 +608,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -673,7 +628,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -702,50 +657,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -875,7 +797,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -895,19 +817,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -958,11 +868,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
@@ -1018,50 +924,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1112,11 +985,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -1,36 +1,40 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+            "locked": "2.13.2"
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -78,10 +82,10 @@
             "project": true
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.9.5"
+            "locked": "1.10.2"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -96,25 +100,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -130,30 +134,34 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+            "locked": "2.13.2"
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -201,10 +209,10 @@
             "project": true
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.9.5"
+            "locked": "1.10.2"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -219,7 +227,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -231,22 +239,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -260,20 +268,53 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -321,10 +362,14 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -336,14 +381,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -352,7 +397,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -385,121 +430,121 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -511,21 +556,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -537,21 +582,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -563,16 +608,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -585,7 +630,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -594,56 +639,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -657,17 +702,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -731,7 +809,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -740,7 +818,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -764,63 +842,75 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -868,10 +958,14 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
@@ -886,31 +980,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -924,20 +1018,53 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -985,10 +1112,14 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1000,14 +1131,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1016,7 +1147,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1040,41 +1171,41 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/DgsAPQSupportAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/DgsAPQSupportAutoConfiguration.kt
@@ -27,6 +27,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics
 import org.apache.commons.lang3.StringUtils
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -36,7 +37,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Duration
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnProperty(
     prefix = DgsAPQSupportProperties.PREFIX,
     name = ["enabled"],

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/DgsAPQSupportProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/apq/DgsAPQSupportProperties.kt
@@ -17,12 +17,10 @@
 package com.netflix.graphql.dgs.apq
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.boot.context.properties.bind.DefaultValue
 
 @ConfigurationProperties(prefix = DgsAPQSupportProperties.PREFIX)
-@ConstructorBinding
 @Suppress("ConfigurationProperties")
 data class DgsAPQSupportProperties(
     /** Enables/Disables support for Automated Persisted Queries (APQ). */

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -46,6 +46,7 @@ import graphql.schema.visibility.GraphqlFieldVisibility
 import graphql.schema.visibility.NoIntrospectionGraphqlFieldVisibility.NO_INTROSPECTION_FIELD_VISIBILITY
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -54,19 +55,17 @@ import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.core.PriorityOrdered
 import org.springframework.core.annotation.Order
 import org.springframework.core.env.Environment
 import java.util.*
-import kotlin.streams.toList
 
 /**
  * Framework auto configuration based on open source Spring only, without Netflix integrations.
  * This does NOT have logging, tracing, metrics and security integration.
  */
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
-@Configuration
+@AutoConfiguration
 @EnableConfigurationProperties(DgsConfigurationProperties::class)
 @ImportAutoConfiguration(classes = [JacksonAutoConfiguration::class, DgsInputArgumentConfiguration::class])
 open class DgsAutoConfiguration(

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -18,13 +18,11 @@ package com.netflix.graphql.dgs.autoconfig
 
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider.Companion.DEFAULT_SCHEMA_LOCATION
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.bind.DefaultValue
 
 /**
  * Configuration properties for DGS framework.
  */
-@ConstructorBinding
 @ConfigurationProperties(prefix = DgsConfigurationProperties.PREFIX)
 @Suppress("ConfigurationProperties")
 data class DgsConfigurationProperties(

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration, \
-  com.netflix.graphql.dgs.apq.DgsAPQSupportAutoConfiguration
-
 org.springframework.boot.diagnostics.FailureAnalyzer=\
   com.netflix.graphql.dgs.diagnostics.SchemaFailureAnalyzer

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration
+com.netflix.graphql.dgs.apq.DgsAPQSupportAutoConfiguration

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/QueryExecutorTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/QueryExecutorTest.kt
@@ -119,8 +119,7 @@ class QueryExecutorTest {
         }
 
         assertThat(error.errors.size).isEqualTo(1)
-        assertThat(error.errors[0].message)
-            .isEqualTo("Validation error (FieldUndefined@[unknown]) : Field 'unknown' in type 'Query' is undefined")
+        assertThat(error.errors[0].message).isEqualTo("Validation error (FieldUndefined@[unknown]) : Field 'unknown' in type 'Query' is undefined")
     }
 
     @Test

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -31,10 +31,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -112,7 +133,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -128,25 +149,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -162,22 +183,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -186,10 +207,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -267,7 +309,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -283,7 +325,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -295,22 +337,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -325,20 +367,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -347,16 +425,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -432,19 +543,23 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -466,7 +581,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -479,7 +594,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -512,41 +627,41 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -555,105 +670,105 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -665,21 +780,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -691,21 +806,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -717,16 +832,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -739,7 +854,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -748,56 +863,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -812,20 +927,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -834,16 +985,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -922,13 +1106,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -950,7 +1134,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -963,7 +1147,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -987,38 +1171,38 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1027,45 +1211,45 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -1074,10 +1258,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1152,13 +1357,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1174,28 +1383,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1210,20 +1419,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1232,16 +1477,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1317,19 +1595,23 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1351,7 +1633,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1364,7 +1646,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1388,41 +1670,41 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1431,25 +1713,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -31,31 +31,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -183,7 +162,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -207,31 +186,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -367,56 +325,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -425,49 +347,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -543,11 +432,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -725,7 +610,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -748,7 +633,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -768,7 +653,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -794,7 +679,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -820,7 +705,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -854,7 +739,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -877,7 +762,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -897,7 +782,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -927,56 +812,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -985,49 +834,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1234,7 +1050,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1258,31 +1074,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1357,11 +1152,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1419,56 +1210,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1477,49 +1232,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1595,11 +1317,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -30,13 +30,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -88,7 +114,7 @@
             "project": true
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -101,25 +127,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -135,22 +161,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -158,13 +184,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -216,7 +268,7 @@
             "project": true
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -229,7 +281,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -241,22 +293,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -270,13 +322,37 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -284,13 +360,34 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -356,19 +453,23 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -383,14 +484,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -402,7 +503,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -436,38 +537,38 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -475,99 +576,99 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -579,21 +680,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -605,21 +706,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -631,16 +732,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -653,7 +754,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -662,56 +763,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -725,23 +826,68 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -796,10 +942,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -814,7 +960,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -824,7 +970,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -849,69 +995,69 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -919,16 +1065,42 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -994,13 +1166,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1015,31 +1191,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1053,13 +1229,37 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1067,13 +1267,34 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1139,19 +1360,23 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1166,14 +1391,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1185,7 +1410,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1210,38 +1435,38 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1249,19 +1474,19 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -30,39 +30,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -161,7 +135,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -184,39 +158,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -322,37 +270,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -360,31 +284,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -453,11 +356,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -625,7 +524,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -648,7 +547,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -668,7 +567,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -694,7 +593,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -720,7 +619,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -754,7 +653,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -777,7 +676,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -797,7 +696,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -826,68 +725,23 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1042,7 +896,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1065,39 +919,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1166,11 +994,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.netty:reactor-netty": {
             "locked": "1.1.0"
@@ -1229,37 +1053,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1267,31 +1067,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1360,11 +1139,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -50,6 +50,7 @@ import graphql.schema.GraphQLSchema
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
@@ -84,7 +85,7 @@ import java.util.*
 import kotlin.streams.toList
 
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
-@Configuration
+@AutoConfiguration
 @EnableConfigurationProperties(DgsWebfluxConfigurationProperties::class)
 open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfigurationProperties) {
 

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebfluxConfigurationProperties.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebfluxConfigurationProperties.kt
@@ -16,14 +16,12 @@
 
 package com.netflix.graphql.dgs.webflux.autoconfiguration
 
+import jakarta.annotation.PostConstruct
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.boot.context.properties.bind.DefaultValue
 import java.time.Duration
-import javax.annotation.PostConstruct
 
-@ConstructorBinding
 @ConfigurationProperties(prefix = "dgs.graphql")
 @Suppress("ConfigurationProperties")
 class DgsWebfluxConfigurationProperties(

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.netflix.graphql.dgs.webflux.autoconfiguration.DgsWebFluxAutoConfiguration

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.graphql.dgs.webflux.autoconfiguration.DgsWebFluxAutoConfiguration

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsGraphQLTransportWSTest.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsGraphQLTransportWSTest.kt
@@ -31,7 +31,7 @@ import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfig
 import org.springframework.boot.autoconfigure.web.reactive.ReactiveWebServerFactoryAutoConfiguration
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.core.ResolvableType
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DataBufferUtils

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsGraphQLWSTest.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsGraphQLWSTest.kt
@@ -34,7 +34,7 @@ import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfig
 import org.springframework.boot.autoconfigure.web.reactive.ReactiveWebServerFactoryAutoConfiguration
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.core.ResolvableType
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DataBufferUtils

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsGraphQLWSTestCustomEndpoint.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/WebsocketSubscriptionsGraphQLWSTestCustomEndpoint.kt
@@ -34,7 +34,7 @@ import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfig
 import org.springframework.boot.autoconfigure.web.reactive.ReactiveWebServerFactoryAutoConfiguration
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.core.ResolvableType
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DataBufferUtils

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,31 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -145,7 +124,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -165,31 +144,10 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -290,50 +248,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -392,11 +317,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"
@@ -542,7 +463,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -565,7 +486,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -585,7 +506,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -611,7 +532,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -637,7 +558,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -671,7 +592,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -694,7 +615,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -714,7 +635,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -743,50 +664,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -919,7 +807,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -939,31 +827,10 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1022,11 +889,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"
@@ -1080,50 +943,17 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.2"
@@ -1182,11 +1012,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -1,36 +1,57 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -78,7 +99,7 @@
             "project": true
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -90,25 +111,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -124,30 +145,51 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -195,7 +237,7 @@
             "project": true
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -207,7 +249,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -219,22 +261,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -248,20 +290,53 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -317,10 +392,14 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -335,14 +414,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -352,7 +431,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -385,37 +464,37 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -423,90 +502,90 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -518,21 +597,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -544,21 +623,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -570,16 +649,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -592,7 +671,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -601,56 +680,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -664,17 +743,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -722,7 +834,7 @@
             "project": true
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -738,7 +850,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -747,7 +859,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -771,69 +883,90 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -889,10 +1022,14 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -905,31 +1042,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -943,20 +1080,53 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "2.9.3"
+            "locked": "3.1.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1012,10 +1182,14 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "4.0.4"
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1030,14 +1204,14 @@
             "locked": "3.12.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1047,7 +1221,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1071,37 +1245,37 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1109,10 +1283,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfiguration.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfiguration.kt
@@ -31,6 +31,7 @@ import com.netflix.graphql.dgs.mvc.internal.method.HandlerMethodArgumentResolver
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -50,7 +51,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ServletCookieValueM
 import org.springframework.web.servlet.mvc.method.annotation.ServletRequestDataBinderFactory
 import kotlin.streams.toList
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnWebApplication
 @EnableConfigurationProperties(DgsWebMvcConfigurationProperties::class)
 open class DgsWebMvcAutoConfiguration {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
@@ -16,16 +16,14 @@
 
 package com.netflix.graphql.dgs.webmvc.autoconfigure
 
+import jakarta.annotation.PostConstruct
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.boot.context.properties.bind.DefaultValue
-import javax.annotation.PostConstruct
 
 /**
  * Configuration properties for DGS web controllers.
  */
-@ConstructorBinding
 @ConfigurationProperties(prefix = "dgs.graphql")
 @Suppress("ConfigurationProperties")
 data class DgsWebMvcConfigurationProperties(

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLConfigurer.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLConfigurer.kt
@@ -17,6 +17,8 @@
 package com.netflix.graphql.dgs.webmvc.autoconfigure
 
 import com.netflix.graphql.dgs.webmvc.autoconfigure.GraphiQLConfigurer.Constants.PATH_TO_GRAPHIQL_INDEX_HTML
+import jakarta.servlet.ServletContext
+import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -32,8 +34,6 @@ import org.springframework.web.servlet.resource.TransformedResource
 import java.io.BufferedReader
 import java.io.IOException
 import java.nio.charset.StandardCharsets
-import javax.servlet.ServletContext
-import javax.servlet.http.HttpServletRequest
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(DgsWebMvcConfigurationProperties::class)

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcAutoConfiguration

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.graphql.dgs.webmvc.autoconfigure.DgsWebMvcAutoConfiguration

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/WebRequestTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/WebRequestTest.kt
@@ -28,6 +28,7 @@ import graphql.language.FieldDefinition
 import graphql.language.ObjectTypeDefinition
 import graphql.language.TypeName
 import graphql.schema.idl.TypeDefinitionRegistry
+import jakarta.servlet.http.Cookie
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.hasItem
@@ -49,7 +50,6 @@ import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.config.annotation.DelegatingWebMvcConfiguration
 import java.util.*
-import javax.servlet.http.Cookie
 
 @SpringBootTest(
     classes = [

--- a/graphql-dgs-spring-webmvc/build.gradle.kts
+++ b/graphql-dgs-spring-webmvc/build.gradle.kts
@@ -21,8 +21,8 @@ dependencies {
     implementation(kotlin("reflect"))
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework:spring-web")
-    compileOnly("javax.servlet:javax.servlet-api")
+    compileOnly("jakarta.servlet:jakarta.servlet-api")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("javax.servlet:javax.servlet-api")
+    testImplementation("jakarta.servlet:jakarta.servlet-api")
 }

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,31 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -136,7 +115,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -156,31 +135,10 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -272,49 +230,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -354,17 +279,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.0.0"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"
@@ -487,7 +402,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -510,7 +425,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -530,7 +445,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -556,7 +471,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -582,7 +497,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -616,7 +531,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -639,7 +554,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -659,7 +574,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -688,49 +603,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -843,7 +725,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -863,31 +745,10 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -927,11 +788,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"
@@ -980,49 +837,16 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1062,17 +886,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.0.0"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0"

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -1,36 +1,57 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -69,14 +90,14 @@
             ],
             "project": true
         },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "4.0.1"
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -84,22 +105,22 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -115,30 +136,51 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -177,14 +219,14 @@
             ],
             "project": true
         },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "4.0.1"
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -192,7 +234,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -204,19 +246,19 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -230,16 +272,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -279,10 +354,20 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
         },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "4.0.1"
+        "jakarta.annotation:jakarta.annotation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.0.0"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -297,7 +382,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -305,7 +390,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -338,114 +423,114 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -457,21 +542,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -483,21 +568,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -509,16 +594,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -531,7 +616,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -540,56 +625,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -603,16 +688,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -664,7 +782,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -672,7 +790,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -696,59 +814,80 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -788,16 +927,20 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "4.0.1"
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -805,25 +948,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -837,16 +980,49 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -886,10 +1062,20 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
         },
-        "javax.servlet:javax.servlet-api": {
-            "locked": "4.0.1"
+        "jakarta.annotation:jakarta.annotation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.0.0"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -904,7 +1090,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -912,7 +1098,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -936,34 +1122,34 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,31 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -94,7 +73,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -114,31 +93,10 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -179,39 +137,13 @@
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -220,11 +152,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -294,7 +222,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -317,7 +245,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -337,7 +265,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -363,7 +291,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -389,7 +317,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -423,7 +351,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -446,7 +374,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -466,7 +394,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -486,31 +414,10 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -542,7 +449,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -562,39 +469,13 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -603,11 +484,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -636,39 +513,13 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -677,11 +528,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -1,36 +1,57 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -42,22 +63,22 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -73,30 +94,51 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -108,7 +150,7 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -120,30 +162,56 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -152,13 +220,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -170,102 +242,102 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -277,21 +349,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -303,21 +375,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -329,16 +401,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -351,7 +423,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -360,64 +432,85 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -429,53 +522,79 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -484,42 +603,72 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -528,31 +677,35 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -1,33 +1,33 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -80,28 +80,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -117,27 +117,27 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -190,7 +190,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -202,25 +202,25 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -234,23 +234,68 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -305,13 +350,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -326,7 +375,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -336,7 +385,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -369,130 +418,130 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -504,21 +553,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -530,21 +579,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -556,16 +605,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -578,7 +627,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -587,56 +636,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -650,23 +699,68 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -724,7 +818,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -739,7 +833,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -749,7 +843,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -773,72 +867,72 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -882,7 +976,11 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -894,31 +992,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -932,23 +1030,68 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1003,13 +1146,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1024,7 +1171,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1034,7 +1181,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1058,50 +1205,50 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,7 +27,7 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -117,7 +117,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -137,7 +137,7 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -234,68 +234,23 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -350,11 +305,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -498,7 +449,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -521,7 +472,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -541,7 +492,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -567,7 +518,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -593,7 +544,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -627,7 +578,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -650,7 +601,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -670,7 +621,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -699,68 +650,23 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -912,7 +818,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -932,7 +838,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -976,11 +882,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1030,68 +932,23 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1146,11 +1003,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-sse-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSEAutoConfig.kt
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSEAutoConfig.kt
@@ -17,13 +17,13 @@
 package com.netflix.graphql.dgs.subscriptions.sse
 
 import com.netflix.graphql.dgs.DgsQueryExecutor
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.DispatcherServlet
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnWebApplication
 @ConditionalOnClass(DispatcherServlet::class)
 open class DgsSSEAutoConfig {

--- a/graphql-dgs-subscriptions-sse-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.netflix.graphql.dgs.subscriptions.sse.DgsSSEAutoConfig

--- a/graphql-dgs-subscriptions-sse-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.graphql.dgs.subscriptions.sse.DgsSSEAutoConfig

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -30,39 +30,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -153,7 +127,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -176,39 +150,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -306,67 +254,22 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -411,11 +314,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
@@ -554,7 +453,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -577,7 +476,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -597,7 +496,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -623,7 +522,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -649,7 +548,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -683,7 +582,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -706,7 +605,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -726,7 +625,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -755,67 +654,22 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -946,7 +800,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -969,39 +823,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1046,11 +874,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
@@ -1106,67 +930,22 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1211,11 +990,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -30,13 +30,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -81,7 +107,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -93,25 +119,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -127,22 +153,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -150,13 +176,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -201,7 +253,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -213,7 +265,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -225,22 +277,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -254,22 +306,67 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -314,13 +411,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -335,7 +436,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -344,7 +445,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -377,126 +478,126 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -508,21 +609,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -534,21 +635,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -560,16 +661,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -582,7 +683,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -591,56 +692,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -654,22 +755,67 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -714,7 +860,7 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -729,7 +875,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -738,7 +884,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -762,60 +908,60 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -823,13 +969,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -874,13 +1046,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -892,31 +1068,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -930,22 +1106,67 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -990,13 +1211,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1011,7 +1236,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1020,7 +1245,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1044,46 +1269,46 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/build.gradle.kts
@@ -21,4 +21,5 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework:spring-websocket")
 
+    compileOnly("jakarta.annotation:jakarta.annotation-api")
 }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -30,10 +30,31 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -84,6 +105,12 @@
             ],
             "project": true
         },
+<<<<<<< HEAD
+=======
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
+        },
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
@@ -95,25 +122,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -129,22 +156,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -152,10 +179,31 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -206,6 +254,12 @@
             ],
             "project": true
         },
+<<<<<<< HEAD
+=======
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
+        },
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
@@ -217,7 +271,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -229,22 +283,22 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -258,23 +312,68 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -329,7 +428,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.0.0"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -344,7 +453,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -354,7 +463,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -387,128 +496,128 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -520,21 +629,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -546,21 +655,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -572,16 +681,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -594,7 +703,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -603,56 +712,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -666,23 +775,68 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -749,7 +903,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -759,7 +913,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -783,65 +937,65 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -849,10 +1003,31 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -904,7 +1079,11 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -917,28 +1096,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -952,23 +1131,68 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1023,7 +1247,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "2.0.0"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1038,7 +1272,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1048,7 +1282,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1072,48 +1306,48 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -30,31 +30,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -105,12 +84,9 @@
             ],
             "project": true
         },
-<<<<<<< HEAD
-=======
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1"
         },
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
@@ -156,7 +132,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -179,31 +155,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -254,12 +209,9 @@
             ],
             "project": true
         },
-<<<<<<< HEAD
-=======
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1"
         },
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
@@ -312,68 +264,23 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -428,17 +335,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.0.0"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -574,7 +471,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -597,7 +494,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -617,7 +514,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -643,7 +540,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -669,7 +566,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -703,7 +600,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -726,7 +623,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -746,7 +643,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -775,68 +672,23 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -980,7 +832,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1003,31 +855,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1079,11 +910,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1131,68 +958,23 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1247,17 +1029,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "firstLevelTransitive": [
-                "com.netflix.graphql.dgs:graphql-dgs"
-            ],
-            "locked": "2.0.0"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketAutoConfig.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketAutoConfig.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.subscriptions.websockets
 
 import com.netflix.graphql.dgs.DgsQueryExecutor
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -28,7 +29,7 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 import org.springframework.web.socket.server.HandshakeInterceptor
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler
 
-@Configuration
+@AutoConfiguration
 @ConditionalOnWebApplication
 @EnableConfigurationProperties(DgsWebSocketConfigurationProperties::class)
 open class DgsWebSocketAutoConfig {

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketConfigurationProperties.kt
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketConfigurationProperties.kt
@@ -16,14 +16,12 @@
 
 package com.netflix.graphql.dgs.subscriptions.websockets
 
+import jakarta.annotation.PostConstruct
 import org.slf4j.event.Level
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.boot.context.properties.bind.DefaultValue
 import java.time.Duration
-import javax.annotation.PostConstruct
 
-@ConstructorBinding
 @ConfigurationProperties(prefix = "dgs.graphql.websocket")
 @Suppress("ConfigurationProperties")
 data class DgsWebSocketConfigurationProperties(

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.netflix.graphql.dgs.subscriptions.websockets.DgsWebSocketAutoConfig

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.netflix.graphql.dgs.subscriptions.websockets.DgsWebSocketAutoConfig

--- a/graphql-dgs-subscriptions-websockets/build.gradle.kts
+++ b/graphql-dgs-subscriptions-websockets/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation("org.springframework:spring-websocket")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
+    compileOnly("jakarta.annotation:jakarta.annotation-api")
     compileOnly("org.springframework.security:spring-security-core")
 
     testImplementation("io.projectreactor:reactor-core")

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -30,13 +30,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -80,6 +106,12 @@
             ],
             "project": true
         },
+<<<<<<< HEAD
+=======
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
+        },
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
@@ -90,31 +122,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -130,22 +162,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -153,13 +185,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -203,6 +261,12 @@
             ],
             "project": true
         },
+<<<<<<< HEAD
+=======
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
+        },
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
@@ -213,7 +277,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -225,28 +289,28 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -260,22 +324,67 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -320,13 +429,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -341,7 +454,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -350,7 +463,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -383,123 +496,123 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -511,21 +624,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -537,21 +650,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -563,16 +676,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -585,7 +698,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -594,56 +707,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -657,22 +770,67 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -729,7 +887,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -738,7 +896,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -762,60 +920,60 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -823,13 +981,39 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -874,13 +1058,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -892,31 +1080,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -930,22 +1118,67 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -990,13 +1223,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1011,7 +1248,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1020,7 +1257,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1044,43 +1281,43 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -30,39 +30,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -106,12 +80,9 @@
             ],
             "project": true
         },
-<<<<<<< HEAD
-=======
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1"
         },
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
@@ -162,7 +133,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -185,39 +156,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -261,12 +206,9 @@
             ],
             "project": true
         },
-<<<<<<< HEAD
-=======
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1"
         },
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
@@ -324,67 +266,22 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -429,11 +326,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.0"
@@ -569,7 +462,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -592,7 +485,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -612,7 +505,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -638,7 +531,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -664,7 +557,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -698,7 +591,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -721,7 +614,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -741,7 +634,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -770,67 +663,22 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -958,7 +806,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -981,39 +829,13 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1058,11 +880,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.0"
@@ -1118,67 +936,22 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1223,11 +996,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.0"

--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/DgsWebSocketHandler.kt
@@ -18,6 +18,7 @@ package com.netflix.graphql.dgs.subscriptions.websockets
 
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.types.subscription.*
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
 import org.springframework.security.core.context.SecurityContext
@@ -29,8 +30,6 @@ import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
 import java.time.Duration
-import java.util.*
-import javax.annotation.PostConstruct
 
 class DgsWebSocketHandler(dgsQueryExecutor: DgsQueryExecutor, connectionInitTimeout: Duration, subscriptionErrorLogLevel: Level) : TextWebSocketHandler(), SubProtocolCapable {
 

--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLTransportWSProtocolHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLTransportWSProtocolHandler.kt
@@ -22,6 +22,7 @@ import com.netflix.graphql.types.subscription.websockets.CloseCode
 import com.netflix.graphql.types.subscription.websockets.Message
 import graphql.ExecutionResult
 import graphql.GraphqlErrorBuilder
+import jakarta.annotation.PostConstruct
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
@@ -35,7 +36,6 @@ import java.time.Duration
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
-import javax.annotation.PostConstruct
 
 /**
  * WebSocketHandler for GraphQL based on

--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandler.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.types.subscription.*
 import graphql.ExecutionResult
+import jakarta.annotation.PostConstruct
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
@@ -31,7 +32,6 @@ import org.springframework.web.socket.handler.TextWebSocketHandler
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
-import javax.annotation.PostConstruct
 
 class WebsocketGraphQLWSProtocolHandler(private val dgsQueryExecutor: DgsQueryExecutor, private val subscriptionErrorLogLevel: Level) : TextWebSocketHandler() {
 

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -31,31 +31,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -189,7 +168,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -213,31 +192,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -379,56 +337,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -438,49 +360,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -564,11 +453,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
@@ -748,7 +633,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -771,7 +656,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -791,7 +676,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -817,7 +702,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -843,7 +728,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -877,7 +762,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -900,7 +785,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -920,7 +805,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -950,56 +835,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1009,49 +858,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1268,7 +1084,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1292,31 +1108,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1399,11 +1194,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
@@ -1459,56 +1250,20 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1518,49 +1273,16 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1644,11 +1366,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -31,10 +31,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -120,7 +141,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -137,22 +158,22 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -168,22 +189,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -192,10 +213,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -281,7 +323,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -298,7 +340,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -310,19 +352,19 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -337,20 +379,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -360,16 +438,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -453,25 +564,29 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -493,7 +608,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -507,7 +622,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -541,10 +656,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
@@ -552,28 +667,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -582,7 +697,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
@@ -590,93 +705,93 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -688,21 +803,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -714,21 +829,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -740,16 +855,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -762,7 +877,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -771,56 +886,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -835,20 +950,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -858,16 +1009,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -954,19 +1138,19 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -988,7 +1172,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1002,7 +1186,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1027,10 +1211,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
@@ -1038,25 +1222,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1065,7 +1249,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
@@ -1073,33 +1257,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -1108,10 +1292,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1194,13 +1399,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -1217,25 +1426,25 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -1250,20 +1459,56 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1273,16 +1518,49 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -1366,25 +1644,29 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ],
-            "locked": "1.1.7"
+            "locked": "1.2.0"
         },
         "io.projectreactor.netty:reactor-netty": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "1.0.24"
+            "locked": "1.1.0"
         },
         "io.projectreactor:reactor-core": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client"
             ],
-            "locked": "3.4.24"
+            "locked": "3.5.1"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -1406,7 +1688,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
@@ -1420,7 +1702,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "firstLevelTransitive": [
@@ -1445,10 +1727,10 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter": {
             "firstLevelTransitive": [
@@ -1456,28 +1738,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
             "firstLevelTransitive": [
@@ -1486,7 +1768,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-webflux": {
             "firstLevelTransitive": [
@@ -1494,13 +1776,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-websocket": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ],
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     compileOnly("org.springframework.security:spring-security-core")
     compileOnly("io.projectreactor:reactor-core")
+    compileOnly("jakarta.annotation:jakarta.annotation-api")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -1,28 +1,28 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
@@ -30,13 +30,39 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -62,20 +88,23 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
@@ -87,25 +116,25 @@
             "locked": "1.6.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -121,22 +150,22 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
@@ -144,13 +173,39 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -176,20 +231,23 @@
             "project": true
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
@@ -210,25 +268,25 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
@@ -236,13 +294,39 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -271,13 +355,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -289,14 +377,14 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
@@ -323,111 +411,111 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -439,21 +527,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -465,21 +553,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -491,16 +579,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -513,7 +601,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -522,56 +610,56 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
@@ -579,13 +667,39 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -620,14 +734,14 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
@@ -642,45 +756,45 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
@@ -688,13 +802,39 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -723,26 +863,30 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
@@ -757,28 +901,28 @@
             "locked": "1.6.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
@@ -786,13 +930,39 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -821,13 +991,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "io.projectreactor:reactor-test": {
-            "locked": "3.4.24"
+            "locked": "3.5.0"
         },
         "net.datafaker:datafaker": {
             "firstLevelTransitive": [
@@ -839,14 +1013,14 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.6.4"
@@ -864,31 +1038,31 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ],
-            "locked": "1.7.36"
+            "locked": "2.0.4"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-context": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -30,39 +30,13 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -150,7 +124,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -173,39 +147,13 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -294,39 +242,13 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -355,11 +277,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
@@ -472,7 +390,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -495,7 +413,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -515,7 +433,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -541,7 +459,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -567,7 +485,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -601,7 +519,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -624,7 +542,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -644,7 +562,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -667,39 +585,13 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -779,7 +671,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -802,39 +694,13 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -863,11 +729,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
@@ -930,39 +792,13 @@
             "locked": "2.1.0"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "firstLevelTransitive": [
@@ -991,11 +827,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsMutation.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsMutation.java
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.dgs;
 
+import org.springframework.core.annotation.AliasFor;
+
 import java.lang.annotation.*;
 
 @Target(ElementType.METHOD)
@@ -23,5 +25,6 @@ import java.lang.annotation.*;
 @DgsData(parentType = "Mutation")
 @Inherited
 public @interface DgsMutation {
+    @AliasFor(annotation = DgsData.class)
     String field() default "";
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQuery.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQuery.java
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.dgs;
 
+import org.springframework.core.annotation.AliasFor;
+
 import java.lang.annotation.*;
 
 @Target(ElementType.METHOD)
@@ -23,5 +25,6 @@ import java.lang.annotation.*;
 @DgsData(parentType = "Query")
 @Inherited
 public @interface DgsQuery {
+    @AliasFor(annotation = DgsData.class)
     String field() default "";
 }

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsSubscription.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsSubscription.java
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.dgs;
 
+import org.springframework.core.annotation.AliasFor;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -27,5 +29,6 @@ import java.lang.annotation.Target;
 @DgsData(parentType = "Subscription")
 @Inherited
 public @interface DgsSubscription {
+    @AliasFor(annotation = DgsData.class)
     String field() default "";
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -24,6 +24,7 @@ import com.netflix.graphql.dgs.exceptions.DgsUnnamedDataLoaderOnFieldException
 import com.netflix.graphql.dgs.exceptions.InvalidDataLoaderTypeException
 import com.netflix.graphql.dgs.exceptions.UnsupportedSecuredDataLoaderException
 import com.netflix.graphql.dgs.internal.utils.DataLoaderNameUtil
+import jakarta.annotation.PostConstruct
 import org.dataloader.BatchLoader
 import org.dataloader.BatchLoaderWithContext
 import org.dataloader.DataLoader
@@ -39,7 +40,6 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.context.ApplicationContext
 import org.springframework.util.ReflectionUtils
 import java.util.function.Supplier
-import javax.annotation.PostConstruct
 
 /**
  * Framework implementation class responsible for finding and configuring data loaders.

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -27,31 +27,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -91,7 +70,7 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -111,31 +90,10 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-            "locked": "2.13.3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.3"
-=======
-            "locked": "2.14.0-rc2"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc2"
->>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
-=======
-            "locked": "2.14.0-rc3"
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.0-rc3"
->>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
-=======
             "locked": "2.14.1"
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.1"
->>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -173,7 +131,7 @@
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -182,11 +140,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -253,7 +207,7 @@
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -276,7 +230,7 @@
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -296,7 +250,7 @@
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -322,7 +276,7 @@
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -348,7 +302,7 @@
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -382,7 +336,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -405,7 +359,7 @@
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -425,7 +379,7 @@
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -445,7 +399,7 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -474,7 +428,7 @@
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -494,7 +448,7 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -503,11 +457,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -533,7 +483,7 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.2"
+            "locked": "2.13.4"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -542,11 +492,7 @@
             "project": true
         },
         "io.mockk:mockk": {
-<<<<<<< HEAD
             "locked": "1.13.2"
-=======
-            "locked": "1.12.4"
->>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -1,36 +1,57 @@
 {
     "annotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -42,19 +63,19 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmh": {
@@ -70,30 +91,51 @@
     },
     "jmhAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.13.4"
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+            "locked": "2.13.3"
         },
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.3"
+=======
+            "locked": "2.14.0-rc2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc2"
+>>>>>>> 761ac952 (feat: upgrades spring boot to first release candidate and fixes metrics.)
+=======
+            "locked": "2.14.0-rc3"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.0-rc3"
+>>>>>>> 5f9e9c8b (feat: bumps sprint boot to latest RC.)
+=======
+            "locked": "2.14.1"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.1"
+>>>>>>> 03ede8c3 (feat: bumps spring boot dependencies to GA versions, except for spring cloud.)
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -105,7 +147,7 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -117,21 +159,21 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -140,13 +182,17 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -158,99 +204,99 @@
             "locked": "1.29"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kapt": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptClasspath_kaptKotlin": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kaptTest": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         }
     },
     "kotlinCompilerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -262,21 +308,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -288,21 +334,21 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
             "locked": "1.7.20"
@@ -314,16 +360,16 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -336,7 +382,7 @@
     },
     "kotlinKlibCommonizerClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
@@ -345,61 +391,61 @@
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "kotlinNativeCompilerPluginClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "nebulaRecommenderBom": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -411,44 +457,44 @@
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testAnnotationProcessor": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -457,33 +503,37 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.13.4"
+            "locked": "2.13.2"
         },
         "com.graphql-java:graphql-java": {
             "locked": "19.2"
@@ -492,28 +542,32 @@
             "project": true
         },
         "io.mockk:mockk": {
+<<<<<<< HEAD
             "locked": "1.13.2"
+=======
+            "locked": "1.12.4"
+>>>>>>> f142d2d6 (feat: upgrades graphql-java to fix conflicting antlr dependency with spring-boot v3.)
         },
         "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.7.20"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.7.20"
+            "locked": "1.7.21"
         },
         "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.5"
+            "locked": "3.0.0"
         },
         "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2021.0.3"
+            "locked": "2022.0.0"
         },
         "org.springframework.security:spring-security-bom": {
-            "locked": "5.7.4"
+            "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
-            "locked": "5.3.23"
+            "locked": "6.0.3"
         }
     }
 }

--- a/scripts/config.yml
+++ b/scripts/config.yml
@@ -19,5 +19,5 @@
 # the Python scripts instead it will fail. Because of this, the list of examples
 # is duplicated in the ./github/workflows/ci-beta.yml file.
 repositories:
-    - "git@github.com:Netflix/dgs-examples-java-2.7.git"
-    - "git@github.com:Netflix/dgs-examples-kotlin-2.7.git"
+    - "git@github.com:Netflix/dgs-examples-java.git"
+    - "git@github.com:Netflix/dgs-examples-kotlin.git"


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This PR adds support for Spring Boot 3 in the DGS Framework. This is a breaking change and requires users of the library to have updated their Spring Boot apps to 3.0.0 prior to using this release. Note that this release also requires JDK 17.

We will continue to release and maintain Spring boot 2.7 as part of a separate release branch `spring-boot-2.7`. All minor updates and bug fixes will be ported over to the 2.7 branch as needed. 

Versions updated:
Spring Boot 3.0.0
Spring Framework 6.0.3
Spring Security 6.0.1
Spring Cloud 2022.0.0
JDK target 17

Related PR: https://github.com/Netflix/dgs-framework/pull/1230

Existing Issues:
https://github.com/Netflix/dgs-framework/issues/1340

