### PR TITLE
Add workaround for newline handling in MultiSourceReader

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -138,6 +138,9 @@ class DgsSchemaProvider(
                 .trackData(false)
             for (schemaFile in findSchemaFiles(hasDynamicTypeRegistry)) {
                 readerBuilder.reader(schemaFile.inputStream.reader(), schemaFile.filename)
+                // Add a reader that inserts a newline between schema files to avoid issues when
+                // the source files aren't newline-terminated.
+                readerBuilder.reader("\n".reader(), "newline")
             }
             SchemaParser().parse(readerBuilder.build())
         } else {

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -43,14 +43,18 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.io.TempDir
 import org.reactivestreams.Publisher
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.ApplicationContext
 import reactor.core.publisher.Flux
 import reactor.test.StepVerifier
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
+import kotlin.io.path.createTempFile
 import kotlin.reflect.KClass
 import kotlin.reflect.full.hasAnnotation
 
@@ -856,6 +860,21 @@ internal class DgsSchemaProviderTest {
             )
             val build = GraphQL.newGraphQL(schema).build()
             assertSubscription(build)
+        }
+    }
+
+    @Test
+    fun `Schema provider works when a schema file is not terminated by a newline`(@TempDir tempDir: Path) {
+        val path = createTempFile(directory = tempDir, prefix = "foo", suffix = ".graphql")
+        val anotherPath = createTempFile(directory = tempDir, prefix = "bar", suffix = ".graphql")
+
+        Files.writeString(path, """type Foo { name: String }""")
+        Files.writeString(anotherPath, """directive @bar on FIELD_DEFINITION""")
+
+        contextRunner.run { context ->
+            val schema = schemaProvider(context, schemaLocations = listOf("file:$tempDir/*.graphql")).schema()
+            assertThat(schema.getType("Foo")).isNotNull
+            assertThat(schema.getDirective("bar")).isNotNull
         }
     }
 


### PR DESCRIPTION
If one of the schema files being loaded by DgsSchemaProvider ends with a definition such as a directive, and did not have a newline, the MultiSourceReader would concatenate the files in such a way that would cause parsing error.

To avoid that, just add a reader that inserts a newline after each schema file.

