### PR TITLE
Map unknown fields to additionalInformation in GraphQLErrorDebugInfo …

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLError.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLError.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.dgs.client
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -42,10 +44,11 @@ data class GraphQLErrorExtensions(
     @JsonProperty val classification: String = ""
 )
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class GraphQLErrorDebugInfo(
     @JsonProperty val subquery: String = "",
-    @JsonProperty val variables: Map<String, Any> = emptyMap()
+    @JsonProperty val variables: Map<String, Any> = emptyMap(),
+    @JsonAnySetter @get:JsonAnyGetter
+    val additionalInformation: Map<String, Any> = hashMapOf()
 )
 
 /**


### PR DESCRIPTION
…(#1600)

Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Captures unmapped/unknown key-values in the error.extensions.debugInfo as addtionalInformation field instead of ignoring them during deserialization.

Issue #1600
Discussion: https://github.com/Netflix/dgs-framework/discussions/1599

Alternatives considered
----

_Describe alternative implementation you have considered_

