### PR TITLE
#1577 bug: Ignore unknown json properties when parsing request object into …

### DIFF
--- a/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
+++ b/graphql-dgs-spring-webmvc/src/main/kotlin/com/netflix/graphql/dgs/mvc/DgsRestController.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.mvc
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
@@ -79,6 +80,7 @@ open class DgsRestController(
         const val DGS_RESPONSE_HEADERS_KEY = DgsExecutionResult.DGS_RESPONSE_HEADERS_KEY
         private val logger: Logger = LoggerFactory.getLogger(DgsRestController::class.java)
 
+        @JsonIgnoreProperties(ignoreUnknown = true)
         private data class InputQuery(
             val query: String?,
             val operationName: String? = null,


### PR DESCRIPTION
[bug: Ignore unknown json properties when parsing request object into InputQuery type](https://github.com/Netflix/dgs-framework/issues/1577#top)
#1577

Pull Request type
----

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Fix for [Issue #1577](https://github.com/Netflix/dgs-framework/issues/1577)

- Help make the GraphQL request parsing more resilient when dealing with older GraphQL implementations that use different field names. This annotation tells the Jackson ObjectMapper to ignore any unknown properties in the JSON serialization, which would allow the code to continue parsing the request even if the operation name is set with a different field name like `legacy operation_name`.


Alternatives considered
----

- Can also only only add @JsonIgnoreProperties to the operationName instead of on the entire data class. This way, if the incoming GraphQL request has an "operation_name" field instead of "operationName," it will be ignored, and the parsing will continue without errors. 

