### PR TITLE
implement hashCode in TypedGraphQLError

### DIFF
--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
@@ -246,6 +246,11 @@ public class TypedGraphQLError implements GraphQLError {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(message, locations, path, extensions);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
         if (obj == null) return false;


### PR DESCRIPTION
TypedGraphQLError already implemented equals, but was not implementing hashCode.

See: https://errorprone.info/bugpattern/EqualsHashCode
