### PR TITLE
nebula-publish.yml: move from release events to push tags

### DIFF
--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -1,9 +1,9 @@
 name: "Publish to NetflixOSS and Maven Central"
 on:
-  release:
-    types:
-      - released
-      - prereleased
+  push:
+    tags:
+      - v*.*.*
+      - v*.*.*-rc.*
 
 jobs:
   build:


### PR DESCRIPTION
I was looking at release builds

* failure: https://github.com/Netflix/dgs-framework/actions/runs/6189557906/job/16804238730
* successful: https://github.com/Netflix/dgs-framework/actions/runs/6031271270/job/16364654237

The last successful one had this while checking out the commit:

```
Checking out the ref
  /usr/bin/git checkout --progress --force refs/tags/v7.5.1
  Note: switching to 'refs/tags/v7.5.1'.
```

while the failed one has this

```
Checking out the ref
  /usr/bin/git checkout --progress --force e70ca5e17f99e821c4f4763452c27079c8feaabd
  Note: switching to 'e70ca5e17f99e821c4f4763452c27079c8feaabd'.
```

Notice the lack of ref to the tag and just checking out the commit.

Because there isn't an actual ref to a tag, nebula fails to release.

I did some digging and found that the failed execution had different agent version:

```
Current runner version: '2.309.0'
Operating System
Runner Image
  Image: ubuntu-[2](https://github.com/Netflix/dgs-framework/actions/runs/6189557906/job/16804238730#step:1:2)2.04
  Version: 20230911.1.0
  Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20230[9](https://github.com/Netflix/dgs-framework/actions/runs/6189557906/job/16804238730#step:1:10)11.1/images/linux/Ubuntu2204-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230911.1
```

And turns out some users have been reporting this problem for a few weeks https://github.com/actions/runner/issues/2788 and still unresolved. It definitely explains the symptoms we see here

This change is to stop using the trigger by release and use it when a tag is pushed instead. 