### PR TITLE
Add configuration to disable/enable resolver and query metrics.

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -61,7 +61,7 @@ class DgsGraphQLMetricsInstrumentation(
         parameters: InstrumentationExecutionParameters,
         state: InstrumentationState
     ): InstrumentationContext<ExecutionResult> {
-        if (! properties.query.enabled) {
+        if (!properties.query.enabled) {
             return noOp()
         }
 

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -17,6 +17,7 @@ import graphql.analysis.QueryVisitorStub
 import graphql.execution.instrumentation.InstrumentationContext
 import graphql.execution.instrumentation.InstrumentationState
 import graphql.execution.instrumentation.SimpleInstrumentationContext
+import graphql.execution.instrumentation.SimpleInstrumentationContext.noOp
 import graphql.execution.instrumentation.SimplePerformantInstrumentation
 import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters
 import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters
@@ -60,6 +61,10 @@ class DgsGraphQLMetricsInstrumentation(
         parameters: InstrumentationExecutionParameters,
         state: InstrumentationState
     ): InstrumentationContext<ExecutionResult> {
+        if (! properties.query.enabled) {
+            return noOp()
+        }
+
         val miState: MetricsInstrumentationState = state as MetricsInstrumentationState
         miState.startTimer()
 
@@ -120,7 +125,8 @@ class DgsGraphQLMetricsInstrumentation(
         if (parameters.isTrivialDataFetcher ||
             miState.isIntrospectionQuery ||
             TagUtils.shouldIgnoreTag(gqlField) ||
-            !schemaProvider.isFieldMetricsInstrumentationEnabled(gqlField)
+            !schemaProvider.isFieldMetricsInstrumentationEnabled(gqlField) ||
+            !properties.resolver.enabled
         ) {
             return dataFetcher
         }

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsProperties.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsProperties.kt
@@ -15,7 +15,12 @@ data class DgsGraphQLMetricsProperties(
     var autotime: PropertiesAutoTimer = PropertiesAutoTimer(autotimeProperties),
     /** Settings that can be used to limit some of the tag metrics used by DGS. */
     @NestedConfigurationProperty
-    var tags: TagsProperties = TagsProperties()
+    var tags: TagsProperties = TagsProperties(),
+    /** Settings to selectively enable/disable gql timers.*/
+    @NestedConfigurationProperty
+    var resolver: ResolverMetricProperties = ResolverMetricProperties(),
+    var query: QueryMetricProperties = QueryMetricProperties()
+
 ) {
 
     data class TagsProperties(
@@ -38,6 +43,16 @@ data class DgsGraphQLMetricsProperties(
     )
 
     data class QueryComplexityProperties(
+        @DefaultValue("true")
+        var enabled: Boolean = true
+    )
+
+    data class ResolverMetricProperties(
+        @DefaultValue("true")
+        var enabled: Boolean = true
+    )
+
+    data class QueryMetricProperties(
         @DefaultValue("true")
         var enabled: Boolean = true
     )

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsPropertiesTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsPropertiesTest.kt
@@ -43,6 +43,9 @@ internal class DgsGraphQLMetricsPropertiesTest {
             assertThat(props.tags.limiter.kind).isEqualTo(DgsGraphQLMetricsProperties.CardinalityLimiterKind.FIRST)
             assertThat(props.tags.limiter.limit).isEqualTo(100)
             assertThat(props.tags.complexity.enabled).isEqualTo(true)
+
+            assertThat(props.resolver.enabled).isTrue()
+            assertThat(props.query.enabled).isTrue()
         }
     }
 
@@ -70,6 +73,30 @@ internal class DgsGraphQLMetricsPropertiesTest {
                 val props = ctx.getBean(DgsGraphQLMetricsProperties::class.java)
 
                 assertThat(props.tags.complexity.enabled).isEqualTo(false)
+            }
+    }
+
+    @Test
+    fun `Can disable resolver metric`() {
+        contextRunner
+            .withPropertyValues(
+                "management.metrics.dgs-graphql.resolver.enabled=false"
+            ).run { ctx ->
+                val props = ctx.getBean(DgsGraphQLMetricsProperties::class.java)
+
+                assertThat(props.resolver.enabled).isEqualTo(false)
+            }
+    }
+
+    @Test
+    fun `Can disable query metric`() {
+        contextRunner
+            .withPropertyValues(
+                "management.metrics.dgs-graphql.query.enabled=false"
+            ).run { ctx ->
+                val props = ctx.getBean(DgsGraphQLMetricsProperties::class.java)
+
+                assertThat(props.query.enabled).isEqualTo(false)
             }
     }
 


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This PR adds properties to selectively disable/enable `gql.resolver` and `gql.query` metrics.
