### PR TITLE
Switch from using unpkg to jsdelivr for graphiql.

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/graphiql/index.html
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/resources/graphiql/index.html
@@ -17,22 +17,21 @@
 <html>
 <head>
     <title><DGS_GRAPHIQL_TITLE></title>
-    <link href="https://unpkg.com/graphiql@1.5.12/graphiql.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/graphiql@2.4.1/graphiql.min.css" rel="stylesheet" />
 </head>
 <body style="margin: 0;">
 <div id="graphiql" style="height: 100vh;"></div>
-
 <script
         crossorigin
-        src="https://unpkg.com/react/umd/react.production.min.js"
+        src="https://cdn.jsdelivr.net/npm/react/umd/react.production.min.js"
 ></script>
 <script
         crossorigin
-        src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"
+        src="https://cdn.jsdelivr.net/npm/react-dom/umd/react-dom.production.min.js"
 ></script>
 <script
         crossorigin
-        src="https://unpkg.com/graphiql@1.5.12/graphiql.min.js"
+        src="https://cdn.jsdelivr.net/npm/graphiql@2.4.1/graphiql.min.js"
 ></script>
 
 <script>

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/graphiql/index.html
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/resources/graphiql/index.html
@@ -17,23 +17,24 @@
 <html>
 <head>
     <title><DGS_GRAPHIQL_TITLE></title>
-    <link href="https://unpkg.com/graphiql@1.5.12/graphiql.min.css" rel="stylesheet" />
+    <link href="https://cdn.jsdelivr.net/npm/graphiql@2.4.1/graphiql.min.css" rel="stylesheet" />
 </head>
 <body style="margin: 0;">
 <div id="graphiql" style="height: 100vh;"></div>
 
 <script
         crossorigin
-        src="https://unpkg.com/react/umd/react.production.min.js"
+        src="https://cdn.jsdelivr.net/npm/react/umd/react.production.min.js"
 ></script>
 <script
         crossorigin
-        src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"
+        src="https://cdn.jsdelivr.net/npm/react-dom/umd/react-dom.production.min.js"
 ></script>
+
 <script
         crossorigin
-        src="https://unpkg.com/graphiql@1.5.12/graphiql.min.js"
-></script>
+        src="https://cdn.jsdelivr.net/npm/graphiql@2.4.1/graphiql.min.js">
+</script>
 
 <script>
       // Parse the search string to get url parameters.


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe):

Changes in this PR
----
Switches to using jsdelivr cdn instead of unpkg that has been more unreliable lately.

_Describe the new behavior from this PR, and why it's needed_
Issue #1454 

