### PR TITLE
Update the default execution strategy for mutations to AsyncExecutionStrategy for better performance.

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -30,7 +30,6 @@ import com.netflix.graphql.dgs.internal.method.MethodDataFetcherFactory
 import com.netflix.graphql.dgs.scalars.UploadScalar
 import com.netflix.graphql.mocking.MockProvider
 import graphql.execution.AsyncExecutionStrategy
-import graphql.execution.AsyncSerialExecutionStrategy
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.ExecutionIdProvider
 import graphql.execution.ExecutionStrategy
@@ -109,7 +108,7 @@ open class DgsAutoConfiguration(
         val queryExecutionStrategy =
             providedQueryExecutionStrategy.orElse(AsyncExecutionStrategy(dataFetcherExceptionHandler))
         val mutationExecutionStrategy =
-            providedMutationExecutionStrategy.orElse(AsyncSerialExecutionStrategy(dataFetcherExceptionHandler))
+            providedMutationExecutionStrategy.orElse(AsyncExecutionStrategy(dataFetcherExceptionHandler))
 
         val instrumentationImpls = instrumentations.orderedStream().toList()
         val instrumentation: Instrumentation? = when {


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe):

Changes in this PR
----
The default mutation execution strategy was set to AsyncSerialExecutionStrategy. In testing with high RPS use cases, this resulted in data loader calls that has batch sizes of 1. This PR in `graphql-java` fixes an underlying issue, allowing us to use AsyncExecutionStrategy for mutations.
https://github.com/graphql-java/graphql-java/pull/2431