### PR TITLE
Data loader features

### DIFF
--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/ExampleLoaderWithContext.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/ExampleLoaderWithContext.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 
 @DgsDataLoader(name = "exampleLoaderWithContext")
 public class ExampleLoaderWithContext implements BatchLoaderWithContext<String, String> {
-    @Override
+    @Override                                                                                                                             
     public CompletionStage<List<String>> load(List<String> keys, BatchLoaderEnvironment environment) {
 
         MyContext context = DgsContext.getCustomContext(environment);

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/ExampleLoaderWithContext.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/ExampleLoaderWithContext.java
@@ -19,12 +19,9 @@ package com.netflix.graphql.dgs.example.shared.dataLoader;
 import com.netflix.graphql.dgs.DgsDataLoader;
 import com.netflix.graphql.dgs.context.DgsContext;
 import com.netflix.graphql.dgs.example.shared.context.MyContext;
-import graphql.GraphQLContext;
 import org.dataloader.BatchLoaderEnvironment;
 import org.dataloader.BatchLoaderWithContext;
-import org.dataloader.Try;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/MessageDataLoader.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/MessageDataLoader.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public class MessageDataLoader implements BatchLoader<String, String> {
 
     @DgsDispatchPredicate
-    DispatchPredicate pred = DispatchPredicate.dispatchIfLongerThan(Duration.ofMinutes(1));
+    DispatchPredicate pred = DispatchPredicate.dispatchIfLongerThan(Duration.ofSeconds(10));
     @Override
     public CompletionStage<List<String>> load(List<String> keys) {
         return CompletableFuture.supplyAsync(() -> keys.stream().map(key -> "hello, " + key + "!").collect(Collectors.toList()));

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/MessageDataLoader.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/MessageDataLoader.java
@@ -17,8 +17,11 @@
 package com.netflix.graphql.dgs.example.shared.dataLoader;
 
 import com.netflix.graphql.dgs.DgsDataLoader;
+import com.netflix.graphql.dgs.DgsDispatchPredicate;
 import org.dataloader.BatchLoader;
+import org.dataloader.registries.DispatchPredicate;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -27,6 +30,8 @@ import java.util.stream.Collectors;
 @DgsDataLoader(name = "messages")
 public class MessageDataLoader implements BatchLoader<String, String> {
 
+    @DgsDispatchPredicate
+    DispatchPredicate pred = DispatchPredicate.dispatchIfLongerThan(Duration.ofMinutes(1));
     @Override
     public CompletionStage<List<String>> load(List<String> keys) {
         return CompletableFuture.supplyAsync(() -> keys.stream().map(key -> "hello, " + key + "!").collect(Collectors.toList()));

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/MessageDataLoaderWithDispatchPredicate.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/MessageDataLoaderWithDispatchPredicate.java
@@ -27,8 +27,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
-@DgsDataLoader(name = "messages")
-public class MessageDataLoader implements BatchLoader<String, String> {
+@DgsDataLoader(name = "messagesWithScheduledDispatch")
+public class MessageDataLoaderWithDispatchPredicate implements BatchLoader<String, String> {
+    @DgsDispatchPredicate
+    DispatchPredicate pred = DispatchPredicate.dispatchIfLongerThan(Duration.ofSeconds(2));
     @Override
     public CompletionStage<List<String>> load(List<String> keys) {
         return CompletableFuture.supplyAsync(() -> keys.stream().map(key -> "hello, " + key + "!").collect(Collectors.toList()));

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/HelloDataFetcher.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/HelloDataFetcher.java
@@ -53,6 +53,14 @@ public class HelloDataFetcher {
         return dataLoader.load("a");
     }
 
+    @DgsData(parentType = "Query", field = "messageFromBatchLoaderWithScheduledDispatch")
+    public CompletableFuture<String> getMessageScheduled(DataFetchingEnvironment env) {
+        DataLoader<String, String> dataLoader = env.getDataLoader("messagesWithScheduledDispatch");
+        CompletableFuture res =  dataLoader.load("a");
+
+        return res;
+    }
+
     @DgsData(parentType = "Query", field = "messagesWithExceptionFromBatchLoader")
     public CompletableFuture<List<Message>> getMessagesWithException(DgsDataFetchingEnvironment env) {
         List<Message> messages = new ArrayList<>();

--- a/graphql-dgs-example-shared/src/main/resources/schema/schema.graphqls
+++ b/graphql-dgs-example-shared/src/main/resources/schema/schema.graphqls
@@ -7,6 +7,7 @@ type Query {
     movies: [Movie]
     messageFromBatchLoader: String
     messagesWithExceptionFromBatchLoader: [Message]
+    messageFromBatchLoaderWithScheduledDispatch: String
 
 #    #Custom scalar example
 #    now: LocalTime

--- a/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/ExampleSpringBootTest.java
+++ b/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/ExampleSpringBootTest.java
@@ -18,6 +18,7 @@ package com.netflix.graphql.dgs.example.shared;
 
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import com.netflix.graphql.dgs.example.datafetcher.HelloDataFetcher;
+import com.netflix.graphql.dgs.example.shared.dataLoader.MessageDataLoaderWithDispatchPredicate;
 import com.netflix.graphql.dgs.example.shared.datafetcher.ConcurrentDataFetcher;
 import com.netflix.graphql.dgs.example.shared.datafetcher.MovieDataFetcher;
 import com.netflix.graphql.dgs.example.shared.datafetcher.RatingMutation;
@@ -31,6 +32,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, ConcurrentDataFetcher.class, RatingMutation.class, DgsAutoConfiguration.class, DgsPaginationAutoConfiguration.class})
+@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, ConcurrentDataFetcher.class, RatingMutation.class, DgsAutoConfiguration.class, DgsPaginationAutoConfiguration.class, MessageDataLoaderWithDispatchPredicate.class})
 public @interface ExampleSpringBootTest {
 }

--- a/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/HelloDataFetcherTest.java
+++ b/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/HelloDataFetcherTest.java
@@ -22,6 +22,10 @@ import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -53,6 +57,16 @@ class HelloDataFetcherTest {
     void helloShouldWorkWithoutName() {
         String message = queryExecutor.executeAndExtractJsonPath("{hello}", "data.hello");
         assertThat(message).isEqualTo("hello, Stranger!");
+    }
+
+    @Test
+    void messageLoaderWithScheduledDispatch() {
+        LocalDateTime now = LocalDateTime.now();
+        String message = queryExecutor.executeAndExtractJsonPath("{ messageFromBatchLoaderWithScheduledDispatch }", "data.messageFromBatchLoaderWithScheduledDispatch");
+        LocalDateTime after = LocalDateTime.now();
+        assertThat( now.until(after, ChronoUnit.SECONDS)).isGreaterThanOrEqualTo(2);
+        assertThat( now.until(after, ChronoUnit.SECONDS)).isLessThanOrEqualTo(4);
+        assertThat(message).isEqualTo("hello, a!");
     }
 
     @Test

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs;
 
 import com.netflix.graphql.dgs.internal.utils.DataLoaderNameUtil;
+import org.dataloader.registries.DispatchPredicate;
 import org.springframework.stereotype.Component;
 
 import java.lang.annotation.ElementType;

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDispatchPredicate.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDispatchPredicate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs;
+
+import com.netflix.graphql.dgs.internal.utils.DataLoaderNameUtil;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a class or field as a Dispatch Predicate for a ScheduledDataLoaderRegistry, which will be registered to the framework.
+ * The method must return an instance of DispatchPredicate.
+ * See https://netflix.github.io/dgs/data-loaders/
+ */
+//@Target(ElementType.METHOD)
+@Target(ElementType.FIELD)
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DgsDispatchPredicate {
+}
+

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -61,7 +61,6 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
 
     fun <T> buildRegistryWithContextSupplier(contextSupplier: Supplier<T>): DataLoaderRegistry {
         val startTime = System.currentTimeMillis()
-        // val dataLoaderRegistry = DataLoaderRegistry()
         val dgsDataLoaderRegistry = DgsDataLoaderRegistry()
 
         batchLoaders.forEach {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -35,14 +35,12 @@ import org.dataloader.DataLoaderRegistry
 import org.dataloader.MappedBatchLoader
 import org.dataloader.MappedBatchLoaderWithContext
 import org.dataloader.registries.DispatchPredicate
-import org.dataloader.registries.ScheduledDataLoaderRegistry
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.context.ApplicationContext
 import org.springframework.util.ReflectionUtils
-import java.lang.reflect.Modifier
 import java.util.function.Supplier
 
 /**
@@ -63,7 +61,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
 
     fun <T> buildRegistryWithContextSupplier(contextSupplier: Supplier<T>): DataLoaderRegistry {
         val startTime = System.currentTimeMillis()
-        //val dataLoaderRegistry = DataLoaderRegistry()
+        // val dataLoaderRegistry = DataLoaderRegistry()
         val dgsDataLoaderRegistry = DgsDataLoaderRegistry()
 
         batchLoaders.forEach {
@@ -167,19 +165,19 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
             val javaClass = AopUtils.getTargetClass(dgsComponent)
             val annotation = javaClass.getAnnotation(DgsDataLoader::class.java)
             val predicateField = javaClass.declaredFields.asSequence().find { it.isAnnotationPresent(DgsDispatchPredicate::class.java) }
-            if (predicateField != null ) {
-                    ReflectionUtils.makeAccessible(predicateField)
-                    val dispatchPredicate =  predicateField.get(dgsComponent)
-                    if (dispatchPredicate is DispatchPredicate) {
-                       addDataLoaders(dgsComponent, javaClass, annotation, dispatchPredicate)
-                    }
+            if (predicateField != null) {
+                ReflectionUtils.makeAccessible(predicateField)
+                val dispatchPredicate = predicateField.get(dgsComponent)
+                if (dispatchPredicate is DispatchPredicate) {
+                    addDataLoaders(dgsComponent, javaClass, annotation, dispatchPredicate)
+                }
             } else {
                 addDataLoaders(dgsComponent, javaClass, annotation, null)
             }
         }
     }
 
-    private fun <T: Any>addDataLoaders(dgsComponent: T, targetClass: Class<*>, annotation: DgsDataLoader, dispatchPredicate: DispatchPredicate?) {
+    private fun <T : Any>addDataLoaders(dgsComponent: T, targetClass: Class<*>, annotation: DgsDataLoader, dispatchPredicate: DispatchPredicate?) {
         fun <T : Any> createHolder(t: T): LoaderHolder<T> =
             LoaderHolder(t, annotation, DataLoaderNameUtil.getDataLoaderName(targetClass, annotation), dispatchPredicate)
         when (dgsComponent) {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -20,6 +20,7 @@ import com.netflix.graphql.dgs.DataLoaderInstrumentationExtensionProvider
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.graphql.dgs.DgsDataLoaderRegistryConsumer
+import com.netflix.graphql.dgs.DgsDispatchPredicate
 import com.netflix.graphql.dgs.exceptions.DgsUnnamedDataLoaderOnFieldException
 import com.netflix.graphql.dgs.exceptions.InvalidDataLoaderTypeException
 import com.netflix.graphql.dgs.exceptions.UnsupportedSecuredDataLoaderException
@@ -33,12 +34,15 @@ import org.dataloader.DataLoaderOptions
 import org.dataloader.DataLoaderRegistry
 import org.dataloader.MappedBatchLoader
 import org.dataloader.MappedBatchLoaderWithContext
+import org.dataloader.registries.DispatchPredicate
+import org.dataloader.registries.ScheduledDataLoaderRegistry
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.context.ApplicationContext
 import org.springframework.util.ReflectionUtils
+import java.lang.reflect.Modifier
 import java.util.function.Supplier
 
 /**
@@ -46,7 +50,7 @@ import java.util.function.Supplier
  */
 class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) {
 
-    private data class LoaderHolder<T>(val theLoader: T, val annotation: DgsDataLoader, val name: String)
+    private data class LoaderHolder<T>(val theLoader: T, val annotation: DgsDataLoader, val name: String, val dispatchPredicate: DispatchPredicate? = null)
 
     private val batchLoaders = mutableListOf<LoaderHolder<BatchLoader<*, *>>>()
     private val batchLoadersWithContext = mutableListOf<LoaderHolder<BatchLoaderWithContext<*, *>>>()
@@ -59,32 +63,67 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
 
     fun <T> buildRegistryWithContextSupplier(contextSupplier: Supplier<T>): DataLoaderRegistry {
         val startTime = System.currentTimeMillis()
+        //val dataLoaderRegistry = DataLoaderRegistry()
+        val dgsDataLoaderRegistry = DgsDataLoaderRegistry()
 
-        val dataLoaderRegistry = DataLoaderRegistry()
         batchLoaders.forEach {
-            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, it.name, dataLoaderRegistry))
+            if (it.dispatchPredicate == null) {
+                dgsDataLoaderRegistry.register(
+                    it.name,
+                    createDataLoader(it.theLoader, it.annotation, it.name, dgsDataLoaderRegistry)
+                )
+            } else {
+                dgsDataLoaderRegistry.registerWithDispatchPredicate(it.name, createDataLoader(it.theLoader, it.annotation, it.name, dgsDataLoaderRegistry), it.dispatchPredicate)
+            }
         }
         mappedBatchLoaders.forEach {
-            dataLoaderRegistry.register(it.name, createDataLoader(it.theLoader, it.annotation, it.name, dataLoaderRegistry))
+            if (it.dispatchPredicate == null) {
+                dgsDataLoaderRegistry.register(
+                    it.name,
+                    createDataLoader(it.theLoader, it.annotation, it.name, dgsDataLoaderRegistry)
+                )
+            } else {
+                dgsDataLoaderRegistry.registerWithDispatchPredicate(
+                    it.name,
+                    createDataLoader(it.theLoader, it.annotation, it.name, dgsDataLoaderRegistry),
+                    it.dispatchPredicate
+                )
+            }
         }
         batchLoadersWithContext.forEach {
-            dataLoaderRegistry.register(
-                it.name,
-                createDataLoader(it.theLoader, it.annotation, it.name, contextSupplier, dataLoaderRegistry)
-            )
+            if (it.dispatchPredicate == null) {
+                dgsDataLoaderRegistry.register(
+                    it.name,
+                    createDataLoader(it.theLoader, it.annotation, it.name, contextSupplier, dgsDataLoaderRegistry)
+                )
+            } else {
+                dgsDataLoaderRegistry.registerWithDispatchPredicate(
+                    it.name,
+                    createDataLoader(it.theLoader, it.annotation, it.name, contextSupplier, dgsDataLoaderRegistry),
+                    it.dispatchPredicate
+                )
+            }
         }
         mappedBatchLoadersWithContext.forEach {
-            dataLoaderRegistry.register(
-                it.name,
-                createDataLoader(it.theLoader, it.annotation, it.name, contextSupplier, dataLoaderRegistry)
-            )
+            if (it.dispatchPredicate == null) {
+                dgsDataLoaderRegistry.register(
+                    it.name,
+                    createDataLoader(it.theLoader, it.annotation, it.name, contextSupplier, dgsDataLoaderRegistry)
+                )
+            } else {
+                dgsDataLoaderRegistry.registerWithDispatchPredicate(
+                    it.name,
+                    createDataLoader(it.theLoader, it.annotation, it.name, contextSupplier, dgsDataLoaderRegistry),
+                    it.dispatchPredicate
+                )
+            }
         }
 
         val endTime = System.currentTimeMillis()
         val totalTime = endTime - startTime
         logger.debug("Created DGS dataloader registry in {}ms", totalTime)
 
-        return dataLoaderRegistry
+        return dgsDataLoaderRegistry
     }
 
     @PostConstruct
@@ -127,16 +166,28 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         dataLoaders.values.forEach { dgsComponent ->
             val javaClass = AopUtils.getTargetClass(dgsComponent)
             val annotation = javaClass.getAnnotation(DgsDataLoader::class.java)
-
-            fun <T : Any> createHolder(t: T): LoaderHolder<T> =
-                LoaderHolder(t, annotation, DataLoaderNameUtil.getDataLoaderName(javaClass, annotation))
-            when (dgsComponent) {
-                is BatchLoader<*, *> -> batchLoaders.add(createHolder(dgsComponent))
-                is BatchLoaderWithContext<*, *> -> batchLoadersWithContext.add(createHolder(dgsComponent))
-                is MappedBatchLoader<*, *> -> mappedBatchLoaders.add(createHolder(dgsComponent))
-                is MappedBatchLoaderWithContext<*, *> -> mappedBatchLoadersWithContext.add(createHolder(dgsComponent))
-                else -> throw InvalidDataLoaderTypeException(dgsComponent::class.java)
+            val predicateField = javaClass.declaredFields.asSequence().find { it.isAnnotationPresent(DgsDispatchPredicate::class.java) }
+            if (predicateField != null ) {
+                    ReflectionUtils.makeAccessible(predicateField)
+                    val dispatchPredicate =  predicateField.get(dgsComponent)
+                    if (dispatchPredicate is DispatchPredicate) {
+                       addDataLoaders(dgsComponent, annotation, dispatchPredicate)
+                    }
+            } else {
+                addDataLoaders(dgsComponent, annotation, null)
             }
+        }
+    }
+
+    private fun <T: Any>addDataLoaders(dgsComponent: T, annotation: DgsDataLoader, dispatchPredicate: DispatchPredicate?) {
+        fun <T : Any> createHolder(t: T): LoaderHolder<T> =
+            LoaderHolder(t, annotation, DataLoaderNameUtil.getDataLoaderName(javaClass, annotation), dispatchPredicate)
+        when (dgsComponent) {
+            is BatchLoader<*, *> -> batchLoaders.add(createHolder(dgsComponent))
+            is BatchLoaderWithContext<*, *> -> batchLoadersWithContext.add(createHolder(dgsComponent))
+            is MappedBatchLoader<*, *> -> mappedBatchLoaders.add(createHolder(dgsComponent))
+            is MappedBatchLoaderWithContext<*, *> -> mappedBatchLoadersWithContext.add(createHolder(dgsComponent))
+            else -> throw InvalidDataLoaderTypeException(dgsComponent::class.java)
         }
     }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -171,17 +171,17 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
                     ReflectionUtils.makeAccessible(predicateField)
                     val dispatchPredicate =  predicateField.get(dgsComponent)
                     if (dispatchPredicate is DispatchPredicate) {
-                       addDataLoaders(dgsComponent, annotation, dispatchPredicate)
+                       addDataLoaders(dgsComponent, javaClass, annotation, dispatchPredicate)
                     }
             } else {
-                addDataLoaders(dgsComponent, annotation, null)
+                addDataLoaders(dgsComponent, javaClass, annotation, null)
             }
         }
     }
 
-    private fun <T: Any>addDataLoaders(dgsComponent: T, annotation: DgsDataLoader, dispatchPredicate: DispatchPredicate?) {
+    private fun <T: Any>addDataLoaders(dgsComponent: T, targetClass: Class<*>, annotation: DgsDataLoader, dispatchPredicate: DispatchPredicate?) {
         fun <T : Any> createHolder(t: T): LoaderHolder<T> =
-            LoaderHolder(t, annotation, DataLoaderNameUtil.getDataLoaderName(javaClass, annotation), dispatchPredicate)
+            LoaderHolder(t, annotation, DataLoaderNameUtil.getDataLoaderName(targetClass, annotation), dispatchPredicate)
         when (dgsComponent) {
             is BatchLoader<*, *> -> batchLoaders.add(createHolder(dgsComponent))
             is BatchLoaderWithContext<*, *> -> batchLoadersWithContext.add(createHolder(dgsComponent))

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderRegistry.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderRegistry.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderRegistry
+import org.dataloader.registries.DispatchPredicate
+import org.dataloader.registries.ScheduledDataLoaderRegistry
+import org.dataloader.stats.Statistics
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.Consumer
+import java.util.function.Function
+
+/**
+ * The DgsDataLoaderRegistry is a registry of DataLoaderRegistry instances. It supports specifying
+ * DispatchPredicate on a per data loader basis, specified using @DispatchPredicate annotation. It creates an instance
+ * of a ScheduledDataLoaderRegistry for every data loader that is registered and delegates to the mapping instance of
+ * the registry based on the key. We need to create a registry per data loader since a DispatchPredicate is applicable
+ * for an instance of the ScheduledDataLoaderRegistry.
+ * https://github.com/graphql-java/java-dataloader#scheduled-dispatching
+ */
+open class DgsDataLoaderRegistry : DataLoaderRegistry() {
+    private val dataLoaderRegistries: MutableMap<String, DataLoaderRegistry> = ConcurrentHashMap()
+
+    /**
+     * This will register a new dataloader
+     *
+     * @param key        the key to put the data loader under
+     * @param dataLoader the data loader to register
+     *
+     * @return this registry
+     */
+    override fun register(key: String, dataLoader: DataLoader<*, *>): DataLoaderRegistry {
+        val registry = ScheduledDataLoaderRegistry.newScheduledRegistry().register(key, dataLoader).build();
+        dataLoaderRegistries.putIfAbsent(key, registry);
+        return this
+    }
+
+    /**
+     * This will register a new dataloader with a dispatch predicate set up for that loader
+     *
+     * @param key        the key to put the data loader under
+     * @param dataLoader the data loader to register
+     *
+     * @return this registry
+     */
+    fun registerWithDispatchPredicate(
+        key: String,
+        dataLoader: DataLoader<*, *>,
+        dispatchPredicate: DispatchPredicate
+    ): DataLoaderRegistry {
+        val registry = ScheduledDataLoaderRegistry.newScheduledRegistry().register(key, dataLoader)
+            .dispatchPredicate(dispatchPredicate)
+            .build();
+        dataLoaderRegistries.putIfAbsent(key, registry);
+        return this
+    }
+
+    /**
+     * Computes a data loader if absent or return it if it was
+     * already registered at that key.
+     *
+     *
+     * Note: The entire method invocation is performed atomically,
+     * so the function is applied at most once per key.
+     *
+     * @param key             the key of the data loader
+     * @param mappingFunction the function to compute a data loader
+     * @param <K>             the type of keys
+     * @param <V>             the type of values
+     *
+     * @return a data loader
+    </V></K> */
+    override fun <K, V> computeIfAbsent(
+        key: String,
+        mappingFunction: Function<String, DataLoader<*, *>>?
+    ): DataLoader<K, V> {
+        val dataLoadersForKey = dataLoaderRegistries[key]
+        return if (dataLoadersForKey == null) {
+            val newRegistry = ScheduledDataLoaderRegistry.newScheduledRegistry().build();
+            dataLoaderRegistries[key] = newRegistry
+            newRegistry.computeIfAbsent<K, V>(key, mappingFunction) as DataLoader<K, V>
+        } else {
+            dataLoadersForKey.computeIfAbsent<K, V>(key, mappingFunction!!) as DataLoader<K, V>;
+        }
+    }
+
+    /**
+     *  This operation is not supported since we cannot store a dataloader registry without a key.
+     */
+    override fun combine(registry: DataLoaderRegistry): DataLoaderRegistry? {
+        throw UnsupportedOperationException("Cannot combine a DgsDataLoaderRegistry with another registry")
+    }
+
+    /**
+     * @return the currently registered data loaders
+     */
+    override fun getDataLoaders(): List<DataLoader<*, *>> {
+        return dataLoaderRegistries.flatMap { it.value.dataLoaders }
+    }
+
+    /**
+     * @return the currently registered data loaders as a map
+     */
+    override fun getDataLoadersMap(): Map<String, DataLoader<*, *>> {
+        var dataLoadersMap: Map<String, DataLoader<*, *>> = emptyMap()
+        dataLoaderRegistries.forEach {
+            dataLoadersMap = dataLoadersMap.plus(it.value.dataLoadersMap)
+        }
+        return LinkedHashMap(dataLoadersMap)
+    }
+
+    /**
+     * This will unregister a new dataloader
+     *
+     * @param key the key of the data loader to unregister
+     *
+     * @return this registry
+     */
+    override fun unregister(key: String): DataLoaderRegistry {
+        dataLoaderRegistries.remove(key)
+        return this
+    }
+
+    /**
+     * Returns the dataloader that was registered under the specified key
+     *
+     * @param key the key of the data loader
+     * @param <K> the type of keys
+     * @param <V> the type of values
+     *
+     * @return a data loader or null if its not present
+    </V></K> */
+    override fun <K, V> getDataLoader(key: String): DataLoader<K, V> {
+        return dataLoaderRegistries[key]!!.dataLoadersMap[key] as DataLoader<K, V>
+    }
+
+    override fun getKeys(): Set<String> {
+        return HashSet(dataLoaderRegistries.keys)
+    }
+
+    /**
+     * This will be called [org.dataloader.DataLoader.dispatch] on each of the registered
+     * [org.dataloader.DataLoader]s
+     */
+    override fun dispatchAll() {
+        dataLoaderRegistries.forEach {
+           it.value.dispatchAll()
+        }
+    }
+
+    /**
+     * Similar to [DataLoaderRegistry.dispatchAll], this calls [org.dataloader.DataLoader.dispatch] on
+     * each of the registered [org.dataloader.DataLoader]s, but returns the number of dispatches.
+     *
+     * @return total number of entries that were dispatched from registered [org.dataloader.DataLoader]s.
+     */
+    override fun dispatchAllWithCount(): Int {
+        var sum = 0
+        dataLoaderRegistries.forEach {
+            sum+= it.value.dispatchAllWithCount()
+        }
+        return sum
+    }
+
+    /**
+     * @return The sum of all batched key loads that need to be dispatched from all registered
+     * [org.dataloader.DataLoader]s
+     */
+    override fun dispatchDepth(): Int {
+        var totalDispatchDepth = 0
+        dataLoaderRegistries.forEach {
+                totalDispatchDepth += it.value.dispatchDepth()
+        }
+        return totalDispatchDepth
+    }
+
+    override fun getStatistics() : Statistics {
+        var stats = Statistics()
+        dataLoaderRegistries.forEach {
+                stats = stats.combine(it.value.statistics)
+        }
+        return stats
+    }
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderRegistry.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderRegistry.kt
@@ -45,7 +45,7 @@ open class DgsDataLoaderRegistry : DataLoaderRegistry() {
      * @return this registry
      */
     override fun register(key: String, dataLoader: DataLoader<*, *>): DataLoaderRegistry {
-        dataLoaderRegistry.register(key, dataLoader);
+        dataLoaderRegistry.register(key, dataLoader)
         return this
     }
 
@@ -64,8 +64,8 @@ open class DgsDataLoaderRegistry : DataLoaderRegistry() {
     ): DataLoaderRegistry {
         val registry = ScheduledDataLoaderRegistry.newScheduledRegistry().register(key, dataLoader)
             .dispatchPredicate(dispatchPredicate)
-            .build();
-        scheduledDataLoaderRegistries.putIfAbsent(key, registry);
+            .build()
+        scheduledDataLoaderRegistries.putIfAbsent(key, registry)
         return this
     }
 
@@ -83,13 +83,13 @@ open class DgsDataLoaderRegistry : DataLoaderRegistry() {
      * @param <V>             the type of values
      *
      * @return a data loader
-    </V></K> */
+     </V></K> */
     override fun <K, V> computeIfAbsent(
         key: String,
         mappingFunction: Function<String, DataLoader<*, *>>?
     ): DataLoader<K, V> {
         // we do not support this method for registering with dispatch predicates
-        return dataLoaderRegistry.computeIfAbsent<K, V>(key, mappingFunction!!) as DataLoader<K, V>;
+        return dataLoaderRegistry.computeIfAbsent<K, V>(key, mappingFunction!!) as DataLoader<K, V>
     }
 
     /**
@@ -138,7 +138,7 @@ open class DgsDataLoaderRegistry : DataLoaderRegistry() {
      * @param <V> the type of values
      *
      * @return a data loader or null if its not present
-    </V></K> */
+     </V></K> */
     override fun <K, V> getDataLoader(key: String): DataLoader<K, V>? {
         if (dataLoaderRegistry.keys.contains(key)) {
             return dataLoaderRegistry.getDataLoader(key)
@@ -158,7 +158,7 @@ open class DgsDataLoaderRegistry : DataLoaderRegistry() {
      */
     override fun dispatchAll() {
         scheduledDataLoaderRegistries.forEach {
-           it.value.dispatchAll()
+            it.value.dispatchAll()
         }
         dataLoaderRegistry.dispatchAll()
     }
@@ -172,9 +172,9 @@ open class DgsDataLoaderRegistry : DataLoaderRegistry() {
     override fun dispatchAllWithCount(): Int {
         var sum = 0
         scheduledDataLoaderRegistries.forEach {
-            sum+= it.value.dispatchAllWithCount()
+            sum += it.value.dispatchAllWithCount()
         }
-        sum+= dataLoaderRegistry.dispatchAllWithCount()
+        sum += dataLoaderRegistry.dispatchAllWithCount()
         return sum
     }
 
@@ -185,17 +185,17 @@ open class DgsDataLoaderRegistry : DataLoaderRegistry() {
     override fun dispatchDepth(): Int {
         var totalDispatchDepth = 0
         scheduledDataLoaderRegistries.forEach {
-                totalDispatchDepth += it.value.dispatchDepth()
+            totalDispatchDepth += it.value.dispatchDepth()
         }
-        totalDispatchDepth+= dataLoaderRegistry.dispatchDepth()
+        totalDispatchDepth += dataLoaderRegistry.dispatchDepth()
 
         return totalDispatchDepth
     }
 
-    override fun getStatistics() : Statistics {
+    override fun getStatistics(): Statistics {
         var stats = Statistics()
         scheduledDataLoaderRegistries.forEach {
-                stats = stats.combine(it.value.statistics)
+            stats = stats.combine(it.value.statistics)
         }
         stats = stats.combine(dataLoaderRegistry.statistics)
         return stats

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -24,7 +24,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.dataloader.BatchLoader
 import org.dataloader.DataLoaderRegistry
-import org.dataloader.registries.DispatchPredicate
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -24,6 +24,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.dataloader.BatchLoader
 import org.dataloader.DataLoaderRegistry
+import org.dataloader.registries.DispatchPredicate
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -41,12 +42,27 @@ class DgsDataLoaderProviderTest {
 
     @Test
     fun findDataLoaders() {
-        applicationContextRunner.withBean(ExampleBatchLoader::class.java).run { context ->
+        applicationContextRunner.withBean(ExampleBatchLoader::class.java).withBean(ExampleBatchLoaderWithDispatchPredicate::class.java).run { context ->
             val provider = context.getBean(DgsDataLoaderProvider::class.java)
             val dataLoaderRegistry = provider.buildRegistry()
-            Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
+            Assertions.assertEquals(2, dataLoaderRegistry.dataLoaders.size)
             val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoader")
             Assertions.assertNotNull(dataLoader)
+            val dataLoaderWithDispatch = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoaderWithDispatch")
+            Assertions.assertNotNull(dataLoaderWithDispatch)
+        }
+    }
+
+    @Test
+    fun findDataLoadersWithContext() {
+        applicationContextRunner.withBean(ExampleBatchLoaderWithContext::class.java).withBean(ExampleBatchLoaderWithContextAndDispatchPredicate::class.java).run { context ->
+            val provider = context.getBean(DgsDataLoaderProvider::class.java)
+            val dataLoaderRegistry = provider.buildRegistry()
+            Assertions.assertEquals(2, dataLoaderRegistry.dataLoaders.size)
+            val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoaderWithContext")
+            Assertions.assertNotNull(dataLoader)
+            val dataLoaderWithDispatch = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoaderWithContextAndDispatch")
+            Assertions.assertNotNull(dataLoaderWithDispatch)
         }
     }
 
@@ -82,12 +98,27 @@ class DgsDataLoaderProviderTest {
 
     @Test
     fun findMappedDataLoaders() {
-        applicationContextRunner.withBean(ExampleMappedBatchLoader::class.java).run { context ->
+        applicationContextRunner.withBean(ExampleMappedBatchLoader::class.java).withBean(ExampleMappedBatchLoaderWithDispatchPredicate::class.java).run { context ->
             val provider = context.getBean(DgsDataLoaderProvider::class.java)
             val dataLoaderRegistry = provider.buildRegistry()
-            Assertions.assertEquals(1, dataLoaderRegistry.dataLoaders.size)
+            Assertions.assertEquals(2, dataLoaderRegistry.dataLoaders.size)
             val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoader")
             Assertions.assertNotNull(dataLoader)
+            val dataLoaderWithDispatch = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoaderWithDispatch")
+            Assertions.assertNotNull(dataLoaderWithDispatch)
+        }
+    }
+
+    @Test
+    fun findMappedDataLoadersWithContext() {
+        applicationContextRunner.withBean(ExampleMappedBatchLoaderWithContext::class.java).withBean(ExampleMappedBatchLoaderWithContextAndDispatchPredicate::class.java).run { context ->
+            val provider = context.getBean(DgsDataLoaderProvider::class.java)
+            val dataLoaderRegistry = provider.buildRegistry()
+            Assertions.assertEquals(2, dataLoaderRegistry.dataLoaders.size)
+            val dataLoader = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoaderWithContext")
+            Assertions.assertNotNull(dataLoader)
+            val dataLoaderWithDispatch = dataLoaderRegistry.getDataLoader<Any, Any>("exampleMappedLoaderWithContextAndDispatch")
+            Assertions.assertNotNull(dataLoaderWithDispatch)
         }
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderRegistryTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderRegistryTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import com.netflix.graphql.dgs.internal.DgsDataLoaderRegistry
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderFactory
+import org.dataloader.registries.DispatchPredicate
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+class DgsDataLoaderRegistryTest {
+
+    private val dgsDataLoaderRegistry = DgsDataLoaderRegistry()
+    private val dataLoaderA = ExampleDataLoaderA()
+    private val dataLoaderB = ExampleDataLoaderB()
+
+    @MockK
+    var mockDataLoaderA: DataLoader<String, String> = mockk()
+
+    @MockK
+    var mockDataLoaderB: DataLoader<String, String> = mockk()
+
+    @Test
+    fun register() {
+        val newLoader = DataLoaderFactory.newDataLoader(dataLoaderA)
+        dgsDataLoaderRegistry.register("exampleLoaderA", newLoader)
+        assertThat(dgsDataLoaderRegistry.dataLoaders.size).isEqualTo(1)
+        val registeredLoader = dgsDataLoaderRegistry.getDataLoader<String, String>("exampleLoaderA")
+        assertThat(registeredLoader).isNotNull
+    }
+
+    @Test
+    fun registerWithScheduledDispatch() {
+
+        val newLoader = DataLoaderFactory.newDataLoader(dataLoaderB)
+        dgsDataLoaderRegistry.registerWithDispatchPredicate(
+            "exampleLoaderB", newLoader,
+            DispatchPredicate.dispatchIfDepthGreaterThan(1)
+        )
+        assertThat(dgsDataLoaderRegistry.dataLoaders.size).isEqualTo(1)
+        val registeredLoader = dgsDataLoaderRegistry.getDataLoader<String, String>("exampleLoaderB")
+        assertThat(registeredLoader).isNotNull
+    }
+
+    @Test
+    fun getDataLoaders() {
+        val newLoaderA = DataLoaderFactory.newDataLoader(dataLoaderA)
+        dgsDataLoaderRegistry.register("exampleLoaderA", newLoaderA)
+
+        val newLoaderB = DataLoaderFactory.newDataLoader(dataLoaderB)
+        dgsDataLoaderRegistry.registerWithDispatchPredicate(
+            "exampleLoaderB", newLoaderB,
+            DispatchPredicate.dispatchIfDepthGreaterThan(1)
+        )
+        assertThat(dgsDataLoaderRegistry.dataLoaders.size).isEqualTo(2)
+        val registeredLoaderA = dgsDataLoaderRegistry.getDataLoader<String, String>("exampleLoaderA")
+        assertThat(registeredLoaderA).isNotNull
+        val registeredLoaderB = dgsDataLoaderRegistry.getDataLoader<String, String>("exampleLoaderB")
+        assertThat(registeredLoaderB).isNotNull
+    }
+
+    @Test
+    fun getDataLoadersAsMap() {
+        val newLoaderA = DataLoaderFactory.newDataLoader(dataLoaderA)
+        dgsDataLoaderRegistry.register("exampleLoaderA", newLoaderA)
+
+        val newLoaderB = DataLoaderFactory.newDataLoader(dataLoaderB)
+        dgsDataLoaderRegistry.registerWithDispatchPredicate(
+            "exampleLoaderB", newLoaderB,
+            DispatchPredicate.dispatchIfDepthGreaterThan(1)
+        )
+
+        assertThat(dgsDataLoaderRegistry.dataLoadersMap.size).isEqualTo(2)
+        val registeredLoaderA = dgsDataLoaderRegistry.dataLoadersMap["exampleLoaderA"]
+        assertThat(registeredLoaderA).isNotNull
+        val registeredLoaderB = dgsDataLoaderRegistry.dataLoadersMap["exampleLoaderB"]
+        assertThat(registeredLoaderB).isNotNull
+    }
+
+    @Test
+    fun dispatchAll() {
+        every { mockDataLoaderB.dispatchDepth() } returns 1
+        every { mockDataLoaderB.dispatch() } returns CompletableFuture.completedFuture(emptyList<String>())
+        every { mockDataLoaderA.dispatch() } returns CompletableFuture.completedFuture(emptyList<String>())
+
+        dgsDataLoaderRegistry.register("exampleLoaderA", mockDataLoaderA)
+        dgsDataLoaderRegistry.registerWithDispatchPredicate(
+            "exampleLoaderB", mockDataLoaderB,
+            DispatchPredicate.dispatchIfDepthGreaterThan(1)
+        )
+        dgsDataLoaderRegistry.dispatchAll()
+    }
+
+    @Test
+    fun dispatchDepth() {
+        every { mockDataLoaderA.dispatchDepth() } returns 2
+        every { mockDataLoaderB.dispatchDepth() } returns 1
+
+        dgsDataLoaderRegistry.register("exampleLoaderA", mockDataLoaderA)
+        dgsDataLoaderRegistry.registerWithDispatchPredicate(
+            "exampleLoaderB", mockDataLoaderB,
+            DispatchPredicate.dispatchIfDepthGreaterThan(1)
+        )
+        assertThat(dgsDataLoaderRegistry.dispatchDepth()).isEqualTo(3)
+    }
+
+    @DgsDataLoader(name = "exampleLoaderA")
+    class ExampleDataLoaderA : BatchLoader<String, String> {
+        override fun load(keys: List<String>): CompletionStage<List<String>> {
+            return CompletableFuture.completedFuture(listOf("A", "B", "C"))
+        }
+    }
+
+    @DgsDataLoader(name = "exampleLoaderB")
+    class ExampleDataLoaderB : BatchLoader<String, String> {
+        override fun load(keys: List<String>): CompletionStage<List<String>> {
+            return CompletableFuture.completedFuture(listOf("A", "B", "C"))
+        }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderRegistryTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderRegistryTest.kt
@@ -68,7 +68,7 @@ class DgsDataLoaderRegistryTest {
 
     @Test
     fun unregister() {
-        val newLoader = DataLoaderFactory.newDataLoader(dataLoaderA)
+        DataLoaderFactory.newDataLoader(dataLoaderA)
         dgsDataLoaderRegistry.register("exampleLoaderA", DataLoaderFactory.newDataLoader(dataLoaderA))
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
             "exampleLoaderB",

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderRegistryTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderRegistryTest.kt
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.assertThrows
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
-
 class DgsDataLoaderRegistryTest {
 
     private val dgsDataLoaderRegistry = DgsDataLoaderRegistry()
@@ -56,10 +55,10 @@ class DgsDataLoaderRegistryTest {
 
     @Test
     fun registerWithScheduledDispatch() {
-
         val newLoader = DataLoaderFactory.newDataLoader(dataLoaderB)
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
-            "exampleLoaderB", newLoader,
+            "exampleLoaderB",
+            newLoader,
             DispatchPredicate.dispatchIfDepthGreaterThan(1)
         )
         assertThat(dgsDataLoaderRegistry.dataLoaders.size).isEqualTo(1)
@@ -72,7 +71,8 @@ class DgsDataLoaderRegistryTest {
         val newLoader = DataLoaderFactory.newDataLoader(dataLoaderA)
         dgsDataLoaderRegistry.register("exampleLoaderA", DataLoaderFactory.newDataLoader(dataLoaderA))
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
-            "exampleLoaderB", DataLoaderFactory.newDataLoader(dataLoaderB),
+            "exampleLoaderB",
+            DataLoaderFactory.newDataLoader(dataLoaderB),
             DispatchPredicate.dispatchIfDepthGreaterThan(1)
         )
         assertThat(dgsDataLoaderRegistry.dataLoaders.size).isEqualTo(2)
@@ -92,7 +92,7 @@ class DgsDataLoaderRegistryTest {
     @Test
     fun computeIfAbsent() {
         val dataLoader = DataLoaderFactory.newDataLoader(dataLoaderA) as DataLoader<*, *>
-        dgsDataLoaderRegistry.computeIfAbsent<String, String>("exampleLoader" ){ dataLoader }
+        dgsDataLoaderRegistry.computeIfAbsent<String, String>("exampleLoader") { dataLoader }
 
         val loader = dgsDataLoaderRegistry.getDataLoader<String, String>("exampleLoader")
         assertThat(loader).isNotNull
@@ -105,7 +105,8 @@ class DgsDataLoaderRegistryTest {
 
         val newLoaderB = DataLoaderFactory.newDataLoader(dataLoaderB)
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
-            "exampleLoaderB", newLoaderB,
+            "exampleLoaderB",
+            newLoaderB,
             DispatchPredicate.dispatchIfDepthGreaterThan(1)
         )
         assertThat(dgsDataLoaderRegistry.dataLoaders.size).isEqualTo(2)
@@ -122,7 +123,8 @@ class DgsDataLoaderRegistryTest {
 
         val newLoaderB = DataLoaderFactory.newDataLoader(dataLoaderB)
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
-            "exampleLoaderB", newLoaderB,
+            "exampleLoaderB",
+            newLoaderB,
             DispatchPredicate.dispatchIfDepthGreaterThan(1)
         )
 
@@ -141,7 +143,8 @@ class DgsDataLoaderRegistryTest {
 
         dgsDataLoaderRegistry.register("exampleLoaderA", mockDataLoaderA)
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
-            "exampleLoaderB", mockDataLoaderB,
+            "exampleLoaderB",
+            mockDataLoaderB,
             DispatchPredicate.dispatchIfDepthGreaterThan(1)
         )
         dgsDataLoaderRegistry.dispatchAll()
@@ -154,7 +157,8 @@ class DgsDataLoaderRegistryTest {
 
         dgsDataLoaderRegistry.register("exampleLoaderA", mockDataLoaderA)
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
-            "exampleLoaderB", mockDataLoaderB,
+            "exampleLoaderB",
+            mockDataLoaderB,
             DispatchPredicate.dispatchIfDepthGreaterThan(1)
         )
         assertThat(dgsDataLoaderRegistry.dispatchDepth()).isEqualTo(3)
@@ -168,7 +172,8 @@ class DgsDataLoaderRegistryTest {
 
         dgsDataLoaderRegistry.register("exampleLoaderA", mockDataLoaderA)
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
-            "exampleLoaderB", mockDataLoaderB,
+            "exampleLoaderB",
+            mockDataLoaderB,
             DispatchPredicate.dispatchIfDepthGreaterThan(1)
         )
         assertThat(dgsDataLoaderRegistry.dispatchAllWithCount()).isEqualTo(7)
@@ -181,7 +186,8 @@ class DgsDataLoaderRegistryTest {
 
         dgsDataLoaderRegistry.register("exampleLoaderA", mockDataLoaderA)
         dgsDataLoaderRegistry.registerWithDispatchPredicate(
-            "exampleLoaderB", mockDataLoaderB,
+            "exampleLoaderB",
+            mockDataLoaderB,
             DispatchPredicate.dispatchIfDepthGreaterThan(1)
         )
         assertThat(dgsDataLoaderRegistry.statistics).isNotNull

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithContextAndDispatchPredicate.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithContextAndDispatchPredicate.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.BatchLoaderEnvironment
+import org.dataloader.BatchLoaderWithContext
+import org.dataloader.registries.DispatchPredicate
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader(name = "exampleLoaderWithContextAndDispatch")
+class ExampleBatchLoaderWithContextAndDispatchPredicate : BatchLoaderWithContext<String, String> {
+    @DgsDispatchPredicate
+    val dgsPredicate : DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
+    override fun load(keys: List<String>, env: BatchLoaderEnvironment): CompletionStage<List<String>> {
+        return CompletableFuture.supplyAsync { keys.map { it.uppercase() } }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithContextAndDispatchPredicate.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithContextAndDispatchPredicate.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletionStage
 @DgsDataLoader(name = "exampleLoaderWithContextAndDispatch")
 class ExampleBatchLoaderWithContextAndDispatchPredicate : BatchLoaderWithContext<String, String> {
     @DgsDispatchPredicate
-    val dgsPredicate : DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
+    val dgsPredicate: DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
     override fun load(keys: List<String>, env: BatchLoaderEnvironment): CompletionStage<List<String>> {
         return CompletableFuture.supplyAsync { keys.map { it.uppercase() } }
     }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithDispatchPredicate.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithDispatchPredicate.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.BatchLoader
+import org.dataloader.registries.DispatchPredicate
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader(name = "exampleLoaderWithDispatch")
+class ExampleBatchLoaderWithDispatchPredicate : BatchLoader<String, String> {
+    @DgsDispatchPredicate
+    val dgsPredicate : DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
+
+    override fun load(keys: MutableList<String>?): CompletionStage<MutableList<String>> {
+        return CompletableFuture.supplyAsync { mutableListOf("a", "b", "c") }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithDispatchPredicate.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithDispatchPredicate.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletionStage
 @DgsDataLoader(name = "exampleLoaderWithDispatch")
 class ExampleBatchLoaderWithDispatchPredicate : BatchLoader<String, String> {
     @DgsDispatchPredicate
-    val dgsPredicate : DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
+    val dgsPredicate: DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
 
     override fun load(keys: MutableList<String>?): CompletionStage<MutableList<String>> {
         return CompletableFuture.supplyAsync { mutableListOf("a", "b", "c") }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithContextAndDispatchPredicate.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithContextAndDispatchPredicate.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletionStage
 @DgsDataLoader(name = "exampleMappedLoaderWithContextAndDispatch")
 class ExampleMappedBatchLoaderWithContextAndDispatchPredicate : MappedBatchLoaderWithContext<String, String> {
     @DgsDispatchPredicate
-    val dgsPredicate : DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
+    val dgsPredicate: DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
     override fun load(keys: Set<String>, env: BatchLoaderEnvironment): CompletionStage<Map<String, String>> {
         return CompletableFuture.supplyAsync {
             keys.associateWith { it.uppercase() }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithContextAndDispatchPredicate.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithContextAndDispatchPredicate.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.BatchLoaderEnvironment
+import org.dataloader.MappedBatchLoaderWithContext
+import org.dataloader.registries.DispatchPredicate
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader(name = "exampleMappedLoaderWithContextAndDispatch")
+class ExampleMappedBatchLoaderWithContextAndDispatchPredicate : MappedBatchLoaderWithContext<String, String> {
+    @DgsDispatchPredicate
+    val dgsPredicate : DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
+    override fun load(keys: Set<String>, env: BatchLoaderEnvironment): CompletionStage<Map<String, String>> {
+        return CompletableFuture.supplyAsync {
+            keys.associateWith { it.uppercase() }
+        }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithDispatchPredicate.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithDispatchPredicate.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletionStage
 @DgsDataLoader(name = "exampleMappedLoaderWithDispatch")
 class ExampleMappedBatchLoaderWithDispatchPredicate : MappedBatchLoader<String, String> {
     @DgsDispatchPredicate
-    val dgsPredicate : DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
+    val dgsPredicate: DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
     override fun load(keys: Set<String>): CompletionStage<Map<String, String>> {
         return CompletableFuture.supplyAsync {
             keys.associateWith { it.uppercase() }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithDispatchPredicate.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleMappedBatchLoaderWithDispatchPredicate.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.MappedBatchLoader
+import org.dataloader.registries.DispatchPredicate
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader(name = "exampleMappedLoaderWithDispatch")
+class ExampleMappedBatchLoaderWithDispatchPredicate : MappedBatchLoader<String, String> {
+    @DgsDispatchPredicate
+    val dgsPredicate : DispatchPredicate = DispatchPredicate.dispatchIfDepthGreaterThan(1)
+    override fun load(keys: Set<String>): CompletionStage<Map<String, String>> {
+        return CompletableFuture.supplyAsync {
+            keys.associateWith { it.uppercase() }
+        }
+    }
+}


### PR DESCRIPTION
Pull request checklist
----

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Implement support for setting up a dispatch predicate per data loader component to use for Scheduled dispatching: https://github.com/graphql-java/java-dataloader#scheduled-dispatching

The framework now supports a `@DgsDispatchPredicate` that is defined as a field in the class that implements the data loader. The framework implementation will wire this up with a new instance of a ScheduledDataLoaderRegistry per dispatch predicate. This is primarily because graphql-java only supports having one instance of the data loader registry. 

The DgsDataLoaderRegistry maintains a `DataLoaderRegistry` for regular data loaders and a map of `ScheduledDataLoaderRegistry` for data loaders that requires setting a dispatch predicate for custom scheduling. 

Below is an example of how the dispatch predicate can be set up for the associated data loader.
```
@DgsDataLoader(name = "messagesWithScheduledDispatch")
public class MessageDataLoaderWithDispatchPredicate implements BatchLoader<String, String> {
    @DgsDispatchPredicate
    DispatchPredicate pred = DispatchPredicate.dispatchIfLongerThan(Duration.ofSeconds(2));
    @Override
    public CompletionStage<List<String>> load(List<String> keys) {
        return CompletableFuture.supplyAsync(() -> keys.stream().map(key -> "hello, " + key + "!").collect(Collectors.toList()));
    }
}
```

I have not yet added support for the use case of dataloaders as fields yet. I will add that in the future.
