### PR TITLE
Fix DgsQueryExecutor behavior with respect to HTTP headers

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     compileOnly("com.github.ben-manes.caffeine:caffeine")
     compileOnly("io.micrometer:micrometer-core")
     compileOnly("io.projectreactor:reactor-core")
+    compileOnly("org.springframework:spring-test")
+    compileOnly("jakarta.servlet:jakarta.servlet-api")
 
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("com.github.ben-manes.caffeine:caffeine")

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -83,6 +83,9 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
         },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
         },
@@ -111,6 +114,9 @@
             "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
+            "locked": "6.0.3"
+        },
+        "org.springframework:spring-test": {
             "locked": "6.0.3"
         },
         "org.springframework:spring-web": {
@@ -206,6 +212,9 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.5.0"
         },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
+        },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
         },
@@ -243,6 +252,9 @@
             "locked": "6.0.1"
         },
         "org.springframework:spring-framework-bom": {
+            "locked": "6.0.3"
+        },
+        "org.springframework:spring-test": {
             "locked": "6.0.3"
         },
         "org.springframework:spring-web": {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsQueryExecutorRequestCustomizer.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsQueryExecutorRequestCustomizer.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import org.springframework.http.HttpHeaders
+import org.springframework.web.context.request.WebRequest
+import java.util.function.BiFunction
+
+fun interface DgsQueryExecutorRequestCustomizer : BiFunction<WebRequest?, HttpHeaders?, WebRequest?> {
+    companion object {
+        /**
+         * Default no-op implementation.
+         */
+        val DEFAULT_REQUEST_CUSTOMIZER = DgsQueryExecutorRequestCustomizer { req, _ -> req }
+    }
+
+    override fun apply(request: WebRequest?, headers: HttpHeaders?): WebRequest?
+}


### PR DESCRIPTION
At some point, the various methods in DgsQueryExecutor that accept HttpHeaders were broken, due to the internal implementation of DGS switching to reading headers from the request. Work around this by adding a pluggable request customizer, DgsQueryExecutorRequestCustomizer, which allows for modifying the request inside DgsQueryExecutor. By default, an implementation of the customizer is installed that will copy any explicitly supplied headers into the request if it implements MockHttpServletRequest.

Fixes #1105 .
