### PR TITLE
Ignore non-graphql files

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -548,7 +548,7 @@ class DgsSchemaProvider(
 
         schemas += metaInfSchemas
 
-        val schemasFiltered = schemas.filter { it.toString().endsWith(".graphql]") || it.toString().endsWith(".graphqls]") }
+        val schemasFiltered = schemas.filter { it.filename.endsWith(".graphql", true) || it.filename.endsWith(".graphqls", true) }
         return schemasFiltered
     }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -548,8 +548,8 @@ class DgsSchemaProvider(
 
         schemas += metaInfSchemas
 
-        val schemasFiltered = schemas.filter { it.filename.endsWith(".graphql", true) || it.filename.endsWith(".graphqls", true) }
-        return schemasFiltered
+        val filteredSchemas = schemas.filter { it.filename.endsWith(".graphql", true) || it.filename.endsWith(".graphqls", true) }
+        return filteredSchemas
     }
 
     companion object {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -548,8 +548,7 @@ class DgsSchemaProvider(
 
         schemas += metaInfSchemas
 
-        val filteredSchemas = schemas.filter { it.filename.endsWith(".graphql", true) || it.filename.endsWith(".graphqls", true) }
-        return filteredSchemas
+        return schemas.filter { it.filename.endsWith(".graphql", true) || it.filename.endsWith(".graphqls", true) }
     }
 
     companion object {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -547,7 +547,8 @@ class DgsSchemaProvider(
         }
 
         schemas += metaInfSchemas
-        return schemas
+        val schemasFiltered = schemas.filter { it.toString().endsWith(".graphql]") || it.toString().endsWith(".graphqls]") }
+        return schemasFiltered
     }
 
     companion object {

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -199,7 +199,7 @@ internal class DgsSchemaProviderTest {
         assertEquals("location3-schema2.graphqls", schemaFiles[1].filename)
 
         // Check that the .graphqlconfig file has been ignored
-        val schemaFilesNames: MutableList<String> = mutableListOf();
+        val schemaFilesNames: MutableList<String> = mutableListOf()
         for (schemaFile in schemaFiles) {
             schemaFilesNames.add(schemaFile.filename)
         }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -191,6 +191,22 @@ internal class DgsSchemaProviderTest {
     }
 
     @Test
+    fun findSchemaFilesIgnoreNonGraphQLFiles() {
+        val schemaFiles = schemaProvider(
+            schemaLocations = listOf("classpath*:location3/**/*.graphql*")
+        ).findSchemaFiles()
+        assertEquals("location3-schema1.graphql", schemaFiles[0].filename)
+        assertEquals("location3-schema2.graphqls", schemaFiles[1].filename)
+
+        // Check that the .graphqlconfig file has been ignored
+        val schemaFilesNames: MutableList<String> = mutableListOf();
+        for (schemaFile in schemaFiles) {
+            schemaFilesNames.add(schemaFile.filename)
+        }
+        assert(!schemaFilesNames.contains("location3-ignore.graphqlconfig"))
+    }
+
+    @Test
     fun addFetchers() {
         val fetcher = object : Any() {
             @DgsData(parentType = "Query", field = "hello")

--- a/graphql-dgs/src/test/resources/location3/location3-ignore.graphqlconfig
+++ b/graphql-dgs/src/test/resources/location3/location3-ignore.graphqlconfig
@@ -1,0 +1,3 @@
+type Query {
+  hello(name:String): String
+}

--- a/graphql-dgs/src/test/resources/location3/location3-schema1.graphql
+++ b/graphql-dgs/src/test/resources/location3/location3-schema1.graphql
@@ -1,0 +1,3 @@
+type Query {
+    hello(name:String): String
+}

--- a/graphql-dgs/src/test/resources/location3/location3-schema2.graphqls
+++ b/graphql-dgs/src/test/resources/location3/location3-schema2.graphqls
@@ -1,0 +1,3 @@
+type Query {
+    hello(name:String): String
+}

--- a/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
+++ b/graphql-error-types/src/main/java/com/netflix/graphql/types/errors/TypedGraphQLError.java
@@ -246,6 +246,11 @@ public class TypedGraphQLError implements GraphQLError {
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(message, locations, path, extensions);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
         if (obj == null) return false;


### PR DESCRIPTION
Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Ignores any files in the schema path that do not have a .graphql or .graphqls extension.

_Describe the new behavior from this PR, and why it's needed_
Issue #1484 
