### PR TITLE
Adding support for Country Code and Currency Extended Scalars

### DIFF
--- a/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
+++ b/graphql-dgs-extended-scalars/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfiguration.kt
@@ -187,6 +187,42 @@ open class DgsExtendedScalarsAutoConfiguration {
     }
 
     @ConditionalOnProperty(
+        prefix = "dgs.graphql.extensions.scalars.currency",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    @Configuration(proxyBeanMethods = false)
+    open class CurrencyExtendedScalarsRegistrar {
+        @Bean
+        open fun currencyExtendedScalarsRegistrar(): ExtendedScalarRegistrar {
+            return object : AbstractExtendedScalarRegistrar() {
+                override fun getScalars(): List<GraphQLScalarType> {
+                    return listOf(ExtendedScalars.Currency)
+                }
+            }
+        }
+    }
+
+    @ConditionalOnProperty(
+        prefix = "dgs.graphql.extensions.scalars.country",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    @Configuration(proxyBeanMethods = false)
+    open class CountryExtendedScalarsRegistrar {
+        @Bean
+        open fun countryCodeExtendedScalarsRegistrar(): ExtendedScalarRegistrar {
+            return object : AbstractExtendedScalarRegistrar() {
+                override fun getScalars(): List<GraphQLScalarType> {
+                    return listOf(ExtendedScalars.CountryCode)
+                }
+            }
+        }
+    }
+
+    @ConditionalOnProperty(
         prefix = "dgs.graphql.extensions.scalars.chars",
         name = ["enabled"],
         havingValue = "true",

--- a/graphql-dgs-extended-scalars/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfigurationTests.kt
+++ b/graphql-dgs-extended-scalars/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsExtendedScalarsAutoConfigurationTests.kt
@@ -142,4 +142,28 @@ internal class DgsExtendedScalarsAutoConfigurationTests {
                 .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.IDsExtendedScalarsAutoConfiguration::class.java)
         }
     }
+
+    @Test
+    fun `Country scalars can be disabled`() {
+        context.withPropertyValues(
+            "dgs.graphql.extensions.scalars.country.enabled=false"
+        ).run { context ->
+            assertThat(context)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration::class.java)
+            assertThat(context)
+                .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.CountryExtendedScalarsRegistrar::class.java)
+        }
+    }
+
+    @Test
+    fun `Currency scalars can be disabled`() {
+        context.withPropertyValues(
+            "dgs.graphql.extensions.scalars.currency.enabled=false"
+        ).run { context ->
+            assertThat(context)
+                .hasSingleBean(DgsExtendedScalarsAutoConfiguration::class.java)
+            assertThat(context)
+                .doesNotHaveBean(DgsExtendedScalarsAutoConfiguration.CurrencyExtendedScalarsRegistrar::class.java)
+        }
+    }
 }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
[Issue #1405 ](https://github.com/Netflix/dgs-framework/issues/1405)

This PR adds support for `CountryCodeScalar` and `CurrencyScalar`, which were both introduced in December, 2022 in 20.0 of `graphql-java-extended-scalars` [here](https://github.com/graphql-java/graphql-java-extended-scalars/releases/tag/20.0).

I introduced new groups for `country` and `currency` since these didn't seem to fit well under any existing groupings, but of course am open to groupings that people think make more sense.
