### PR TITLE
feat: add DgsDataLoaderOptionsProvider

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.autoconfig
 
+import com.netflix.graphql.dgs.DgsDataLoaderOptionsProvider
 import com.netflix.graphql.dgs.DgsFederationResolver
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilder

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -136,6 +136,12 @@ open class DgsAutoConfiguration(
     }
 
     @Bean
+    @ConditionalOnMissingBean
+    open fun dgsDataLoaderOptionsProvider(): DgsDataLoaderOptionsProvider {
+        return DefaultDataLoaderOptionsProvider()
+    }
+
+    @Bean
     open fun dgsDataLoaderProvider(applicationContext: ApplicationContext): DgsDataLoaderProvider {
         return DgsDataLoaderProvider(applicationContext)
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataLoaderOptionsProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataLoaderOptionsProvider.kt
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.internal
+package com.netflix.graphql.dgs
 
-import com.netflix.graphql.dgs.DgsDataLoader
 import org.dataloader.DataLoaderOptions
 
 fun interface DgsDataLoaderOptionsProvider {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDataLoaderOptionsProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDataLoaderOptionsProvider.kt
@@ -17,6 +17,7 @@
 package com.netflix.graphql.dgs.internal
 
 import com.netflix.graphql.dgs.DgsDataLoader
+import com.netflix.graphql.dgs.DgsDataLoaderOptionsProvider
 import org.dataloader.DataLoaderOptions
 
 class DefaultDataLoaderOptionsProvider : DgsDataLoaderOptionsProvider {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDataLoaderOptionsProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDataLoaderOptionsProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import com.netflix.graphql.dgs.DgsDataLoader
+import org.dataloader.DataLoaderOptions
+
+class DefaultDataLoaderOptionsProvider : DgsDataLoaderOptionsProvider {
+    override fun getOptions(dataLoaderName: String, annotation: DgsDataLoader): DataLoaderOptions {
+        val options = DataLoaderOptions()
+            .setBatchingEnabled(annotation.batching)
+            .setCachingEnabled(annotation.caching)
+        if (annotation.maxBatchSize > 0) {
+            options.setMaxBatchSize(annotation.maxBatchSize)
+        }
+        return options
+    }
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderOptionsProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderOptionsProvider.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import com.netflix.graphql.dgs.DgsDataLoader
+import org.dataloader.DataLoaderOptions
+
+fun interface DgsDataLoaderOptionsProvider {
+    fun getOptions(dataLoaderName: String, annotation: DgsDataLoader): DataLoaderOptions
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.internal
 import com.netflix.graphql.dgs.DataLoaderInstrumentationExtensionProvider
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsDataLoader
+import com.netflix.graphql.dgs.DgsDataLoaderOptionsProvider
 import com.netflix.graphql.dgs.DgsDataLoaderRegistryConsumer
 import com.netflix.graphql.dgs.DgsDispatchPredicate
 import com.netflix.graphql.dgs.exceptions.DgsUnnamedDataLoaderOnFieldException

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -29,7 +29,6 @@ import org.dataloader.BatchLoader
 import org.dataloader.BatchLoaderWithContext
 import org.dataloader.DataLoader
 import org.dataloader.DataLoaderFactory
-import org.dataloader.DataLoaderOptions
 import org.dataloader.DataLoaderRegistry
 import org.dataloader.MappedBatchLoader
 import org.dataloader.MappedBatchLoaderWithContext
@@ -46,7 +45,10 @@ import javax.annotation.PostConstruct
 /**
  * Framework implementation class responsible for finding and configuring data loaders.
  */
-class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) {
+class DgsDataLoaderProvider(
+    private val applicationContext: ApplicationContext,
+    private val dataLoaderOptionsProvider: DgsDataLoaderOptionsProvider = DefaultDataLoaderOptionsProvider()
+) {
 
     private data class LoaderHolder<T>(val theLoader: T, val annotation: DgsDataLoader, val name: String, val dispatchPredicate: DispatchPredicate? = null)
 
@@ -194,7 +196,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         dataLoaderName: String,
         dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<*, *> {
-        val options = dataLoaderOptions(dgsDataLoader)
+        val options = dataLoaderOptionsProvider.getOptions(dataLoaderName, dgsDataLoader)
 
         if (batchLoader is DgsDataLoaderRegistryConsumer) {
             batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
@@ -210,7 +212,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         dataLoaderName: String,
         dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<*, *> {
-        val options = dataLoaderOptions(dgsDataLoader)
+        val options = dataLoaderOptionsProvider.getOptions(dataLoaderName, dgsDataLoader)
 
         if (batchLoader is DgsDataLoaderRegistryConsumer) {
             batchLoader.setDataLoaderRegistry(dataLoaderRegistry)
@@ -227,7 +229,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         supplier: Supplier<T>,
         dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<*, *> {
-        val options = dataLoaderOptions(dgsDataLoader)
+        val options = dataLoaderOptionsProvider.getOptions(dataLoaderName, dgsDataLoader)
             .setBatchLoaderContextProvider(supplier::get)
 
         if (batchLoader is DgsDataLoaderRegistryConsumer) {
@@ -245,7 +247,7 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
         supplier: Supplier<T>,
         dataLoaderRegistry: DataLoaderRegistry
     ): DataLoader<*, *> {
-        val options = dataLoaderOptions(dgsDataLoader)
+        val options = dataLoaderOptionsProvider.getOptions(dataLoaderName, dgsDataLoader)
             .setBatchLoaderContextProvider(supplier::get)
 
         if (batchLoader is DgsDataLoaderRegistryConsumer) {
@@ -254,16 +256,6 @@ class DgsDataLoaderProvider(private val applicationContext: ApplicationContext) 
 
         val extendedBatchLoader = wrappedDataLoader(batchLoader, dataLoaderName)
         return DataLoaderFactory.newMappedDataLoader(extendedBatchLoader, options)
-    }
-
-    private fun dataLoaderOptions(annotation: DgsDataLoader): DataLoaderOptions {
-        val options = DataLoaderOptions()
-            .setBatchingEnabled(annotation.batching)
-            .setCachingEnabled(annotation.caching)
-        if (annotation.maxBatchSize > 0) {
-            options.setMaxBatchSize(annotation.maxBatchSize)
-        }
-        return options
     }
 
     private inline fun <reified T> wrappedDataLoader(loader: T, name: String): T {


### PR DESCRIPTION
Copy of this https://github.com/Netflix/dgs-framework/pull/1485 for Spring Boot 2.7
----
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Add ability to customize DataLoaderOptions for DataLoaders

Extract a data loader options provider from DataLoaderProvider. Make default version of it as it was before. Add ability to customize provider through custom bean injection.

As discussed in here https://github.com/Netflix/dgs-framework/pull/1120#issuecomment-1510532242
