### PR TITLE
Replace usages of io.micrometer.core.instrument.Tags with Iterable<Tag>

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
@@ -18,7 +18,6 @@ package com.netflix.graphql.dgs.metrics
 
 import com.netflix.graphql.dgs.Internal
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 
 object DgsMetrics {
 
@@ -104,9 +103,8 @@ object DgsMetrics {
          */
         SUCCESS(GqlTag.OUTCOME.key, "success") {
             /** Returns the success [tag] along with the [JAVA_CLASS] of the value.*/
-            override fun <T : Any> tags(v: T): Tags {
-                return Tags.of(tag)
-                    .and(JAVA_CLASS.tags(v))
+            override fun <T : Any> tags(v: T): Iterable<Tag> {
+                return listOf(tag).plus(JAVA_CLASS.tags(v))
             }
         },
 
@@ -115,16 +113,15 @@ object DgsMetrics {
          */
         FAILURE(GqlTag.OUTCOME.key, "failure") {
             /** Returns failure [tag] along with the [JAVA_CLASS] of the value.*/
-            override fun <T : Any> tags(v: T): Tags {
-                return Tags.of(tag)
-                    .and(JAVA_CLASS.tags(v))
+            override fun <T : Any> tags(v: T): Iterable<Tag> {
+                return listOf(tag).plus(JAVA_CLASS.tags(v))
             }
         },
 
         /** Tag that reflects the class associated with the metric. */
         JAVA_CLASS("class", "unknown") {
-            override fun <T : Any> tags(v: T): Tags {
-                return Tags.of(key, v::class.java.name)
+            override fun <T : Any> tags(v: T): Iterable<Tag> {
+                return listOf(Tag.of(key, v::class.java.name))
             }
         },
 
@@ -133,13 +130,13 @@ object DgsMetrics {
          *The metric with this tag will normally be accompanied by the [JAVA_CLASS] tag as well.
          */
         JAVA_CLASS_METHOD("method", "unknown") {
-            override fun <T : Any> tags(v: T): Tags {
-                return Tags.of(key, "$v")
+            override fun <T : Any> tags(v: T): Iterable<Tag> {
+                return listOf(Tag.of(key, "$v"))
             }
         };
 
         val tag: Tag = Tag.of(key, defaultValue)
 
-        abstract fun <T : Any> tags(v: T): Tags
+        abstract fun <T : Any> tags(v: T): Iterable<Tag>
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLCollatedMetricsTagsProvider.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLCollatedMetricsTagsProvider.kt
@@ -24,7 +24,6 @@ import graphql.ExecutionResult
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 import java.util.*
 
 class DgsGraphQLCollatedMetricsTagsProvider(
@@ -34,7 +33,7 @@ class DgsGraphQLCollatedMetricsTagsProvider(
 ) : DgsGraphQLMetricsTagsProvider {
 
     override fun getContextualTags(): Iterable<Tag> {
-        return Tags.of(contextualTagCustomizer.flatMap { it.getContextualTags() })
+        return contextualTagCustomizer.flatMap { it.getContextualTags() }
     }
 
     override fun getExecutionTags(
@@ -43,7 +42,7 @@ class DgsGraphQLCollatedMetricsTagsProvider(
         result: ExecutionResult,
         exception: Throwable?
     ): Iterable<Tag> {
-        return Tags.of(executionTagCustomizer.flatMap { it.getExecutionTags(state, parameters, result, exception) })
+        return executionTagCustomizer.flatMap { it.getExecutionTags(state, parameters, result, exception) }
     }
 
     override fun getFieldFetchTags(
@@ -51,6 +50,6 @@ class DgsGraphQLCollatedMetricsTagsProvider(
         parameters: InstrumentationFieldFetchParameters,
         exception: Throwable?
     ): Iterable<Tag> {
-        return Tags.of(fieldFetchTagCustomizer.flatMap { it.getFieldFetchTags(state, parameters, exception) })
+        return fieldFetchTagCustomizer.flatMap { it.getFieldFetchTags(state, parameters, exception) }
     }
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/LimitedTagMetricResolver.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/LimitedTagMetricResolver.kt
@@ -18,14 +18,13 @@ package com.netflix.graphql.dgs.metrics.micrometer
 
 import com.netflix.graphql.dgs.Internal
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 import java.util.*
 
 @Internal
 interface LimitedTagMetricResolver {
 
-    fun tags(key: String, value: String): Tags {
-        return tag(key, value).map { Tags.of(it) }.orElse(Tags.empty())
+    fun tags(key: String, value: String): Iterable<Tag> {
+        return tag(key, value).map { listOf(it) }.orElse(emptyList())
     }
 
     fun tag(key: String, value: String): Optional<Tag>

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderInterceptor.kt
@@ -4,7 +4,6 @@ import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlMetric
 import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlTag
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 import io.micrometer.core.instrument.Timer
 import net.bytebuddy.implementation.bind.annotation.Pipe
 import org.dataloader.BatchLoader
@@ -26,7 +25,7 @@ internal class BatchLoaderInterceptor(
                 timerSampler.stop(
                     Timer.builder(ID)
                         .tags(
-                            Tags.of(
+                            listOf(
                                 Tag.of(GqlTag.LOADER_NAME.key, name),
                                 Tag.of(GqlTag.LOADER_BATCH_SIZE.key, result.size.toString())
                             )

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderWithContextInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/BatchLoaderWithContextInterceptor.kt
@@ -4,7 +4,6 @@ import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlMetric
 import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlTag
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 import io.micrometer.core.instrument.Timer
 import net.bytebuddy.implementation.bind.annotation.Pipe
 import org.dataloader.BatchLoaderWithContext
@@ -26,7 +25,7 @@ internal class BatchLoaderWithContextInterceptor(
                 timerSampler.stop(
                     Timer.builder(ID)
                         .tags(
-                            Tags.of(
+                            listOf(
                                 Tag.of(GqlTag.LOADER_NAME.key, name),
                                 Tag.of(GqlTag.LOADER_BATCH_SIZE.key, result.size.toString())
                             )

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/MappedBatchLoaderInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/MappedBatchLoaderInterceptor.kt
@@ -4,7 +4,6 @@ import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlMetric
 import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlTag
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 import io.micrometer.core.instrument.Timer
 import net.bytebuddy.implementation.bind.annotation.Pipe
 import org.dataloader.MappedBatchLoader
@@ -25,7 +24,7 @@ internal class MappedBatchLoaderInterceptor(
                 timerSampler.stop(
                     Timer.builder(ID)
                         .tags(
-                            Tags.of(
+                            listOf(
                                 Tag.of(GqlTag.LOADER_NAME.key, name),
                                 Tag.of(GqlTag.LOADER_BATCH_SIZE.key, result.size.toString())
                             )

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/MappedBatchLoaderWithContextInterceptor.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/dataloader/MappedBatchLoaderWithContextInterceptor.kt
@@ -4,7 +4,6 @@ import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlMetric
 import com.netflix.graphql.dgs.metrics.DgsMetrics.GqlTag
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 import io.micrometer.core.instrument.Timer
 import net.bytebuddy.implementation.bind.annotation.Pipe
 import org.dataloader.MappedBatchLoaderWithContext
@@ -26,7 +25,7 @@ internal class MappedBatchLoaderWithContextInterceptor(
                 timerSampler.stop(
                     Timer.builder(ID)
                         .tags(
-                            Tags.of(
+                            listOf(
                                 Tag.of(GqlTag.LOADER_NAME.key, name),
                                 Tag.of(GqlTag.LOADER_BATCH_SIZE.key, result.size.toString())
                             )

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/DgsGraphQLMetricsTagsProvider.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/DgsGraphQLMetricsTagsProvider.kt
@@ -21,22 +21,21 @@ import graphql.ExecutionResult
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 
 interface DgsGraphQLMetricsTagsProvider {
 
-    fun getContextualTags(): Iterable<Tag> = Tags.empty()
+    fun getContextualTags(): Iterable<Tag> = emptyList()
 
     fun getExecutionTags(
         state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
         parameters: InstrumentationExecutionParameters,
         result: ExecutionResult,
         exception: Throwable?
-    ): Iterable<Tag> = Tags.empty()
+    ): Iterable<Tag> = emptyList()
 
     fun getFieldFetchTags(
         state: DgsGraphQLMetricsInstrumentation.MetricsInstrumentationState,
         parameters: InstrumentationFieldFetchParameters,
         exception: Throwable?
-    ): Iterable<Tag> = Tags.empty()
+    ): Iterable<Tag> = emptyList()
 }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/SimpleGqlOutcomeTagCustomizer.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/tagging/SimpleGqlOutcomeTagCustomizer.kt
@@ -22,7 +22,6 @@ import graphql.ExecutionResult
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters
 import io.micrometer.core.instrument.Tag
-import io.micrometer.core.instrument.Tags
 
 class SimpleGqlOutcomeTagCustomizer : DgsExecutionTagCustomizer, DgsFieldFetchTagCustomizer {
 
@@ -33,9 +32,9 @@ class SimpleGqlOutcomeTagCustomizer : DgsExecutionTagCustomizer, DgsFieldFetchTa
         exception: Throwable?
     ): Iterable<Tag> {
         return if (result.errors.isNotEmpty() || exception != null) {
-            Tags.of(FAILURE.tag)
+            listOf(FAILURE.tag)
         } else {
-            Tags.of(SUCCESS.tag)
+            listOf(SUCCESS.tag)
         }
     }
 
@@ -45,9 +44,9 @@ class SimpleGqlOutcomeTagCustomizer : DgsExecutionTagCustomizer, DgsFieldFetchTa
         error: Throwable?
     ): Iterable<Tag> {
         return if (error == null) {
-            Tags.of(SUCCESS.tag)
+            listOf(SUCCESS.tag)
         } else {
-            Tags.of(FAILURE.tag)
+            listOf(FAILURE.tag)
         }
     }
 }


### PR DESCRIPTION
`io.micrometer.core.instrument.Tags` turns out to be a poor intermediate representation of `Iterable<Tag>`. In addition to being immutable and requiring a new instance for every call, it sorts and deduplicates elements on every operation which can lead to some significant CPU overhead on hot paths and/or with large numbers of tags:

https://github.com/micrometer-metrics/micrometer/blob/a56b968ba5b3db9b5e4a4feac813080783a16f5f/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java#L43-L47

All of the `tags` builder methods call `Tags::and` and there's no optimization for an initially empty state or the passed `Iterable<? extends Tag>` being a `Tags` instance, so you pay that overhead when finally adding the tags, no matter how the tags are constructed:

- https://github.com/micrometer-metrics/micrometer/blob/a56b968ba5b3db9b5e4a4feac813080783a16f5f/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java#L54-L80
- https://github.com/micrometer-metrics/micrometer/blob/a56b968ba5b3db9b5e4a4feac813080783a16f5f/micrometer-core/src/main/java/io/micrometer/core/instrument/Gauge.java#L108-L134

This replaces all direct usages of `Tags` with `Iterable<Tag>` and avoids calling the `tag` builder methods more than once.
