### PR TITLE
Return NoOp InstrumentationContext where possible

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMicrometerAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMicrometerAutoConfiguration.kt
@@ -20,7 +20,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.util.*
+import java.util.Optional
 
 /**
  * [Auto-configuration][org.springframework.boot.autoconfigure.EnableAutoConfiguration] for instrumentation of Spring GraphQL
@@ -173,7 +173,7 @@ open class DgsGraphQLMicrometerAutoConfiguration {
             private val DEFAULT_METER_REGISTRY = SimpleMeterRegistry()
         }
 
-        private val registry: MeterRegistry by lazy {
+        private val registry: MeterRegistry by lazy(LazyThreadSafetyMode.PUBLICATION) {
             meterRegistryProvider.ifAvailable ?: DEFAULT_METER_REGISTRY
         }
 


### PR DESCRIPTION
Change beginValidation to simply return the No-op InstrumentationContext if no document or QuerySignatureRepository are present. Additionally, only allocate tags in instrumentExecutionResult if there are actually errors, and avoid calling the get method on the registry supplier repeatedly.

Finally, update DefaultMeterRegistrySupplier to avoid locking when calling the get method.
