### PR TITLE
DgsContext: Fix getRequestData with BatchLoaderEnvironment

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
@@ -125,7 +125,7 @@ open class DgsContext(val customContext: Any? = null, val requestData: DgsReques
 
         @JvmStatic
         fun getRequestData(batchLoaderEnvironment: BatchLoaderEnvironment): DgsRequestData? {
-            val dgsContext = batchLoaderEnvironment.getContext<DgsContext>()
+            val dgsContext = from(batchLoaderEnvironment.getContext<GraphQLContext>())
             return dgsContext.requestData
         }
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/DgsContext.kt
@@ -96,6 +96,15 @@ open class DgsContext(val customContext: Any? = null, val requestData: DgsReques
         }
 
         @JvmStatic
+        fun from(batchLoaderEnvironment: BatchLoaderEnvironment): DgsContext {
+            return when (val context = batchLoaderEnvironment.getContext<Any>()) {
+                is GraphQLContext -> from(context)
+                is DgsContext -> context
+                else -> throw RuntimeException("Cannot resolve DgsContext from ${context::class.java.name}.")
+            }
+        }
+
+        @JvmStatic
         fun <T> getCustomContext(context: Any): T {
             @Suppress("UNCHECKED_CAST")
             return when (context) {
@@ -113,8 +122,8 @@ open class DgsContext(val customContext: Any? = null, val requestData: DgsReques
 
         @JvmStatic
         fun <T> getCustomContext(batchLoaderEnvironment: BatchLoaderEnvironment): T {
-            val dgsContext = batchLoaderEnvironment.getContext<GraphQLContext>()
-            return getCustomContext(dgsContext)
+            val context = batchLoaderEnvironment.getContext<Any>()
+            return getCustomContext(context)
         }
 
         @JvmStatic
@@ -125,7 +134,7 @@ open class DgsContext(val customContext: Any? = null, val requestData: DgsReques
 
         @JvmStatic
         fun getRequestData(batchLoaderEnvironment: BatchLoaderEnvironment): DgsRequestData? {
-            val dgsContext = from(batchLoaderEnvironment.getContext<GraphQLContext>())
+            val dgsContext = from(batchLoaderEnvironment)
             return dgsContext.requestData
         }
     }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/context/DgsContextTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/context/DgsContextTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.context
+
+import com.netflix.graphql.dgs.*
+import com.netflix.graphql.dgs.internal.DefaultDgsGraphQLContextBuilder
+import com.netflix.graphql.dgs.internal.DefaultDgsQueryExecutor
+import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
+import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
+import com.netflix.graphql.dgs.internal.method.MethodDataFetcherFactory
+import graphql.execution.AsyncExecutionStrategy
+import graphql.execution.AsyncSerialExecutionStrategy
+import graphql.execution.instrumentation.SimplePerformantInstrumentation
+import org.assertj.core.api.Assertions.assertThat
+import org.dataloader.BatchLoaderEnvironment
+import org.dataloader.BatchLoaderWithContext
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.ApplicationContext
+import org.springframework.http.HttpHeaders
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+internal class DgsContextTest {
+
+    private val applicationContextRunner: ApplicationContextRunner = ApplicationContextRunner()
+        .withBean(DgsDataLoaderProvider::class.java)
+
+    @Test
+    fun `getRequestData should return request data with headers`() {
+        applicationContextRunner.withBean(DgsTestComponent::class.java).run { context ->
+            val dgsQueryExecutor = createQueryExecutor(context, "type Query { hello(name: String): String }")
+
+            val httpHeaders = HttpHeaders()
+            httpHeaders.add("x-name-prefix", "Hello ")
+
+            val hello = dgsQueryExecutor.executeAndExtractJsonPathAsObject(
+                """{hello(name: "World")}""",
+                "data.hello",
+                emptyMap(),
+                String::class.java,
+                httpHeaders
+            )
+
+            assertThat(hello).isEqualTo("Hello World")
+        }
+    }
+
+    private fun createQueryExecutor(context: ApplicationContext, schemaString: String): DefaultDgsQueryExecutor {
+        val provider = DgsSchemaProvider(
+            applicationContext = context,
+            federationResolver = Optional.empty(),
+            existingTypeDefinitionRegistry = Optional.empty(),
+            methodDataFetcherFactory = MethodDataFetcherFactory(
+                listOf(
+                    InputArgumentResolver(DefaultInputObjectMapper()),
+                    DataFetchingEnvironmentArgumentResolver()
+                )
+            )
+        )
+
+        return DefaultDgsQueryExecutor(
+            defaultSchema = provider.schema(schemaString),
+            schemaProvider = provider,
+            dataLoaderProvider = context.getBean(DgsDataLoaderProvider::class.java),
+            contextBuilder = DefaultDgsGraphQLContextBuilder(Optional.empty()),
+            instrumentation = SimplePerformantInstrumentation.INSTANCE,
+            queryExecutionStrategy = AsyncExecutionStrategy(),
+            mutationExecutionStrategy = AsyncSerialExecutionStrategy(),
+            idProvider = Optional.empty()
+        )
+    }
+
+    @DgsComponent
+    class DgsTestComponent {
+        @DgsQuery
+        fun hello(@InputArgument name: String, dfe: DgsDataFetchingEnvironment): CompletableFuture<String> {
+            val loader = dfe.getDataLoader<String, String>(HelloLoader::class.java)
+            return loader.load(name)
+        }
+
+        @DgsDataLoader
+        class HelloLoader : BatchLoaderWithContext<String, String> {
+            override fun load(keys: List<String>, env: BatchLoaderEnvironment): CompletionStage<List<String>> {
+                val prefix = DgsContext.getRequestData(env)?.headers?.getFirst("x-name-prefix") ?: ""
+                return CompletableFuture.completedFuture(keys.map { prefix + it })
+            }
+        }
+    }
+}


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions) first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix

Changes in this PR
----

`DgsContext.getRequestData(batchLoaderEnvironment: BatchLoaderEnvironment)` has been fixed to properly return DgsRequestData. It currently kicks an  exception:

```
java.lang.ClassCastException: class graphql.GraphQLContext cannot be cast to class com.netflix.graphql.dgs.context.DgsContext (graphql.GraphQLContext and com.netflix.graphql.dgs.context.DgsContext are in unnamed module of loader 'app')
	at com.netflix.graphql.dgs.context.DgsContext$Companion.getRequestData(DgsContext.kt:128) ~[graphql-dgs-7.1.0.jar:7.1.0]
	at ...
```

Alternatives considered
----

I believe the fix is fairly straight forward, but I'm not quite sure if the test is in the correct namespace etc. (DgsContext did not have a test class before.)

Please let me know if there's anything missing / to change. .) Thank you. .)

