### PR TITLE
Add message overload to TypedGraphQLError

### DIFF
--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
@@ -293,6 +293,11 @@ public class TypedGraphQLError implements GraphQLError {
             return extensionsMap;
         }
 
+        public Builder message(String message) {
+            this.message = assertNotNull(message);
+            return this;
+        }
+
         public Builder message(String message, Object... formatArgs) {
             this.message = String.format(assertNotNull(message), formatArgs);
             return this;


### PR DESCRIPTION
Add a message overload that simply accepts the message as a String without doing any formatting.