### PR TITLE
(Experimental) Added support for automatically running data fetchers on virtual threads

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,8 @@ plugins {
     id("nebula.netflixoss") version "11.3.2"
     id("org.jmailen.kotlinter") version "3.11.1"
     id("me.champeau.jmh") version "0.7.1"
+    id("me.champeau.mrjar") version "0.1.1"
+
 
     kotlin("jvm") version Versions.KOTLIN_VERSION
     kotlin("kapt") version Versions.KOTLIN_VERSION

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -588,7 +588,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "firstLevelTransitive": [
@@ -1163,7 +1163,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "firstLevelTransitive": [
@@ -1736,7 +1736,7 @@
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ],
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -119,7 +119,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -294,7 +294,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -489,7 +489,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -891,7 +891,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -1085,7 +1085,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"
@@ -1277,7 +1277,7 @@
             "project": true
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.6.10"
+            "locked": "1.6.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.15"

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -5,6 +5,11 @@
       "name": "dgs.graphql.introspection.enabled",
       "type": "java.lang.Boolean",
       "description": "Setting this value to false will prevent Introspection queries from being performed. Note that this is against GraphQL Specification, that said, some production systems want this lock down in place for security concerns."
+    },
+    {
+      "name": "dgs.graphql.virtualthreads.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Setting this value will enable virtual threads for data fetchers when running on JDK 21+. This enables parallel data fetcher behavior without explicitly using CompletableFuture."
     }
   ],
   "hints": []

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -13,6 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+plugins {
+    id("me.champeau.mrjar")
+}
+
+multiRelease {
+    targetVersions(17, 21)
+}
 
 dependencies {
 
@@ -26,6 +33,7 @@ dependencies {
 
     implementation("org.springframework:spring-web")
     implementation("org.springframework:spring-context")
+    "java21Implementation"("org.springframework:spring-context")
 
     compileOnly("org.springframework.security:spring-security-core")
     compileOnly("io.projectreactor:reactor-core")
@@ -38,9 +46,11 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
+
     testImplementation("org.springframework.security:spring-security-core")
     testImplementation("io.projectreactor:reactor-core")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("com.graphql-java:graphql-java-extended-scalars")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
 }
+

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -99,6 +99,264 @@
             "locked": "6.0.10"
         }
     },
+    "java21AnnotationProcessor": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.2"
+        },
+        "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "2022.0.0"
+        }
+    },
+    "java21CompileClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.2"
+        },
+        "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.7.22"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "2022.0.0"
+        }
+    },
+    "java21RuntimeClasspath": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.2"
+        },
+        "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.7.22"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "2022.0.0"
+        }
+    },
+    "java21TestAnnotationProcessor": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.2"
+        },
+        "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "2022.0.0"
+        }
+    },
+    "java21TestCompileClasspath": {
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "3.0.0"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.2"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.2"
+        },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "20.6"
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "20.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.7.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.5"
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.5.7"
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.5.7"
+        },
+        "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.7.22"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "1.8.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.6.4"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "locked": "1.6.4"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.6.4"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
+            "locked": "1.6.4"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "2022.0.0"
+        },
+        "org.springframework.security:spring-security-core": {
+            "locked": "6.0.4"
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.0.10"
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.0.10"
+        }
+    },
+    "java21TestRuntimeClasspath": {
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "3.0.0"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.2"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.2"
+        },
+        "com.graphql-java:graphql-java": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "20.6"
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "20.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.7.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.5"
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.5.7"
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.5.7"
+        },
+        "net.datafaker:datafaker": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "1.9.0"
+        },
+        "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.8.20"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ],
+            "locked": "1.8.20"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.6.4"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8": {
+            "locked": "1.6.4"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.6.4"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
+            "locked": "1.6.4"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
+            ],
+            "locked": "2.0.7"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "2022.0.0"
+        },
+        "org.springframework.security:spring-security-core": {
+            "locked": "6.0.4"
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.0.10"
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.0.10"
+        }
+    },
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.36"
@@ -342,6 +600,22 @@
             "locked": "3.0.8"
         }
     },
+    "kaptJava21": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.0.8"
+        }
+    },
+    "kaptJava21Test": {
+        "org.springframework.boot:spring-boot-autoconfigure-processor": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.0.8"
+        }
+    },
     "kaptJmh": {
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
             "locked": "3.0.8"
@@ -380,6 +654,46 @@
             "locked": "2.15.2"
         },
         "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "2022.0.0"
+        }
+    },
+    "kotlinCompilerPluginClasspathJava21": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.2"
+        },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.7.20"
+        },
+        "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
+            "locked": "1.7.20"
+        },
+        "org.springframework.boot:spring-boot-dependencies": {
+            "locked": "3.0.8"
+        },
+        "org.springframework.cloud:spring-cloud-dependencies": {
+            "locked": "2022.0.0"
+        }
+    },
+    "kotlinCompilerPluginClasspathJava21Test": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.2"
+        },
+        "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
+            "locked": "1.7.20"
+        },
+        "org.jetbrains.kotlin:kotlin-bom": {
+            "locked": "1.7.20"
+        },
+        "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
             "locked": "1.7.20"
         },
         "org.springframework.boot:spring-boot-dependencies": {

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/conditionals/ConditionalOnJava21.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/conditionals/ConditionalOnJava21.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.conditionals;
+
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Conditional(Java21Condition.class)
+public @interface ConditionalOnJava21 {
+}

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/conditionals/Java21Condition.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/conditionals/Java21Condition.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.conditionals;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition used in @ConditionalOnJava21.
+ * Always returns false for the main implementation, but is re-implemented for JDK 21 only using the multi-release JAR feature.
+ */
+public class Java21Condition implements Condition {
+    @Override
+    public boolean matches(@NotNull ConditionContext context, @NotNull AnnotatedTypeMetadata metadata) {
+        return false;
+    }
+}

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/internal/VirtualThreadTaskExecutor.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/internal/VirtualThreadTaskExecutor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+/**
+ * Unimplemented version of the VirtualThreadTaskExecutor just for reachability.
+ * The actual implementation is in the java21 source folder, using the multi-release JAR feature.
+ */
+public class VirtualThreadTaskExecutor implements AsyncTaskExecutor {
+    public VirtualThreadTaskExecutor() {
+    }
+
+    @Override
+    public void execute(@NotNull Runnable task) {
+        throw new UnsupportedOperationException("VirtualThreadTaskExecutor is only supported on JDK 21+");
+    }
+
+    @Override
+    public void execute(@NotNull Runnable task, long startTimeout) {
+        throw new UnsupportedOperationException("VirtualThreadTaskExecutor is only supported on JDK 21+");
+    }
+
+    @NotNull
+    @Override
+    public Future<?> submit(@NotNull Runnable task) {
+        throw new UnsupportedOperationException("VirtualThreadTaskExecutor is only supported on JDK 21+");
+    }
+
+    @NotNull
+    @Override
+    public <T> Future<T> submit(@NotNull Callable<T> task) {
+        throw new UnsupportedOperationException("VirtualThreadTaskExecutor is only supported on JDK 21+");
+    }
+}

--- a/graphql-dgs/src/main/java21/com.netflix.graphql.dgs.internal.VirtualThreadTaskExecutor/VirtualThreadTaskExecutor.java
+++ b/graphql-dgs/src/main/java21/com.netflix.graphql.dgs.internal.VirtualThreadTaskExecutor/VirtualThreadTaskExecutor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * AsyncTaskExecutor based on Virtual Threads.
+ * JDK21+ only.
+ */
+@SuppressWarnings("unused")
+public class VirtualThreadTaskExecutor implements AsyncTaskExecutor {
+    private final ThreadFactory threadFactory;
+
+    public VirtualThreadTaskExecutor() {
+        this.threadFactory = Thread.ofVirtual().name("dgs-virtual-thread-", 0).factory();
+    }
+
+    @Override
+    public void execute(@NotNull Runnable task) {
+        threadFactory.newThread(task).start();
+    }
+
+    @Override
+    public void execute(@NotNull Runnable task, long startTimeout) {
+        var future = new FutureTask<>(task, null);
+        execute(future);
+    }
+
+    @NotNull
+    @Override
+    public Future<?> submit(@NotNull Runnable task) {
+        var future = new FutureTask<>(task, null);
+        execute(future);
+        return future;
+    }
+
+    @NotNull
+    @Override
+    public <T> Future<T> submit(@NotNull Callable<T> task) {
+        var future = new FutureTask<>(task);
+        execute(future);
+        return future;
+    }
+}

--- a/graphql-dgs/src/main/java21/com/netflix/graphql/dgs/conditionals/Java21Condition.java
+++ b/graphql-dgs/src/main/java21/com/netflix/graphql/dgs/conditionals/Java21Condition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.conditionals;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Condition used in @ConditionalOnJava21.
+ * This is the JDK 21 version of the condition, which is only loaded on JDK 21+ using the multi-release JAR feature.
+ */
+@SuppressWarnings("unused")
+public class Java21Condition implements Condition {
+    @Override
+    public boolean matches(@NotNull ConditionContext context, @NotNull AnnotatedTypeMetadata metadata) {
+        return true;
+    }
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/MethodDataFetcherFactory.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/MethodDataFetcherFactory.kt
@@ -22,6 +22,7 @@ import graphql.schema.DataFetcher
 import org.springframework.core.DefaultParameterNameDiscoverer
 import org.springframework.core.MethodParameter
 import org.springframework.core.ParameterNameDiscoverer
+import org.springframework.core.task.AsyncTaskExecutor
 import java.lang.reflect.Method
 
 /**
@@ -31,7 +32,8 @@ import java.lang.reflect.Method
  */
 class MethodDataFetcherFactory(
     argumentResolvers: List<ArgumentResolver>,
-    internal val parameterNameDiscoverer: ParameterNameDiscoverer = DefaultParameterNameDiscoverer()
+    internal val parameterNameDiscoverer: ParameterNameDiscoverer = DefaultParameterNameDiscoverer(),
+    private val asyncTaskExecutor: AsyncTaskExecutor? = null
 ) {
 
     private val resolvers = ArgumentResolverComposite(argumentResolvers)
@@ -41,7 +43,8 @@ class MethodDataFetcherFactory(
             dgsComponent = bean,
             method = method,
             resolvers = resolvers,
-            parameterNameDiscoverer = parameterNameDiscoverer
+            parameterNameDiscoverer = parameterNameDiscoverer,
+            asyncTaskExecutor
         )
     }
 


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

When running on JDK 21 this change wraps each data fetcher in a ComletableFuture, which is run on a new virtual thread. This enables parallel data fetching without needing to manually deal with CompletableFuture, and without the need to manually manage a thread pool for data fetchers.
The future currently needs to be enabled with `dgs.graphql.virtualthreads.enabled=true`. We might enable by default at a later point in time if this turns out to be beneficial.

- This doesn't (yet) affect data loaders
- DataFetchers that explicitly return CompletableFuture are ignored for this feature, they'll continue to use the `Executor` specified by the user. This way you can, if needed, be specific about using a thread pool for certain data fetchers if they are CPU bound.
- It uses a multi release JAR to be able to use Java 21 APIs for Virtual Threads, while still compiling the project with Java 17.
- The virtual thread factory can be provided by the user as a `@Bean`. This is important for integration with other frameworks for things like context propagation.


