### PR TITLE
 Fix the inference of the data. path in the response

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -114,8 +114,6 @@ data class GraphQLResponse(val json: String, val headers: Map<String, List<Strin
         return extractValueAsObject("gatewayRequestDetails", RequestDetails::class.java)
     }
 
-    private fun getDataPath(path: String) = if (!path.startsWith("data")) "data.$path" else path
-
     fun hasErrors(): Boolean = errors.isNotEmpty()
 
     companion object {
@@ -131,6 +129,10 @@ data class GraphQLResponse(val json: String, val headers: Map<String, List<Strin
             .jsonProvider(JacksonJsonProvider(mapper))
             .mappingProvider(JacksonMappingProvider(mapper)).build()
             .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL)
+
+        fun getDataPath(path: String): String {
+            return if (!path.startsWith("data.")) "data.$path" else path
+        }
     }
 }
 


### PR DESCRIPTION

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

It might be the case that data returned in the data field starts has a suffix that starts with `data`. This will incorrectly cause the GraphQLResponse to infer that it shouldn't add the `data.` suffix which will might cause confusion since the expected behavior is for the `data.` suffix to be inferred.

----

As an alternative we could leave it as is, that said, this will cause unexpected inconsistent behavior that is dependent on the payload of the response. Specifically the name of the field that is being queried.

