### PR TITLE
Inject DataLoaderOptionsProvider bean, if custom is provided.

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -154,8 +154,8 @@ open class DgsAutoConfiguration(
     }
 
     @Bean
-    open fun dgsDataLoaderProvider(applicationContext: ApplicationContext): DgsDataLoaderProvider {
-        return DgsDataLoaderProvider(applicationContext)
+    open fun dgsDataLoaderProvider(applicationContext: ApplicationContext, dataloaderOptionProvider: DgsDataLoaderOptionsProvider): DgsDataLoaderProvider {
+        return DgsDataLoaderProvider(applicationContext, dataloaderOptionProvider)
     }
 
     /**

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfigurationTest.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfigurationTest.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.autoconfig
 
+import com.netflix.graphql.dgs.DgsDataLoaderOptionsProvider
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.autoconfig.testcomponents.CustomContextBuilderConfig
 import com.netflix.graphql.dgs.autoconfig.testcomponents.CustomDataFetcherFactoryFixtures
@@ -144,6 +145,22 @@ class DgsAutoConfigurationTest {
             assertThat(ctx).getBean("dataFetchingEnvironmentArgumentResolver", DataFetchingEnvironmentArgumentResolver::class.java).isNotNull
             assertThat(ctx).getBean("coroutineArgumentResolver", ContinuationArgumentResolver::class.java).isNotNull
             assertThat(ctx).getBean("fallbackEnvironmentArgumentResolver", FallbackEnvironmentArgumentResolver::class.java).isNotNull
+        }
+    }
+
+    @Test
+    fun `DGS custom data loader options beans is available and used`() {
+        context.withUserConfiguration(DataLoaderConfig::class.java).run { ctx ->
+            assertThat(ctx).getBean(DgsDataLoaderOptionsProvider::class.java).isNotNull()
+            assertThat(ctx).getBean(DgsDataLoaderOptionsProvider::class.java).javaClass.simpleName.equals("CustomDataLoaderOptionsProvider")
+        }
+    }
+
+    @Test
+    fun `DGS default data loader options bean is available`() {
+        context.run { ctx ->
+            assertThat(ctx).getBean(DgsDataLoaderOptionsProvider::class.java).isNotNull()
+            assertThat(ctx).getBean(DgsDataLoaderOptionsProvider::class.java).javaClass.simpleName.equals("DefaultDataLoaderOptionsProvider")
         }
     }
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/TestDataLoader.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/TestDataLoader.kt
@@ -19,8 +19,10 @@ package com.netflix.graphql.dgs.autoconfig.testcomponents
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsData
 import com.netflix.graphql.dgs.DgsDataLoader
+import com.netflix.graphql.dgs.DgsDataLoaderOptionsProvider
 import graphql.schema.DataFetchingEnvironment
 import org.dataloader.BatchLoader
+import org.dataloader.DataLoaderOptions
 import org.dataloader.MappedBatchLoader
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -79,5 +81,21 @@ open class DataLoaderConfig {
     @Bean
     open fun createFetcherUsingMappedLoader(): FetcherUsingMappedDataLoader {
         return FetcherUsingMappedDataLoader()
+    }
+
+    @Bean
+    open fun dgsDataLoaderOptionsProvider(): DgsDataLoaderOptionsProvider {
+        return CustomDataLoaderOptionsProvider()
+    }
+}
+
+class CustomDataLoaderOptionsProvider : DgsDataLoaderOptionsProvider {
+    override fun getOptions(dataLoaderName: String, annotation: DgsDataLoader): DataLoaderOptions {
+        val options = DataLoaderOptions()
+            .setBatchingEnabled(false)
+            .setCachingEnabled(false)
+
+        options.setMaxBatchSize(50)
+        return options
     }
 }


### PR DESCRIPTION
When a custom DataLoaderOptionsProvider is set up, we need to use that instead of the DefaultDgsDataLoaderOptionsProvider.