### PR TITLE
Detect and throw exception for dataloaders with same name

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -933,13 +933,6 @@ class MicrometerServletSmokeTest {
         }
 
         @Bean
-        open fun reverserDataLoader(
-            @Qualifier("dataLoaderTaskExecutor") executor: Executor
-        ): ExampleImplementation.ReverseStringDataLoader {
-            return ExampleImplementation.ReverseStringDataLoader(executor)
-        }
-
-        @Bean
         open fun dataLoaderTaskExecutor(): Executor {
             val executor = ThreadPoolTaskExecutor()
             executor.corePoolSize = 1

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -18,6 +18,7 @@ package com.netflix.graphql.dgs
 
 import com.netflix.graphql.dgs.exceptions.DgsUnnamedDataLoaderOnFieldException
 import com.netflix.graphql.dgs.exceptions.InvalidDataLoaderTypeException
+import com.netflix.graphql.dgs.exceptions.MultipleDataLoadersDefinedException
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import graphql.schema.DataFetchingEnvironmentImpl
 import org.assertj.core.api.Assertions.assertThat
@@ -62,6 +63,16 @@ class DgsDataLoaderProviderTest {
             Assertions.assertNotNull(dataLoader)
             val dataLoaderWithDispatch = dataLoaderRegistry.getDataLoader<Any, Any>("exampleLoaderWithContextAndDispatch")
             Assertions.assertNotNull(dataLoaderWithDispatch)
+        }
+    }
+
+    @Test
+    fun detectDuplicateDataLoaders() {
+        applicationContextRunner.withBean(ExampleBatchLoader::class.java).withBean(ExampleDuplicateBatchLoader::class.java).run { context ->
+            val provider = context.getBean(DgsDataLoaderProvider::class.java)
+            assertThrows<MultipleDataLoadersDefinedException> {
+                provider.buildRegistry()
+            }
         }
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleDuplicateBatchLoader.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleDuplicateBatchLoader.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.BatchLoader
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader(name = "exampleLoader")
+class ExampleDuplicateBatchLoader : BatchLoader<String, String> {
+    override fun load(keys: MutableList<String>?): CompletionStage<MutableList<String>> {
+        return CompletableFuture.supplyAsync { mutableListOf("a", "b", "c") }
+    }
+}


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #
It is hard to detect when we have multiple dataloaders registered with the same name. This PR introduces a change to detect that and throw an exception.
