### PR TITLE
Fix breakage when extracting "data" as the path in GraphQLResponse

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -131,7 +131,11 @@ data class GraphQLResponse(val json: String, val headers: Map<String, List<Strin
             .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL)
 
         fun getDataPath(path: String): String {
-            return if (!path.startsWith("data.")) "data.$path" else path
+            return if (path == "data" || path.startsWith("data.")) {
+                path
+            } else {
+                "data.$path"
+            }
         }
     }
 }


### PR DESCRIPTION
Recently a change was made in b386856c8 that broke support for extracting the value from the response using the path "data". While users could simply use the "dataAsObject" method, there are many instances where users call extractValue with "data" as the path. Restore support for this, and add unit tests.
