### PR TITLE
Get rid of usage of deprecated SimpleInstrumentation class

### DIFF
--- a/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/MyInstrumentation.java
+++ b/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/MyInstrumentation.java
@@ -19,7 +19,7 @@ package com.netflix.graphql.dgs.example.datafetcher;
 import com.netflix.graphql.dgs.DgsExecutionResult;
 import graphql.ExecutionResult;
 import graphql.execution.instrumentation.InstrumentationState;
-import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpHeaders;
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.CompletableFuture;
 
 @Component
-public class MyInstrumentation extends SimpleInstrumentation {
+public class MyInstrumentation extends SimplePerformantInstrumentation {
     @NotNull
     @Override
     public CompletableFuture<ExecutionResult> instrumentExecutionResult(ExecutionResult executionResult,

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/instrumentation/ExampleInstrumentationDependingOnContextContributor.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/instrumentation/ExampleInstrumentationDependingOnContextContributor.java
@@ -21,7 +21,7 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQLContext;
 import graphql.execution.instrumentation.InstrumentationState;
-import graphql.execution.instrumentation.SimpleInstrumentation;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
 import org.jetbrains.annotations.Nullable;
@@ -35,7 +35,7 @@ import java.util.concurrent.CompletableFuture;
  * the CONTRIBUTOR_ENABLED_CONTEXT_KEY.
  */
 @Component
-public class ExampleInstrumentationDependingOnContextContributor extends SimpleInstrumentation {
+public class ExampleInstrumentationDependingOnContextContributor extends SimplePerformantInstrumentation {
 
     @Override
     public InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
@@ -54,12 +54,10 @@ public class ExampleInstrumentationDependingOnContextContributor extends SimpleI
 
     @Override
     public CompletableFuture<ExecutionResult> instrumentExecutionResult(
-            ExecutionResult executionResult, InstrumentationExecutionParameters parameters) {
-        final @Nullable InstrumentationState state = parameters.getInstrumentationState();
-
+            ExecutionResult executionResult, InstrumentationExecutionParameters parameters, InstrumentationState state) {
         // skip if the expected property has not been set by context contributor
         if (state == null) {
-            return super.instrumentExecutionResult(executionResult, parameters);
+            return super.instrumentExecutionResult(executionResult, parameters, state);
         }
 
         // otherwise pass its value via extension to make this testable from a client perspective

--- a/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/DefaultDgsReactiveQueryExecutorTest.kt
+++ b/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/DefaultDgsReactiveQueryExecutorTest.kt
@@ -31,7 +31,7 @@ import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveGraphQLContex
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveQueryExecutor
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
-import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.SimplePerformantInstrumentation
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -139,7 +139,7 @@ internal class DefaultDgsReactiveQueryExecutorTest {
             schemaProvider = provider,
             dataLoaderProvider = dgsDataLoaderProvider,
             contextBuilder = DefaultDgsReactiveGraphQLContextBuilder(Optional.empty()),
-            instrumentation = SimpleInstrumentation.INSTANCE,
+            instrumentation = SimplePerformantInstrumentation.INSTANCE,
             queryExecutionStrategy = AsyncExecutionStrategy(),
             mutationExecutionStrategy = AsyncSerialExecutionStrategy(),
             idProvider = Optional.empty()

--- a/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/ReactiveReturnTypesTest.kt
+++ b/graphql-dgs-reactive/src/test/kotlin/com/netflix/graphql/dgs/reactive/ReactiveReturnTypesTest.kt
@@ -31,7 +31,7 @@ import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveGraphQLContex
 import com.netflix.graphql.dgs.reactive.internal.DefaultDgsReactiveQueryExecutor
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
-import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.SimplePerformantInstrumentation
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -176,7 +176,7 @@ internal class ReactiveReturnTypesTest {
             schemaProvider = provider,
             dataLoaderProvider = dgsDataLoaderProvider,
             contextBuilder = DefaultDgsReactiveGraphQLContextBuilder(Optional.empty()),
-            instrumentation = SimpleInstrumentation.INSTANCE,
+            instrumentation = SimplePerformantInstrumentation.INSTANCE,
             queryExecutionStrategy = AsyncExecutionStrategy(),
             mutationExecutionStrategy = AsyncSerialExecutionStrategy(),
             idProvider = Optional.empty()

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/GraphQLContextContributorInstrumentation.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/context/GraphQLContextContributorInstrumentation.kt
@@ -18,7 +18,7 @@ package com.netflix.graphql.dgs.context
 
 import graphql.GraphQLContext
 import graphql.execution.instrumentation.InstrumentationState
-import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.SimplePerformantInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters
 
 /**
@@ -28,23 +28,21 @@ import graphql.execution.instrumentation.parameters.InstrumentationCreateStatePa
  *
  * @see com.netflix.graphql.dgs.context.GraphQLContextContributor.contribute()
  */
-class GraphQLContextContributorInstrumentation(private val graphQLContextContributors: List<GraphQLContextContributor>) :
-    SimpleInstrumentation() {
+class GraphQLContextContributorInstrumentation(private val graphQLContextContributors: List<GraphQLContextContributor>) : SimplePerformantInstrumentation() {
 
     /**
      * createState is the very first method invoked in an Instrumentation, and thus is where this logic is placed to
      * contribute to the GraphQLContext as early as possible.
      */
-    override fun createState(parameters: InstrumentationCreateStateParameters?): InstrumentationState? {
-        var graphqlContext = parameters?.executionInput?.graphQLContext
-        if (graphqlContext != null && graphQLContextContributors.iterator().hasNext()) {
-            val extensions = parameters?.executionInput?.extensions
+    override fun createState(parameters: InstrumentationCreateStateParameters): InstrumentationState? {
+        val graphqlContext = parameters.executionInput.graphQLContext
+        if (graphqlContext != null && graphQLContextContributors.isNotEmpty()) {
+            val extensions = parameters.executionInput.extensions
             val requestData = DgsContext.from(graphqlContext).requestData
             val builderForContributors = GraphQLContext.newContext()
-            graphQLContextContributors.forEach() { it.contribute(builderForContributors, extensions, requestData) }
+            graphQLContextContributors.forEach { it.contribute(builderForContributors, extensions, requestData) }
             graphqlContext.putAll(builderForContributors)
         }
-
         return super.createState(parameters)
     }
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutorTest.kt
@@ -18,7 +18,13 @@ package com.netflix.graphql.dgs.internal
 
 import com.jayway.jsonpath.TypeRef
 import com.jayway.jsonpath.spi.mapper.MappingException
-import com.netflix.graphql.dgs.*
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsData
+import com.netflix.graphql.dgs.DgsDirective
+import com.netflix.graphql.dgs.DgsExecutionResult
+import com.netflix.graphql.dgs.DgsScalar
+import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.LocalDateTimeScalar
 import com.netflix.graphql.dgs.exceptions.DgsBadRequestException
 import com.netflix.graphql.dgs.exceptions.DgsQueryExecutionDataExtractionException
 import com.netflix.graphql.dgs.exceptions.QueryException
@@ -27,7 +33,7 @@ import com.netflix.graphql.dgs.internal.method.MethodDataFetcherFactory
 import graphql.InvalidSyntaxError
 import graphql.execution.AsyncExecutionStrategy
 import graphql.execution.AsyncSerialExecutionStrategy
-import graphql.execution.instrumentation.SimpleInstrumentation
+import graphql.execution.instrumentation.SimplePerformantInstrumentation
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
@@ -40,7 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.context.ApplicationContext
 import org.springframework.http.HttpHeaders
 import java.time.LocalDateTime
-import java.util.*
+import java.util.Optional
 import java.util.function.Supplier
 
 @Suppress("GraphQLUnresolvedReference")
@@ -146,7 +152,7 @@ internal class DefaultDgsQueryExecutorTest {
             schemaProvider = provider,
             dataLoaderProvider = dgsDataLoaderProvider,
             contextBuilder = DefaultDgsGraphQLContextBuilder(Optional.empty()),
-            instrumentation = SimpleInstrumentation.INSTANCE,
+            instrumentation = SimplePerformantInstrumentation.INSTANCE,
             queryExecutionStrategy = AsyncExecutionStrategy(),
             mutationExecutionStrategy = AsyncSerialExecutionStrategy(),
             idProvider = Optional.empty()


### PR DESCRIPTION
Stop using the deprecated SimpleInstrumentation class and switch to SimplePerformantInstrumentation.

