### PR TITLE
Validate at schema build time that @DgsData and @InputArgument match actual schema elements

### DIFF
--- a/graphql-dgs-example-java-webflux/build.gradle.kts
+++ b/graphql-dgs-example-java-webflux/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":graphql-dgs-example-shared"))
     implementation(project(":graphql-dgs-pagination"))
     implementation(project(":graphql-dgs-webflux-starter"))
+    implementation(project(":graphql-dgs-extended-scalars"))
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("io.projectreactor:reactor-core")
 }

--- a/graphql-dgs-example-java-webflux/src/test/java/ReactiveGraphQLContextContributorTest.java
+++ b/graphql-dgs-example-java-webflux/src/test/java/ReactiveGraphQLContextContributorTest.java
@@ -15,6 +15,7 @@
  */
 
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
 import com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor;
 import com.netflix.graphql.dgs.example.shared.datafetcher.MovieDataFetcher;
 import com.netflix.graphql.dgs.example.shared.instrumentation.ExampleInstrumentationDependingOnContextContributor;
@@ -33,7 +34,7 @@ import static com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLConte
 import static com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor.CONTEXT_CONTRIBUTOR_HEADER_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = {WebFluxConfigurationSupport.class, DgsAutoConfiguration.class, MovieDataFetcher.class, ExampleGraphQLContextContributor.class, ExampleInstrumentationDependingOnContextContributor.class, DgsWebFluxAutoConfiguration.class, DgsPaginationAutoConfiguration.class})
+@SpringBootTest(classes = {WebFluxConfigurationSupport.class, DgsAutoConfiguration.class, MovieDataFetcher.class, ExampleGraphQLContextContributor.class, ExampleInstrumentationDependingOnContextContributor.class, DgsWebFluxAutoConfiguration.class, DgsPaginationAutoConfiguration.class, DgsExtendedScalarsAutoConfiguration.class})
 public class ReactiveGraphQLContextContributorTest {
 
     @Autowired

--- a/graphql-dgs-example-java/build.gradle.kts
+++ b/graphql-dgs-example-java/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":graphql-dgs-example-shared"))
     implementation(project(":graphql-dgs-spring-boot-starter"))
     implementation(project(":graphql-dgs-pagination"))
+    implementation(project(":graphql-dgs-extended-scalars"))
     implementation(project(":graphql-dgs-subscriptions-websockets-autoconfigure"))
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("io.projectreactor:reactor-core")

--- a/graphql-dgs-example-java/src/test/java/FileUploadMutationTest.java
+++ b/graphql-dgs-example-java/src/test/java/FileUploadMutationTest.java
@@ -16,6 +16,7 @@
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
 import com.netflix.graphql.dgs.example.datafetcher.FileUploadMutation;
 import com.netflix.graphql.dgs.example.datafetcher.HelloDataFetcher;
 import com.netflix.graphql.dgs.example.shared.datafetcher.ConcurrentDataFetcher;
@@ -36,7 +37,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, ConcurrentDataFetcher.class, RatingMutation.class, DgsAutoConfiguration.class, DgsPaginationAutoConfiguration.class, FileUploadMutation.class})
+@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, ConcurrentDataFetcher.class, RatingMutation.class, DgsExtendedScalarsAutoConfiguration.class, DgsAutoConfiguration.class, DgsPaginationAutoConfiguration.class, FileUploadMutation.class})
 public class FileUploadMutationTest {
 
     @Autowired

--- a/graphql-dgs-example-java/src/test/java/GraphQLContextContributorTest.java
+++ b/graphql-dgs-example-java/src/test/java/GraphQLContextContributorTest.java
@@ -16,6 +16,7 @@
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
 import com.netflix.graphql.dgs.example.context.MyContextBuilder;
 import com.netflix.graphql.dgs.example.datafetcher.HelloDataFetcher;
 import com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor;
@@ -34,7 +35,7 @@ import static com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLConte
 import static com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor.CONTEXT_CONTRIBUTOR_HEADER_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, MyContextBuilder.class, ExampleGraphQLContextContributor.class, ExampleInstrumentationDependingOnContextContributor.class, DgsAutoConfiguration.class, DgsPaginationAutoConfiguration.class, ExampleLoaderWithContext.class, ExampleLoaderWithGraphQLContext.class})
+@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, MyContextBuilder.class, ExampleGraphQLContextContributor.class, ExampleInstrumentationDependingOnContextContributor.class, DgsExtendedScalarsAutoConfiguration.class, DgsAutoConfiguration.class, DgsPaginationAutoConfiguration.class, ExampleLoaderWithContext.class, ExampleLoaderWithGraphQLContext.class})
 public class GraphQLContextContributorTest {
 
     @Autowired

--- a/graphql-dgs-example-shared/build.gradle
+++ b/graphql-dgs-example-shared/build.gradle
@@ -17,6 +17,7 @@
 dependencies {
     implementation(project(":graphql-dgs-spring-boot-oss-autoconfigure"))
     implementation(project(":graphql-dgs-pagination"))
+    implementation(project(":graphql-dgs-extended-scalars"))
     implementation("io.projectreactor:reactor-core")
     implementation("org.springframework:spring-context")
     implementation("org.springframework:spring-web")

--- a/graphql-dgs-example-shared/src/main/resources/schema/schema.graphqls
+++ b/graphql-dgs-example-shared/src/main/resources/schema/schema.graphqls
@@ -9,9 +9,9 @@ type Query {
     messagesWithExceptionFromBatchLoader: [Message]
     messageFromBatchLoaderWithScheduledDispatch: String
 
-#    #Custom scalar example
-#    now: LocalTime
-#    schedule(time: LocalTime): Boolean
+    #Custom scalar example
+    now: LocalTime
+    schedule(time: LocalTime): Boolean
 
     #To show how exceptions are handled
     withGraphqlException: String
@@ -92,5 +92,5 @@ type Stock {
 }
 
 scalar Upload
-
+scalar LocalTime
 

--- a/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/ExampleSpringBootTest.java
+++ b/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/ExampleSpringBootTest.java
@@ -17,9 +17,11 @@
 package com.netflix.graphql.dgs.example.shared;
 
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
 import com.netflix.graphql.dgs.example.datafetcher.HelloDataFetcher;
 import com.netflix.graphql.dgs.example.shared.dataLoader.MessageDataLoaderWithDispatchPredicate;
 import com.netflix.graphql.dgs.example.shared.datafetcher.ConcurrentDataFetcher;
+import com.netflix.graphql.dgs.example.shared.datafetcher.CurrentTimeDateFetcher;
 import com.netflix.graphql.dgs.example.shared.datafetcher.MovieDataFetcher;
 import com.netflix.graphql.dgs.example.shared.datafetcher.RatingMutation;
 import com.netflix.graphql.dgs.pagination.DgsPaginationAutoConfiguration;
@@ -32,6 +34,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, ConcurrentDataFetcher.class, RatingMutation.class, DgsAutoConfiguration.class, DgsPaginationAutoConfiguration.class, MessageDataLoaderWithDispatchPredicate.class})
+@SpringBootTest(classes = {HelloDataFetcher.class, MovieDataFetcher.class, ConcurrentDataFetcher.class, RatingMutation.class, CurrentTimeDateFetcher.class, DgsExtendedScalarsAutoConfiguration.class, DgsAutoConfiguration.class, DgsPaginationAutoConfiguration.class, MessageDataLoaderWithDispatchPredicate.class})
 public @interface ExampleSpringBootTest {
 }

--- a/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/datafetcher/SubscriptionDataFetcherTest.java
+++ b/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/datafetcher/SubscriptionDataFetcherTest.java
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.example.shared.datafetcher;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
 import com.netflix.graphql.dgs.example.shared.types.Stock;
 import com.netflix.graphql.dgs.pagination.DgsPaginationAutoConfiguration;
 import graphql.ExecutionResult;
@@ -33,7 +34,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = {DgsAutoConfiguration.class, SubscriptionDataFetcher.class, DgsPaginationAutoConfiguration.class})
+@SpringBootTest(classes = {DgsAutoConfiguration.class, SubscriptionDataFetcher.class, DgsExtendedScalarsAutoConfiguration.class, DgsPaginationAutoConfiguration.class})
 class SubscriptionDataFetcherTest {
 
     @Autowired

--- a/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/datafetcher/TimeDataFetcherTest.java
+++ b/graphql-dgs-example-shared/src/test/java/com/netflix/graphql/dgs/example/shared/datafetcher/TimeDataFetcherTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.example.shared.datafetcher;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.example.shared.ExampleSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExampleSpringBootTest
+class TimeDataFetcherTest {
+
+    @Autowired
+    DgsQueryExecutor queryExecutor;
+
+    @Test
+    void returnCurrentTime() {
+        String message = queryExecutor.executeAndExtractJsonPath("{ now }", "data.now");
+        assertThat(message).isNotNull();
+    }
+
+    @Test
+    void acceptTime() {
+        LocalTime aTime = LocalTime.parse("12:01:00");
+        Boolean result = queryExecutor.executeAndExtractJsonPath("{ schedule(time:\""+aTime.format(DateTimeFormatter.ISO_LOCAL_TIME)+"\") }", "data.schedule");
+        assertThat(result).isTrue();
+    }
+}

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -197,7 +197,8 @@ open class DgsAutoConfiguration(
             dataFetcherExceptionHandler = dataFetcherExceptionHandler,
             entityFetcherRegistry = entityFetcherRegistry,
             defaultDataFetcherFactory = defaultDataFetcherFactory,
-            methodDataFetcherFactory = methodDataFetcherFactory
+            methodDataFetcherFactory = methodDataFetcherFactory,
+            schemaWiringValidationEnabled = configProps.schemaWiringValidationEnabled
         )
     }
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -28,7 +28,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 data class DgsConfigurationProperties(
     /** Location of the GraphQL schema files. */
     @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>,
-    @DefaultValue("true") val schemaWiringValidationEnabled: Boolean,
+    @DefaultValue("true") val schemaWiringValidationEnabled: Boolean
 ) {
     companion object {
         const val PREFIX: String = "dgs.graphql"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -27,8 +27,8 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 @Suppress("ConfigurationProperties")
 data class DgsConfigurationProperties(
     /** Location of the GraphQL schema files. */
-    @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>
-
+    @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>,
+    @DefaultValue("true") val schemaWiringValidationEnabled: Boolean,
 ) {
     companion object {
         const val PREFIX: String = "dgs.graphql"

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DataFetcherInputArgumentSchemaMismatchException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DataFetcherInputArgumentSchemaMismatchException.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.exceptions
+
+class DataFetcherInputArgumentSchemaMismatchException(message: String) : RuntimeException(message)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DataFetcherSchemaMismatchException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DataFetcherSchemaMismatchException.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.exceptions
+
+class DataFetcherSchemaMismatchException(message: String) : RuntimeException(message)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -85,7 +85,7 @@ class DgsSchemaProvider(
     private val defaultDataFetcherFactory: Optional<DataFetcherFactory<*>> = Optional.empty(),
     private val methodDataFetcherFactory: MethodDataFetcherFactory,
     private val componentFilter: ((Any) -> Boolean)? = null,
-    private val schemaWiringValidationEnabled: Boolean = true,
+    private val schemaWiringValidationEnabled: Boolean = true
 ) {
 
     private val schemaReadWriteLock = ReentrantReadWriteLock()

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -401,7 +401,7 @@ class DgsSchemaProvider(
                 .firstOrNull()
             ?: throw DataFetcherSchemaMismatchException(
                 "@DgsData in $methodClassName on field $field references " +
-                    "object type $parentType it has no field named $field. All data fetchers registered with @DgsData " +
+                    "object type `$parentType` it has no field named `$field`. All data fetchers registered with @DgsData " +
                     "must match a field in the schema."
             )
     }
@@ -418,8 +418,8 @@ class DgsSchemaProvider(
                 .flatMap { it.fieldDefinitions.filter { f -> f.name == field } }
                 .firstOrNull()
             ?: throw DataFetcherSchemaMismatchException(
-                "@DgsData in $methodClassName on field $field references " +
-                    "interface $parentType it has no field named $field. All data fetchers registered with @DgsData " +
+                "@DgsData in $methodClassName on field `$field` references " +
+                    "interface `$parentType` it has no field named `$field`. All data fetchers registered with @DgsData " +
                     "must match a field in the schema."
             )
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -429,7 +429,7 @@ class DgsSchemaProvider(
             )
     }
 
-    fun checkInputArgumentsAreValid(method: Method, argumentNames: Set<String>) {
+    private fun checkInputArgumentsAreValid(method: Method, argumentNames: Set<String>) {
         val bridgedMethod: Method = BridgeMethodResolver.findBridgedMethod(method)
         val methodParameters: List<MethodParameter> = bridgedMethod.parameters.map { parameter ->
             val methodParameter = SynthesizingMethodParameter.forParameter(parameter)

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -406,8 +406,8 @@ class DgsSchemaProvider(
                 .firstOrNull()
             ?: throw DataFetcherSchemaMismatchException(
                 "@DgsData in $methodClassName on field $field references " +
-                    "object type `$parentType` it has no field named `$field`. All data fetchers registered with @DgsData " +
-                    "must match a field in the schema."
+                    "object type `$parentType` it has no field named `$field`. All data fetchers registered with " +
+                    "@DgsData|@DgsQuery|@DgsMutation|@DgsSubscription must match a field in the schema."
             )
     }
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -362,8 +362,10 @@ class DgsSchemaProvider(
                     )
                 }
                 else -> {
-                    throw InvalidDgsConfigurationException("Parent type $parentType referenced on ${javaClass.name} in " +
-                        "@DgsData annotation for field $field must be either an interface, a union, or an object.")
+                    throw InvalidDgsConfigurationException(
+                        "Parent type $parentType referenced on ${javaClass.name} in " +
+                            "@DgsData annotation for field $field must be either an interface, a union, or an object."
+                    )
                 }
             }
         } catch (ex: Exception) {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/AbstractInputArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/AbstractInputArgumentResolver.kt
@@ -57,7 +57,7 @@ abstract class AbstractInputArgumentResolver(inputObjectMapper: InputObjectMappe
         return convertedValue
     }
 
-    protected abstract fun resolveArgumentName(parameter: MethodParameter): String?
+    internal abstract fun resolveArgumentName(parameter: MethodParameter): String?
 
     private fun getArgumentName(parameter: MethodParameter): String? {
         val cachedName = argumentNameCache[parameter]

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/ArgumentResolverComposite.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/ArgumentResolverComposite.kt
@@ -39,7 +39,7 @@ class ArgumentResolverComposite(private val argumentResolvers: List<ArgumentReso
         return resolver.resolveArgument(parameter, dfe)
     }
 
-    private fun getArgumentResolver(parameter: MethodParameter): ArgumentResolver? {
+    internal fun getArgumentResolver(parameter: MethodParameter): ArgumentResolver? {
         val cachedResolver = this.argumentResolverCache[parameter]
         if (cachedResolver != null) {
             return cachedResolver

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/InputArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/InputArgumentResolver.kt
@@ -34,7 +34,7 @@ class InputArgumentResolver(
         return parameter.hasParameterAnnotation(InputArgument::class.java)
     }
 
-    override fun resolveArgumentName(parameter: MethodParameter): String? {
+    override fun resolveArgumentName(parameter: MethodParameter): String {
         val annotation = parameter.getParameterAnnotation(InputArgument::class.java)
             ?: throw IllegalArgumentException("Unsupported parameter type [${parameter.parameterType.name}]. supportsParameter should be called first.")
 

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/MethodDataFetcherFactory.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/MethodDataFetcherFactory.kt
@@ -17,10 +17,15 @@
 package com.netflix.graphql.dgs.internal.method
 
 import com.netflix.graphql.dgs.DgsData
+import com.netflix.graphql.dgs.InputArgument
+import com.netflix.graphql.dgs.exceptions.DataFetcherInputArgumentSchemaMismatchException
 import com.netflix.graphql.dgs.internal.DataFetcherInvoker
 import graphql.schema.DataFetcher
+import org.springframework.core.BridgeMethodResolver
 import org.springframework.core.DefaultParameterNameDiscoverer
+import org.springframework.core.MethodParameter
 import org.springframework.core.ParameterNameDiscoverer
+import org.springframework.core.annotation.SynthesizingMethodParameter
 import java.lang.reflect.Method
 
 /**
@@ -29,11 +34,40 @@ import java.lang.reflect.Method
  * Resolving of method arguments is handled by the supplied [argument resolvers][ArgumentResolver].
  */
 class MethodDataFetcherFactory(
-    argumentResolvers: List<ArgumentResolver>,
+    private val argumentResolvers: List<ArgumentResolver>,
     private val parameterNameDiscoverer: ParameterNameDiscoverer = DefaultParameterNameDiscoverer()
 ) {
 
     private val resolvers = ArgumentResolverComposite(argumentResolvers)
+
+    fun checkInputArgumentsAreValid(method: Method, argumentNames: Set<String>) {
+        val inputArgumentResolvers = argumentResolvers.filterIsInstance<AbstractInputArgumentResolver>()
+        if (inputArgumentResolvers.isEmpty()) return
+
+        val bridgedMethod: Method = BridgeMethodResolver.findBridgedMethod(method)
+        val methodParameters: List<MethodParameter> = bridgedMethod.parameters.map { parameter ->
+            val methodParameter = SynthesizingMethodParameter.forParameter(parameter)
+            methodParameter.initParameterNameDiscovery(parameterNameDiscoverer)
+            methodParameter
+        }
+        val annotatedMethodParams = methodParameters.filter { it.hasParameterAnnotation(InputArgument::class.java) }
+        annotatedMethodParams.forEach { m ->
+            val paramName = m.parameterName ?: return@forEach
+            val possibleParamNames = inputArgumentResolvers.map { it.resolveArgumentName(m) }.toSet()
+            if (possibleParamNames.none { argumentNames.contains(it) }) {
+                val arguments = if (argumentNames.isNotEmpty()) {
+                    "Found the following argument(s) in the schema: " + argumentNames.joinToString(prefix = "[", postfix = "]")
+                } else {
+                    "No arguments on the field are defined in the schema."
+                }
+                throw DataFetcherInputArgumentSchemaMismatchException(
+                    "@InputArgument is defined in ${method.declaringClass} in method `${method.name}` on parameter named `$paramName` but there is " +
+                        "no matching argument in the GraphQL schema that matches the possible names: ${possibleParamNames.joinToString(prefix = "[", postfix = "]")}. " +
+                        arguments
+                )
+            }
+        }
+    }
 
     fun createDataFetcher(bean: Any, method: Method): DataFetcher<Any?> {
         return DataFetcherInvoker(

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/MethodDataFetcherFactory.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/MethodDataFetcherFactory.kt
@@ -17,14 +17,11 @@
 package com.netflix.graphql.dgs.internal.method
 
 import com.netflix.graphql.dgs.DgsData
-import com.netflix.graphql.dgs.exceptions.DataFetcherInputArgumentSchemaMismatchException
 import com.netflix.graphql.dgs.internal.DataFetcherInvoker
 import graphql.schema.DataFetcher
-import org.springframework.core.BridgeMethodResolver
 import org.springframework.core.DefaultParameterNameDiscoverer
 import org.springframework.core.MethodParameter
 import org.springframework.core.ParameterNameDiscoverer
-import org.springframework.core.annotation.SynthesizingMethodParameter
 import java.lang.reflect.Method
 
 /**

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CustomDirectivesTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/CustomDirectivesTest.kt
@@ -141,6 +141,7 @@ class CustomDirectivesTest {
                 """
                 type Query {
                     hello: String
+                    word: String
                 }
                 """.trimIndent()
             )

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -642,7 +642,7 @@ internal class DgsSchemaProviderTest {
             }
         }
 
-        contextRunner.withBeans(HelloFetcher::class, TitleFetcher::class).run { context ->
+        contextRunner.withBeans(TitleFetcher::class).run { context ->
             val schemaProvider = schemaProvider(applicationContext = context)
             schemaProvider.schema(schema)
             assertThat(schemaProvider.isFieldInstrumentationEnabled("Video.title")).isTrue

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs
 
+import com.netflix.graphql.dgs.exceptions.DataFetcherSchemaMismatchException
 import com.netflix.graphql.dgs.exceptions.InvalidDgsConfigurationException
 import com.netflix.graphql.dgs.exceptions.InvalidTypeResolverException
 import com.netflix.graphql.dgs.exceptions.NoSchemaFoundException
@@ -887,6 +888,99 @@ internal class DgsSchemaProviderTest {
             ).schema()
             val build = GraphQL.newGraphQL(schema).build()
             assertHello(build)
+        }
+    }
+
+    @Test
+    fun `@DgsData annotation not matching any field on the schema should fail`() {
+        @DgsComponent
+        class Fetcher {
+            @DgsData(parentType = "Query")
+            fun hell(): String {
+                return "Hello"
+            }
+        }
+
+        contextRunner.withBeans(Fetcher::class).run { context ->
+            val schemaProvider = schemaProvider(applicationContext = context)
+            assertThrows<DataFetcherSchemaMismatchException> {
+                schemaProvider.schema()
+            }
+        }
+    }
+
+    @Test
+    fun `@DgsData annotation not matching a field on extension should not fail`() {
+        @DgsComponent
+        class Fetcher {
+            @DgsData(parentType = "Query")
+            fun world(): String {
+                return "World"
+            }
+        }
+
+        contextRunner.withBeans(Fetcher::class).run { context ->
+            val schemaProvider = schemaProvider(applicationContext = context)
+            val schema = schemaProvider.schema()
+            val build = GraphQL.newGraphQL(schema).build()
+            val executionResult = build.execute("{world}")
+            assertTrue(executionResult.isDataPresent)
+            val data = executionResult.getData<Map<String, *>>()
+            assertEquals("World", data["world"])
+        }
+    }
+
+    @Test
+    fun `@DgsData annotation not matching any field on the schema should fail - interface`() {
+        @DgsComponent
+        class Fetcher {
+            @DgsData(parentType = "Character")
+            fun nam(): String {
+                return "Hello"
+            }
+        }
+
+        contextRunner.withBeans(Fetcher::class).run { context ->
+            val schemaProvider = schemaProvider(applicationContext = context)
+            assertThrows<DataFetcherSchemaMismatchException> {
+                schemaProvider.schema()
+            }
+        }
+    }
+
+    @Test
+    fun `@DgsData annotation not matching a field on extension should not fail - interface`() {
+        @DgsComponent
+        class Fetcher {
+            @DgsData(parentType = "Character")
+            fun age(): Int {
+                return 42
+            }
+
+            @DgsData(parentType = "Query")
+            fun character(): Map<String, Any> {
+                return mapOf()
+            }
+        }
+
+        @DgsComponent
+        class FetcherWithDefaultResolver {
+            @DgsTypeResolver(name = "Character")
+            @DgsDefaultTypeResolver
+            fun resolveType(@Suppress("unused_parameter") type: Any): String {
+                return "Human"
+            }
+        }
+
+        contextRunner.withBeans(Fetcher::class, FetcherWithDefaultResolver::class).run { context ->
+            val schemaProvider = schemaProvider(applicationContext = context)
+            val schema = schemaProvider.schema()
+            val build = GraphQL.newGraphQL(schema).build()
+            val executionResult = build.execute("{character { age }}")
+            assertTrue(executionResult.isDataPresent)
+            val data = executionResult.getData<Map<String, *>>()
+            assertNotNull(data["character"])
+            assertEquals(42, (data["character"] as Map<*, *>)["age"])
         }
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -201,47 +201,6 @@ internal class InputArgumentTest {
     }
 
     @Test
-    fun `when no @InputArgument fallback to method param name to match argument on schema`() {
-        @DgsComponent
-        class Fetcher {
-            @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(name: String?): String {
-                return "Hello, ${name ?: "no name"}"
-            }
-        }
-
-        contextRunner.withBeans(Fetcher::class).run { context ->
-            val provider = schemaProvider(context)
-            val schema = provider.schema()
-            val build = GraphQL.newGraphQL(schema).build()
-            val executionResult = build.execute("""{hello(name: "tester")}""")
-            assertThat(executionResult.errors).isEmpty()
-            assertThat(executionResult.isDataPresent).isTrue
-            val data = executionResult.getData<Map<String, *>>()
-            assertThat(data).containsEntry("hello", "Hello, tester")
-        }
-    }
-
-    @Test
-    fun `no @InputArgument and method param name does not match an argument on schema, it should fail`() {
-        @DgsComponent
-        class Fetcher {
-            @DgsData(parentType = "Query", field = "hello")
-            fun someFetcher(abc: String?): String {
-                fail("should not have been called")
-            }
-        }
-
-        contextRunner.withBeans(Fetcher::class).run { context ->
-            val provider = schemaProvider(context)
-            val exc = assertThrows<DataFetcherInputArgumentSchemaMismatchException> {
-                provider.schema()
-            }
-            assertThat(exc).message().contains("has no matching argument with name `abc` in the GraphQL schema.")
-        }
-    }
-
-    @Test
     fun `Inferred input argument, on String type`() {
         @DgsComponent
         class Fetcher {

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -149,8 +149,10 @@ internal class InputArgumentTest {
             val exc = assertThrows<DataFetcherInputArgumentSchemaMismatchException> {
                 provider.schema()
             }
-            assertThat(exc).message().contains("on parameter named `abc` has no matching argument with name `abc` in the GraphQL schema. " +
-                "Found the following argument(s) in the schema: [name]")
+            assertThat(exc).message().contains(
+                "on parameter named `abc` has no matching argument with name `abc` in the GraphQL schema. " +
+                    "Found the following argument(s) in the schema: [name]"
+            )
         }
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -57,7 +57,6 @@ import org.assertj.core.api.InstanceOfAssertFactories
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.fail
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.ApplicationContext
 import org.springframework.core.convert.ConversionFailedException

--- a/graphql-dgs/src/test/resources/schema/schema1.graphqls
+++ b/graphql-dgs/src/test/resources/schema/schema1.graphqls
@@ -1,3 +1,28 @@
 type Query {
     hello(name:String): String
+    character: Character
 }
+
+interface Character {
+    name: String
+}
+
+extend interface Character {
+    age: Int
+}
+
+type Droid implements Character {
+    name: String
+    age: Int
+}
+
+type Human implements Character {
+    name: String
+    age: Int
+}
+
+extend type Query {
+    world(name: String): String
+}
+
+


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

### Current issues:

1.  When performing a refactor of data fetcher related classes, it's possible there can be data fetchers annotated with `@DgsData` that become orphan where there is no matching field on the schema that is wired to it. I can't think of any use case where this is not a developer error. Currently the framework will not fail (only log at warn level) when a request is processed. This is too late in the development workflow and can be easily missed by service owners.
2.  Similarly, data fetcher parameters annotated with `@InputArgument` can be missed if the annotation name value or method parameter name doesn't match any argument of the corresponding field on the schema.

### Proposed solution:

Add some validation at schema build time in the `SchemaProvider` to prevent the DGS from starting if there are obvious orphan parameters or data fetchers.

**Note**: It is currently possible to wire a data fetcher on a field of every possible type of a union through the current wiring logic. However it is not guaranteed that every member type will have the requested field. In case of unions, I chose to not perform any validation as a subset of the types could have the field while others would not.

### Alternatives considered

We could keep the status quo, as in, we would not perform any ahead-of-time validation and only log are a higher level. This does not come with the benefit of failing fast when building the schema vs at runtime when executing requests.

