### PR TITLE
Improve IntelliJ language detection for the graphql string.

### DIFF
--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
     implementation("com.graphql-java:graphql-java")
 
+    implementation("org.jetbrains:annotations")
+
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework:spring-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/CustomGraphQLClient.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.dgs.client
 
+import org.intellij.lang.annotations.Language
+
 /**
  * Blocking implementation of a GraphQL client.
  * The user is responsible for doing the actual HTTP request, making this pluggable with any HTTP client.
@@ -26,11 +28,18 @@ class CustomGraphQLClient(private val url: String, private val requestExecutor: 
         return executeQuery(query, emptyMap(), null)
     }
 
-    override fun executeQuery(query: String, variables: Map<String, Any>): GraphQLResponse {
+    override fun executeQuery(
+        @Language("graphql") query: String,
+        variables: Map<String, Any>
+    ): GraphQLResponse {
         return executeQuery(query, variables, null)
     }
 
-    override fun executeQuery(query: String, variables: Map<String, Any>, operationName: String?): GraphQLResponse {
+    override fun executeQuery(
+        @Language("graphql") query: String,
+        variables: Map<String, Any>,
+        operationName: String?
+    ): GraphQLResponse {
         val serializedRequest = GraphQLClients.objectMapper.writeValueAsString(
             Request(
                 query,


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

IntelliJ supports language detection for String templates via the `@Language` annotation. This will allow the IDE to _color_ the elements of the template as if they were a GraphQL Query.
