### PR TITLE
Fix handling of concrete type data fetchers for interface fields.

### DIFF
--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/ActionMovieDataFetcher.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/ActionMovieDataFetcher.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.example.shared.datafetcher;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+
+@DgsComponent
+public class ActionMovieDataFetcher {
+    @SuppressWarnings("SameReturnValue")
+    @DgsData(parentType = "ActionMovie", field = "director")
+    public String director() {
+
+        return "Action movie director";
+    }
+}

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/ScaryMovieDataFetcher.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/ScaryMovieDataFetcher.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.example.shared.datafetcher;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.example.shared.types.ActionMovie;
+import com.netflix.graphql.dgs.example.shared.types.Movie;
+import com.netflix.graphql.dgs.example.shared.types.ScaryMovie;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DgsComponent
+public class ScaryMovieDataFetcher {
+    @SuppressWarnings("SameReturnValue")
+    @DgsData(parentType = "ScaryMovie", field = "director")
+    public String director() {
+
+        return "Scary movie director";
+    }
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -368,14 +368,20 @@ class DgsSchemaProvider(
                     }
                     val implementationsOf = typeDefinitionRegistry.getImplementationsOf(type)
                     implementationsOf.forEach { implType ->
-                        val dataFetcher =
-                            createBasicDataFetcher(method, dgsComponent, parentType == "Subscription")
-                        codeRegistryBuilder.dataFetcher(
-                            FieldCoordinates.coordinates(implType.name, field),
-                            dataFetcher
-                        )
-                        dataFetcherTracingInstrumentationEnabled["${implType.name}.$field"] = enableTracingInstrumentation
-                        dataFetcherMetricsInstrumentationEnabled["${implType.name}.$field"] = enableMetricsInstrumentation
+                        // if we have a datafetcher explicitly defined for a parentType/field, use that and do not
+                        // register the base implementation for interfaces
+                        if (!codeRegistryBuilder.hasDataFetcher(FieldCoordinates.coordinates(implType.name, field))) {
+                            val dataFetcher =
+                                createBasicDataFetcher(method, dgsComponent, parentType == "Subscription")
+                            codeRegistryBuilder.dataFetcher(
+                                FieldCoordinates.coordinates(implType.name, field),
+                                dataFetcher
+                            )
+                            dataFetcherTracingInstrumentationEnabled["${implType.name}.$field"] =
+                                enableTracingInstrumentation
+                            dataFetcherMetricsInstrumentationEnabled["${implType.name}.$field"] =
+                                enableMetricsInstrumentation
+                        }
                     }
                 }
                 is UnionTypeDefinition -> {


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
This PR fixes handling of data fetchers for an interface field that override the base type data fetcher. The updated example shows the scenario that triggers the problem where the base type's data fetcher may overwrite the registration of the concrete type's data fetcher depending on the order in which the `DgsComponent`s are processed.

