### PR TITLE
Fix issue #1262

### DIFF
--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfiguration.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfiguration.kt
@@ -92,7 +92,7 @@ open class DgsWebMvcAutoConfiguration {
 
         @Bean
         @Dgs
-        open fun dgsWebDataBinderFactory(adapter: ObjectProvider<RequestMappingHandlerAdapter>): WebDataBinderFactory {
+        open fun dgsWebDataBinderFactory(@Qualifier("requestMappingHandlerAdapter") adapter: ObjectProvider<RequestMappingHandlerAdapter>): WebDataBinderFactory {
             return ServletRequestDataBinderFactory(listOf(), adapter.ifAvailable?.webBindingInitializer)
         }
 


### PR DESCRIPTION
Fixes  injection issue when more than one RequestMappingHandlerAdapter is available. Explicitly pick the one from webmvc.
Fix for: #1262

Pull Request type
----

- [x ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):
