### PR TITLE
feat(DgsSchemaProvider): use multiSourceReader for parsing schema files

### DIFF
--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -42,6 +42,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -155,6 +156,21 @@ internal class DgsSchemaProviderTest {
         assertEquals("location1-schema2.graphqls", schemaFiles[1].filename)
         assertEquals("location2-schema1.graphqls", schemaFiles[2].filename)
         assertEquals("location2-schema2.graphqls", schemaFiles[3].filename)
+    }
+
+    @Test
+    fun `Should specify sourceName on SourceLocation`() {
+        val schemaProvider = schemaProvider(
+            schemaLocations = listOf("classpath*:schema/**/*.graphql*")
+        )
+
+        val schema = schemaProvider.schema()
+
+        for (type in schema.allTypesAsList) {
+            if (type.definition?.sourceLocation != null) {
+                assertNotNull(type.definition?.sourceLocation?.sourceName)
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This change makes it so that the DGS framework provides the source file name when it is specifying the source location of a given schema file. I followed @osi's notes and graphql-java does this conversion itself, if it's not already provided a MultiSourceReader. Specifying a MultiSourceReader will have graphql-java take the reader's source file name and use that when building a SourceLocation. 

Added test for validation.