### PR TITLE
Avoid DataLoaderRegistry.getKeys when calling getDataLoader

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderRegistry.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderRegistry.kt
@@ -140,16 +140,11 @@ open class DgsDataLoaderRegistry : DataLoaderRegistry() {
      * @return a data loader or null if its not present
      </V></K> */
     override fun <K, V> getDataLoader(key: String): DataLoader<K, V>? {
-        if (dataLoaderRegistry.keys.contains(key)) {
-            return dataLoaderRegistry.getDataLoader(key)
-        } else if (scheduledDataLoaderRegistries.contains(key)) {
-            return scheduledDataLoaderRegistries[key]?.getDataLoader(key)
-        }
-        return null
+        return dataLoaderRegistry.getDataLoader(key) ?: scheduledDataLoaderRegistries[key]?.getDataLoader(key)
     }
 
     override fun getKeys(): Set<String> {
-        return HashSet(scheduledDataLoaderRegistries.keys).plus(dataLoaderRegistry.keys)
+        return scheduledDataLoaderRegistries.keys.plus(dataLoaderRegistry.keys)
     }
 
     /**


### PR DESCRIPTION
`getDataLoader` is a CPU hotspot in loaders because `getKeys().contains()` creates a two new hashsets for each call, when a plain `get` with a fallback on null will do:

![getDataLoader](https://github.com/Netflix/dgs-framework/assets/1479220/ddeb6c66-71a7-4abb-a7ec-3859c55487ac)

Also avoids the unnecessary wrapping of `HashSet` here, `plus` is doing that for us.