### PR TITLE
Enable metrics for completable futures.

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -119,8 +119,7 @@ class DgsGraphQLMetricsInstrumentation(
 
         if (parameters.isTrivialDataFetcher ||
             miState.isIntrospectionQuery ||
-            TagUtils.shouldIgnoreTag(gqlField) ||
-            !schemaProvider.isFieldInstrumentationEnabled(gqlField)
+            TagUtils.shouldIgnoreTag(gqlField)
         ) {
             return dataFetcher
         }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -119,7 +119,8 @@ class DgsGraphQLMetricsInstrumentation(
 
         if (parameters.isTrivialDataFetcher ||
             miState.isIntrospectionQuery ||
-            TagUtils.shouldIgnoreTag(gqlField)
+            TagUtils.shouldIgnoreTag(gqlField) ||
+            !schemaProvider.isFieldMetricsInstrumentationEnabled(gqlField)
         ) {
             return dataFetcher
         }

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -149,33 +149,6 @@ class MicrometerServletSmokeTest {
     }
 
     @Test
-    fun `Metrics for a query with a data fetcher with disabled instrumentation`() {
-        mvc.perform(
-            MockMvcRequestBuilders
-                .post("/graphql")
-                .contentType("application/json")
-                .content("""{ "query": "{someTrivialThings}" }""")
-        ).andExpect(status().isOk)
-            .andExpect(content().json("""{"data":{"someTrivialThings":"some insignificance"}}""", false))
-
-        val meters = fetchMeters()
-
-        assertThat(meters).containsOnlyKeys("gql.query")
-
-        assertThat(meters["gql.query"]).isNotNull.hasSize(1)
-        assertThat(meters["gql.query"]?.first()?.id?.tags)
-            .containsAll(
-                Tags.of("execution-tag", "foo")
-                    .and("contextual-tag", "foo")
-                    .and("outcome", "success")
-                    .and("gql.operation", "QUERY")
-                    .and("gql.operation.name", "anonymous")
-                    .and("gql.query.complexity", "5")
-                    .and("gql.query.sig.hash", MOCKED_QUERY_SIGNATURE.hash)
-            )
-    }
-
-    @Test
     fun `Metrics for a successful mutation`() {
         mvc.perform(
             // Note that the query below uses an aliased field, aliasing `ping` to `op_name`.

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -389,6 +389,33 @@ class MicrometerServletSmokeTest {
     }
 
     @Test
+    fun `Metrics for a query with a data fetcher with disabled instrumentation`() {
+        mvc.perform(
+            MockMvcRequestBuilders
+                .post("/graphql")
+                .contentType("application/json")
+                .content("""{ "query": "{someTrivialThings}" }""")
+        ).andExpect(status().isOk)
+            .andExpect(content().json("""{"data":{"someTrivialThings":"some insignificance"}}""", false))
+
+        val meters = fetchMeters()
+
+        assertThat(meters).containsOnlyKeys("gql.query")
+
+        assertThat(meters["gql.query"]).isNotNull.hasSize(1)
+        assertThat(meters["gql.query"]?.first()?.id?.tags)
+            .containsAll(
+                Tags.of("execution-tag", "foo")
+                    .and("contextual-tag", "foo")
+                    .and("outcome", "success")
+                    .and("gql.operation", "QUERY")
+                    .and("gql.operation.name", "anonymous")
+                    .and("gql.query.complexity", "5")
+                    .and("gql.query.sig.hash", MOCKED_QUERY_SIGNATURE.hash)
+            )
+    }
+
+    @Test
     fun `Assert metrics for a bad input error`() {
         mvc.perform(
             MockMvcRequestBuilders

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -559,7 +559,8 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBeans(HelloFetcher::class).run { context ->
             val provider = schemaProvider(applicationContext = context)
             provider.schema()
-            assertThat(provider.isFieldInstrumentationEnabled("Query.hello")).isTrue
+            assertThat(provider.isFieldTracingInstrumentationEnabled("Query.hello")).isTrue
+            assertThat(provider.isFieldMetricsInstrumentationEnabled("Query.hello")).isTrue
         }
     }
 
@@ -568,7 +569,8 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBeans(FetcherImplementingInterface::class).run { context ->
             val schemaProvider = schemaProvider(applicationContext = context)
             schemaProvider.schema()
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Query.hello")).isTrue
+            assertThat(schemaProvider.isFieldTracingInstrumentationEnabled("Query.hello")).isTrue
+            assertThat(schemaProvider.isFieldMetricsInstrumentationEnabled("Query.hello")).isTrue
         }
     }
 
@@ -586,12 +588,13 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBeans(NoTracingFetcher::class).run { context ->
             val schemaProvider = schemaProvider(applicationContext = context)
             schemaProvider.schema()
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Query.hello")).isFalse
+            assertThat(schemaProvider.isFieldTracingInstrumentationEnabled("Query.hello")).isFalse
+            assertThat(schemaProvider.isFieldMetricsInstrumentationEnabled("Query.hello")).isFalse
         }
     }
 
     @Test
-    fun disableInstrumentationForAsyncDataFetchers() {
+    fun disableTracingInstrumentationAndEnableMetricsForAsyncDataFetchers() {
         @DgsComponent
         class NoTracingDataFetcher {
             @DgsData(parentType = "Query", field = "hello")
@@ -603,7 +606,8 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBeans(NoTracingDataFetcher::class).run { context ->
             val schemaProvider = schemaProvider(applicationContext = context)
             schemaProvider.schema()
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Query.hello")).isFalse
+            assertThat(schemaProvider.isFieldTracingInstrumentationEnabled("Query.hello")).isFalse
+            assertThat(schemaProvider.isFieldMetricsInstrumentationEnabled("Query.hello")).isTrue
         }
     }
 
@@ -621,7 +625,8 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBeans(NoTracingDataFetcher::class).run { context ->
             val schemaProvider = schemaProvider(applicationContext = context)
             schemaProvider.schema()
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Query.hello")).isTrue
+            assertThat(schemaProvider.isFieldTracingInstrumentationEnabled("Query.hello")).isTrue
+            assertThat(schemaProvider.isFieldMetricsInstrumentationEnabled("Query.hello")).isTrue
         }
     }
 
@@ -652,8 +657,8 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBeans(TitleFetcher::class).run { context ->
             val schemaProvider = schemaProvider(applicationContext = context)
             schemaProvider.schema(schema)
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Video.title")).isTrue
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Show.title")).isTrue
+            assertThat(schemaProvider.isFieldTracingInstrumentationEnabled("Video.title")).isTrue
+            assertThat(schemaProvider.isFieldMetricsInstrumentationEnabled("Show.title")).isTrue
         }
     }
 
@@ -685,13 +690,13 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBeans(VideoFetcher::class, TitleFetcher::class).run { context ->
             val schemaProvider = schemaProvider(applicationContext = context)
             schemaProvider.schema(schema)
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Video.title")).isFalse
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Show.title")).isFalse
+            assertThat(schemaProvider.isFieldTracingInstrumentationEnabled("Video.title")).isFalse
+            assertThat(schemaProvider.isFieldMetricsInstrumentationEnabled("Show.title")).isFalse
         }
     }
 
     @Test
-    fun disableInstrumentationForAsyncInterfaceDataFetcher() {
+    fun disableTracingInstrumentationAndEnableMetricsForAsyncInterfaceDataFetcher() {
         val schema = """
               type Query {
                 video: Video
@@ -717,8 +722,8 @@ internal class DgsSchemaProviderTest {
         contextRunner.withBeans(VideoFetcher::class, TitleFetcher::class).run { context ->
             val schemaProvider = schemaProvider(applicationContext = context)
             schemaProvider.schema(schema)
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Video.title")).isFalse
-            assertThat(schemaProvider.isFieldInstrumentationEnabled("Show.title")).isFalse
+            assertThat(schemaProvider.isFieldTracingInstrumentationEnabled("Video.title")).isFalse
+            assertThat(schemaProvider.isFieldMetricsInstrumentationEnabled("Show.title")).isTrue
         }
     }
 


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ x Other (please describe):

Changes in this PR
----
We explicitly disable metrics and tracing for fetchers that return CompletableFutures. This makes sense for tracing since with data loaders this will generate a lot of small traces that are not useful. For metrics, it makes sense to have them be tracked anyways.
