### PR TITLE
Add nullability annotations to DgsQueryExecutor

### DIFF
--- a/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
+++ b/graphql-dgs-reactive/src/main/kotlin/com/netflix/graphql/dgs/reactive/internal/DefaultDgsReactiveQueryExecutor.kt
@@ -61,8 +61,8 @@ class DefaultDgsReactiveQueryExecutor(
 
     override fun execute(
         query: String?,
-        variables: MutableMap<String, Any>?,
-        extensions: MutableMap<String, Any>?,
+        variables: Map<String, Any>?,
+        extensions: Map<String, Any>?,
         headers: HttpHeaders?,
         operationName: String?,
         serverHttpRequest: ServerRequest?
@@ -106,7 +106,7 @@ class DefaultDgsReactiveQueryExecutor(
     override fun <T : Any> executeAndExtractJsonPath(
         query: String,
         jsonPath: String,
-        variables: MutableMap<String, Any>?,
+        variables: Map<String, Any>?,
         serverRequest: ServerRequest?
     ): Mono<T> {
         return getJsonResult(query, variables, serverRequest).map { JsonPath.read(it, jsonPath) }
@@ -114,7 +114,7 @@ class DefaultDgsReactiveQueryExecutor(
 
     override fun executeAndGetDocumentContext(
         query: String,
-        variables: MutableMap<String, Any>
+        variables: Map<String, Any>
     ): Mono<DocumentContext> {
         return getJsonResult(query, variables, null).map(BaseDgsQueryExecutor.parseContext::parse)
     }
@@ -122,7 +122,7 @@ class DefaultDgsReactiveQueryExecutor(
     override fun <T : Any?> executeAndExtractJsonPathAsObject(
         query: String,
         jsonPath: String,
-        variables: MutableMap<String, Any>,
+        variables: Map<String, Any>,
         clazz: Class<T>
     ): Mono<T> {
         return getJsonResult(query, variables, null)
@@ -139,7 +139,7 @@ class DefaultDgsReactiveQueryExecutor(
     override fun <T : Any?> executeAndExtractJsonPathAsObject(
         query: String,
         jsonPath: String,
-        variables: MutableMap<String, Any>,
+        variables: Map<String, Any>,
         typeRef: TypeRef<T>
     ): Mono<T> {
         return getJsonResult(query, variables, null)
@@ -153,7 +153,7 @@ class DefaultDgsReactiveQueryExecutor(
             }
     }
 
-    private fun getJsonResult(query: String, variables: MutableMap<String, Any>?, serverRequest: ServerRequest?): Mono<String> {
+    private fun getJsonResult(query: String, variables: Map<String, Any>?, serverRequest: ServerRequest?): Mono<String> {
         val httpHeaders = serverRequest?.headers()?.asHttpHeaders()
         return execute(query, variables, null, httpHeaders, null, serverRequest).map { executionResult ->
             if (executionResult.errors.size > 0) {

--- a/graphql-dgs-subscriptions-graphql-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/graphql/sse/DgsGraphQLSSESubscriptionHandler.kt
+++ b/graphql-dgs-subscriptions-graphql-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/graphql/sse/DgsGraphQLSSESubscriptionHandler.kt
@@ -79,7 +79,7 @@ open class DgsGraphQLSSESubscriptionHandler(
             throw ServerWebInputException("Invalid query. operation type is not a subscription")
         }
 
-        val executionResult: ExecutionResult = dgsQueryExecutor.execute(queryPayload.query, queryPayload.variables)
+        val executionResult: ExecutionResult = dgsQueryExecutor.execute(queryPayload.query, queryPayload.variables.orEmpty())
         if (executionResult.errors.isNotEmpty()) {
             val errorMessage =
                 if (executionResult.errors.any { error -> error is ValidationError || error is InvalidSyntaxError }) {

--- a/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
+++ b/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
@@ -79,7 +79,7 @@ open class DgsSSESubscriptionHandler(open val dgsQueryExecutor: DgsQueryExecutor
             throw ServerWebInputException("Invalid query. operation type is not a subscription")
         }
 
-        val executionResult: ExecutionResult = dgsQueryExecutor.execute(queryPayload.query, queryPayload.variables)
+        val executionResult: ExecutionResult = dgsQueryExecutor.execute(queryPayload.query, queryPayload.variables.orEmpty())
         if (executionResult.errors.isNotEmpty()) {
             val errorMessage = if (executionResult.errors.any { error -> error is ValidationError || error is InvalidSyntaxError }) {
                 "Subscription query failed to validate: ${executionResult.errors.joinToString()}"

--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLTransportWSProtocolHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLTransportWSProtocolHandler.kt
@@ -26,6 +26,7 @@ import jakarta.annotation.PostConstruct
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
 import org.springframework.web.socket.CloseStatus
@@ -155,7 +156,7 @@ class WebsocketGraphQLTransportWSProtocolHandler(private val dgsQueryExecutor: D
         val executionResult: ExecutionResult =
             dgsQueryExecutor.execute(
                 payload.query,
-                payload.variables,
+                payload.variables.orEmpty(),
                 payload.extensions,
                 null,
                 payload.operationName,
@@ -221,7 +222,7 @@ class WebsocketGraphQLTransportWSProtocolHandler(private val dgsQueryExecutor: D
     }
 
     private companion object {
-        val logger = LoggerFactory.getLogger(WebsocketGraphQLTransportWSProtocolHandler::class.java)
+        val logger: Logger = LoggerFactory.getLogger(WebsocketGraphQLTransportWSProtocolHandler::class.java)
         val objectMapper = jacksonObjectMapper()
     }
 }

--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandler.kt
@@ -75,7 +75,7 @@ class WebsocketGraphQLWSProtocolHandler(private val dgsQueryExecutor: DgsQueryEx
                 subscriptions[session.id]?.remove(id)
             }
             GQL_CONNECTION_TERMINATE -> {
-                logger.info("Terminated session " + session.id)
+                logger.info("Terminated session {}", session.id)
                 cleanupSubscriptionsForSession(session)
                 session.close()
             }
@@ -91,7 +91,7 @@ class WebsocketGraphQLWSProtocolHandler(private val dgsQueryExecutor: DgsQueryEx
     }
 
     private fun handleSubscription(id: String, payload: QueryPayload, session: WebSocketSession) {
-        val executionResult: ExecutionResult = dgsQueryExecutor.execute(payload.query, payload.variables)
+        val executionResult: ExecutionResult = dgsQueryExecutor.execute(payload.query, payload.variables.orEmpty())
         val subscriptionStream: Publisher<ExecutionResult> = executionResult.getData()
 
         subscriptionStream.subscribe(object : Subscriber<ExecutionResult> {

--- a/graphql-dgs-subscriptions-websockets/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandlerTest.kt
+++ b/graphql-dgs-subscriptions-websockets/src/test/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLWSProtocolHandlerTest.kt
@@ -54,6 +54,7 @@ import reactor.core.publisher.Mono
 @ExtendWith(MockKExtension::class)
 class WebsocketGraphQLWSProtocolHandlerTest {
 
+    private val objectMapper = jacksonObjectMapper()
     private lateinit var dgsWebsocketHandler: WebsocketGraphQLWSProtocolHandler
 
     @BeforeEach
@@ -228,7 +229,7 @@ class WebsocketGraphQLWSProtocolHandlerTest {
 
         assertThat(dgsWebsocketHandler.sessions.size).isEqualTo(currentNrOfSessions + 1)
 
-        val returnMessage = jacksonObjectMapper().readValue<OperationMessage>(slot.captured.asBytes())
+        val returnMessage = objectMapper.readValue<OperationMessage>(slot.captured.asBytes())
         assertThat(returnMessage.type).isEqualTo(GQL_CONNECTION_ACK)
     }
 
@@ -297,7 +298,7 @@ class WebsocketGraphQLWSProtocolHandlerTest {
 
         every { executionResult.getData<Publisher<ExecutionResult>>() } returns Mono.just(results).flatMapMany { Flux.fromIterable(results) }
 
-        every { dgsQueryExecutor.execute("query HELLO(\$name: String){ hello(name:\$name) }", null) } returns executionResult
+        every { dgsQueryExecutor.execute("query HELLO(\$name: String){ hello(name:\$name) }", emptyMap()) } returns executionResult
 
         dgsWebsocketHandler.handleTextMessage(webSocketSession, queryMessageWithNullVariable)
     }
@@ -312,7 +313,7 @@ class WebsocketGraphQLWSProtocolHandlerTest {
 
         dgsWebsocketHandler.handleTextMessage(webSocketSession, queryMessage)
 
-        val returnMessage = jacksonObjectMapper().readValue<OperationMessage>(slot.captured.asBytes())
+        val returnMessage = objectMapper.readValue<OperationMessage>(slot.captured.asBytes())
         assertThat(returnMessage.type).isEqualTo(GQL_ERROR)
         assertThat((returnMessage.payload as DataPayload).errors?.size).isEqualTo(1)
         assertThat((returnMessage.payload as DataPayload).errors?.get(0)).isEqualTo("That's wrong!")
@@ -334,7 +335,7 @@ class WebsocketGraphQLWSProtocolHandlerTest {
 
         dgsWebsocketHandler.handleTextMessage(webSocketSession, queryMessage)
 
-        val returnMessage = jacksonObjectMapper().readValue<OperationMessage>(slotList[0].asBytes())
+        val returnMessage = objectMapper.readValue<OperationMessage>(slotList[0].asBytes())
         assertThat(returnMessage.type).isEqualTo(GQL_DATA)
 
         val payload = returnMessage.payload as DataPayload

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsQueryExecutor.java
@@ -21,6 +21,8 @@ import com.jayway.jsonpath.TypeRef;
 import graphql.ExecutionResult;
 import org.intellij.lang.annotations.Language;
 import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 
@@ -42,7 +44,7 @@ public interface DgsQueryExecutor {
      * @param query The query string
      * @return Returns a GraphQL {@link ExecutionResult}. This includes data and errors.
      */
-    default ExecutionResult execute(@Language("GraphQL") String query) {
+    default ExecutionResult execute(@Language("GraphQL") @Nullable String query) {
         return execute(query, Collections.emptyMap(), null, null, null, null);
     }
 
@@ -52,8 +54,8 @@ public interface DgsQueryExecutor {
      * @return Returns a GraphQL {@link ExecutionResult}. This includes data and errors.
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
-    default ExecutionResult execute(@Language("GraphQL") String query,
-                                    Map<String, Object> variables) {
+    default ExecutionResult execute(@Language("GraphQL") @Nullable String query,
+                                    @NonNull Map<String, Object> variables) {
         return execute(query, variables, null, null, null, null);
     }
 
@@ -65,9 +67,9 @@ public interface DgsQueryExecutor {
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      * @see <a href="https://graphql.org/learn/queries/#operation-name">Operation name</a>
      */
-    default ExecutionResult execute(@Language("GraphQL") String query,
-                                    Map<String, Object> variables,
-                                    String operationName) {
+    default ExecutionResult execute(@Language("GraphQL") @Nullable String query,
+                                    @NonNull Map<String, Object> variables,
+                                    @Nullable String operationName) {
         return execute(query, variables, null, null, operationName, null);
     }
 
@@ -80,9 +82,9 @@ public interface DgsQueryExecutor {
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
     default ExecutionResult execute(@Language("GraphQL") String query,
-                                    Map<String, Object> variables,
-                                    Map<String, Object> extensions,
-                                    HttpHeaders headers) {
+                                    @NonNull Map<String, Object> variables,
+                                    @Nullable Map<String, Object> extensions,
+                                    @Nullable HttpHeaders headers) {
         return execute(query, variables, extensions, headers, null, null);
     }
 
@@ -100,11 +102,11 @@ public interface DgsQueryExecutor {
      * @see <a href="https://graphql.org/learn/queries/#operation-name">Operation name</a>
      */
     ExecutionResult execute(@Language("GraphQL") String query,
-                            Map<String, Object> variables,
-                            Map<String, Object> extensions,
-                            HttpHeaders headers,
-                            String operationName,
-                            WebRequest webRequest);
+                            @NonNull Map<String, Object> variables,
+                            @Nullable Map<String, Object> extensions,
+                            @Nullable HttpHeaders headers,
+                            @Nullable String operationName,
+                            @Nullable WebRequest webRequest);
 
     /**
      * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
@@ -116,8 +118,8 @@ public interface DgsQueryExecutor {
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      */
-    default <T> T executeAndExtractJsonPath(@Language("GraphQL") String query,
-                                            @Language("JSONPath") String jsonPath) {
+    default <T> T executeAndExtractJsonPath(@Language("GraphQL") @NonNull String query,
+                                            @Language("JSONPath") @NonNull String jsonPath) {
         return executeAndExtractJsonPath(query, jsonPath, Collections.emptyMap());
     }
 
@@ -137,9 +139,9 @@ public interface DgsQueryExecutor {
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      */
-    <T> T executeAndExtractJsonPath(@Language("GraphQL") String query,
-                                    @Language("JSONPath") String jsonPath,
-                                    Map<String, Object> variables);
+    <T> T executeAndExtractJsonPath(@Language("GraphQL") @NonNull String query,
+                                    @Language("JSONPath") @NonNull String jsonPath,
+                                    @NonNull Map<String, Object> variables);
 
     /**
      * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
@@ -155,9 +157,9 @@ public interface DgsQueryExecutor {
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      */
-    <T> T executeAndExtractJsonPath(@Language("GraphQL") String query,
-                                    @Language("JSONPath") String jsonPath,
-                                    HttpHeaders headers);
+    <T> T executeAndExtractJsonPath(@Language("GraphQL") @NonNull String query,
+                                    @Language("JSONPath") @NonNull String jsonPath,
+                                    @NonNull HttpHeaders headers);
     /**
      * Executes a GraphQL query, parses the returned data, and uses a Json Path to extract specific elements out of the data.
      * The method is generic, and tries to cast the result into the type you specify. This does NOT work on Lists. Use {@link #executeAndExtractJsonPathAsObject(String, String, TypeRef)}instead.
@@ -172,9 +174,9 @@ public interface DgsQueryExecutor {
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      */
-    <T> T executeAndExtractJsonPath(@Language("GraphQL") String query,
-                                    @Language("JSONPath") String jsonPath,
-                                    ServletWebRequest servletWebRequest);
+    <T> T executeAndExtractJsonPath(@Language("GraphQL") @NonNull String query,
+                                    @Language("JSONPath") @NonNull String jsonPath,
+                                    @NonNull ServletWebRequest servletWebRequest);
 
     /**
      * Executes a GraphQL query, parses the returned data, and return a {@link DocumentContext}.
@@ -183,7 +185,7 @@ public interface DgsQueryExecutor {
      * @param query Query string
      * @return {@link DocumentContext} is a JsonPath type used to extract values from.
      */
-    default DocumentContext executeAndGetDocumentContext(@Language("GraphQL") String query) {
+    default DocumentContext executeAndGetDocumentContext(@Language("GraphQL") @NonNull String query) {
         return executeAndGetDocumentContext(query, Collections.emptyMap());
     }
 
@@ -196,7 +198,7 @@ public interface DgsQueryExecutor {
      * @return {@link DocumentContext} is a JsonPath type used to extract values from.
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
-    DocumentContext executeAndGetDocumentContext(@Language("GraphQL") String query, Map<String, Object> variables);
+    DocumentContext executeAndGetDocumentContext(@Language("GraphQL") @NonNull String query, @NonNull Map<String, Object> variables);
 
     /**
      * Executes a GraphQL query, parses the returned data, and return a {@link DocumentContext}.
@@ -208,9 +210,9 @@ public interface DgsQueryExecutor {
      * @return {@link DocumentContext} is a JsonPath type used to extract values from.
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
-    DocumentContext executeAndGetDocumentContext(@Language("GraphQL") String query,
-                                                 Map<String, Object> variables,
-                                                 HttpHeaders headers);
+    DocumentContext executeAndGetDocumentContext(@Language("GraphQL") @NonNull String query,
+                                                 @NonNull Map<String, Object> variables,
+                                                 @Nullable HttpHeaders headers);
 
     /**
      * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
@@ -223,10 +225,10 @@ public interface DgsQueryExecutor {
      * @return The extracted value from the result, converted to type T
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      */
-    default <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") String query,
-                                                    @Language("JSONPath") String jsonPath,
-                                                    Class<T> clazz) {
-        return executeAndExtractJsonPathAsObject(query, jsonPath, Collections.emptyMap(), clazz, null);
+    default <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") @NonNull String query,
+                                                    @Language("JSONPath") @NonNull String jsonPath,
+                                                    @NonNull Class<T> clazz) {
+        return executeAndExtractJsonPathAsObject(query, jsonPath, Collections.emptyMap(), clazz, HttpHeaders.EMPTY);
     }
 
     /**
@@ -242,11 +244,11 @@ public interface DgsQueryExecutor {
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
-    default <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") String query,
-                                                    @Language("JSONPath") String jsonPath,
-                                                    Map<String, Object> variables,
-                                                    Class<T> clazz) {
-        return executeAndExtractJsonPathAsObject(query, jsonPath, variables, clazz, null);
+    default <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") @NonNull String query,
+                                                    @Language("JSONPath") @NonNull String jsonPath,
+                                                    @NonNull Map<String, Object> variables,
+                                                    @NonNull Class<T> clazz) {
+        return executeAndExtractJsonPathAsObject(query, jsonPath, variables, clazz, HttpHeaders.EMPTY);
     }
 
     /**
@@ -263,11 +265,11 @@ public interface DgsQueryExecutor {
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      */
-    <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") String query,
-                                            @Language("JSONPath") String jsonPath,
-                                            Map<String, Object> variables,
-                                            Class<T> clazz,
-                                            HttpHeaders headers);
+    <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") @NonNull String query,
+                                            @Language("JSONPath") @NonNull String jsonPath,
+                                            @NonNull Map<String, Object> variables,
+                                            @NonNull Class<T> clazz,
+                                            @Nullable HttpHeaders headers);
 
     /**
      * Executes a GraphQL query, parses the returned data, extracts a value using JsonPath, and converts that value into the given type.
@@ -282,10 +284,10 @@ public interface DgsQueryExecutor {
      * @see <a href="https://github.com/json-path/JsonPath">JsonPath syntax docs</a>
      * @see <a href="https://github.com/json-path/JsonPath#what-is-returned-when">Using TypeRef</a>
      */
-    default <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") String query,
-                                                    @Language("JSONPath") String jsonPath,
-                                                    TypeRef<T> typeRef) {
-        return executeAndExtractJsonPathAsObject(query, jsonPath, Collections.emptyMap(), typeRef, null);
+    default <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") @NonNull String query,
+                                                    @Language("JSONPath") @NonNull String jsonPath,
+                                                    @NonNull TypeRef<T> typeRef) {
+        return executeAndExtractJsonPathAsObject(query, jsonPath, Collections.emptyMap(), typeRef, HttpHeaders.EMPTY);
     }
 
     /**
@@ -303,11 +305,11 @@ public interface DgsQueryExecutor {
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      * @see <a href="https://github.com/json-path/JsonPath#what-is-returned-when">Using TypeRef</a>
      */
-    default <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") String query,
-                                                    @Language("JSONPath") String jsonPath,
-                                                    Map<String, Object> variables,
-                                                    TypeRef<T> typeRef) {
-        return executeAndExtractJsonPathAsObject(query, jsonPath, variables, typeRef, null);
+    default <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") @NonNull String query,
+                                                    @Language("JSONPath") @NonNull String jsonPath,
+                                                    @NonNull Map<String, Object> variables,
+                                                    @NonNull TypeRef<T> typeRef) {
+        return executeAndExtractJsonPathAsObject(query, jsonPath, variables, typeRef, HttpHeaders.EMPTY);
     }
 
     /**
@@ -326,10 +328,10 @@ public interface DgsQueryExecutor {
      * @see <a href="https://graphql.org/learn/queries/#variables">Query Variables</a>
      * @see <a href="https://github.com/json-path/JsonPath#what-is-returned-when">Using TypeRef</a>
      */
-    <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") String query,
-                                            @Language("JSONPath") String jsonPath,
-                                            Map<String, Object> variables,
-                                            TypeRef<T> typeRef,
-                                            HttpHeaders headers);
+    <T> T executeAndExtractJsonPathAsObject(@Language("GraphQL") @NonNull String query,
+                                            @Language("JSONPath") @NonNull String jsonPath,
+                                            @NonNull Map<String, Object> variables,
+                                            @NonNull TypeRef<T> typeRef,
+                                            @Nullable HttpHeaders headers);
 
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
@@ -31,7 +31,6 @@ import com.netflix.graphql.dgs.context.DgsContext
 import com.netflix.graphql.dgs.exceptions.DgsBadRequestException
 import graphql.ExecutionInput
 import graphql.ExecutionResult
-import graphql.ExecutionResultImpl
 import graphql.GraphQL
 import graphql.GraphQLContext
 import graphql.GraphQLError
@@ -44,7 +43,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.util.StringUtils
-import java.util.*
+import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
 object BaseDgsQueryExecutor {
@@ -78,7 +77,7 @@ object BaseDgsQueryExecutor {
         idProvider: Optional<ExecutionIdProvider>,
         preparsedDocumentProvider: PreparsedDocumentProvider?
     ): CompletableFuture<ExecutionResult> {
-        val inputVariables = variables ?: Collections.emptyMap()
+        val inputVariables = variables ?: emptyMap()
 
         if (!StringUtils.hasText(query)) {
             return CompletableFuture.completedFuture(
@@ -86,15 +85,9 @@ object BaseDgsQueryExecutor {
                     .builder()
                     .status(HttpStatus.BAD_REQUEST)
                     .executionResult(
-                        ExecutionResultImpl
-                            .newExecutionResult()
-                            .errors(
-                                listOf(
-                                    DgsBadRequestException
-                                        .NULL_OR_EMPTY_QUERY_EXCEPTION
-                                        .toGraphQlError()
-                                )
-                            )
+                        ExecutionResult.newExecutionResult()
+                            .addError(DgsBadRequestException.NULL_OR_EMPTY_QUERY_EXCEPTION.toGraphQlError())
+                            .build()
                     ).build()
             )
         }
@@ -126,9 +119,9 @@ object BaseDgsQueryExecutor {
             graphQLContextFuture.complete(executionInput.graphQLContext)
             graphQL.executeAsync(executionInput)
         } catch (e: Exception) {
-            logger.error("Encountered an exception while handling query $query", e)
+            logger.error("Encountered an exception while handling query {}", query, e)
             val errors: List<GraphQLError> = if (e is GraphQLError) listOf<GraphQLError>(e) else emptyList()
-            CompletableFuture.completedFuture(ExecutionResultImpl(null, errors))
+            CompletableFuture.completedFuture(ExecutionResult.newExecutionResult().errors(errors).build())
         }
     }
 }


### PR DESCRIPTION
Add nullability annotations to DgsQueryExecutor, an interface written in Java; note this is mostly to capture the "status quo" based on the method signatures of the default implementation in Kotlin in order to catch potential issues at compile time.
