### PR TITLE
Remove explicit handling of Optional conversion

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/AbstractInputArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/AbstractInputArgumentResolver.kt
@@ -71,21 +71,8 @@ abstract class AbstractInputArgumentResolver(inputObjectMapper: InputObjectMappe
     }
 
     private fun convertValue(source: Any?, target: TypeDescriptor): Any? {
-        if (source == null) {
-            return when (target.type) {
-                Optional::class.java -> Optional.empty<Any?>()
-                else -> null
-            }
-        }
-
         if (target.resolvableType.isInstance(source)) {
             return source
-        }
-
-        if (target.type == Optional::class.java) {
-            val generic = target.resolvableType.getGeneric(0)
-            val elementType = TypeDescriptor(generic, null, null)
-            return Optional.ofNullable(convertValue(source, elementType))
         }
 
         val sourceType = TypeDescriptor.forObject(source)
@@ -93,6 +80,6 @@ abstract class AbstractInputArgumentResolver(inputObjectMapper: InputObjectMappe
             return conversionService.convert(source, sourceType, target)
         }
 
-        throw DgsInvalidInputArgumentException("Unable to convert from ${source.javaClass} to ${target.type}")
+        throw DgsInvalidInputArgumentException("Unable to convert from ${source?.javaClass} to ${target.type}")
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/InputObjectMapperConverter.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/InputObjectMapperConverter.kt
@@ -21,6 +21,7 @@ import org.springframework.core.KotlinDetector
 import org.springframework.core.convert.TypeDescriptor
 import org.springframework.core.convert.converter.ConditionalGenericConverter
 import org.springframework.core.convert.converter.GenericConverter
+import java.util.Optional
 
 internal class InputObjectMapperConverter(private val inputObjectMapper: InputObjectMapper) : ConditionalGenericConverter {
     override fun getConvertibleTypes(): Set<GenericConverter.ConvertiblePair> {
@@ -28,7 +29,9 @@ internal class InputObjectMapperConverter(private val inputObjectMapper: InputOb
     }
 
     override fun matches(sourceType: TypeDescriptor, targetType: TypeDescriptor): Boolean {
-        return sourceType.isMap && !targetType.isMap
+        return sourceType.isMap &&
+            !targetType.isMap &&
+            !targetType.type.isAssignableFrom(Optional::class.java)
     }
 
     override fun convert(source: Any?, sourceType: TypeDescriptor, targetType: TypeDescriptor): Any {


### PR DESCRIPTION
Change InputObjectMapperConverter.matches to return false for Optional targets so that the ConversionService can delegate to ObjectToOptionalConverter from Spring. Gets rid of custom handling in AbstractInputArgumentResolver.
