### PR TITLE
Fix issue where java datafetcher methods were incorrectly called as Kotlin function

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DataFetcherInvoker.kt
@@ -65,7 +65,7 @@ class DataFetcherInvoker internal constructor(
             return ReflectionUtils.invokeMethod(bridgedMethod, dgsComponent)
         }
 
-        if (kotlinFunction != null) {
+        if (dgsComponent.javaClass.getDeclaredAnnotation(Metadata::class.java) != null && kotlinFunction != null) {
             return invokeKotlinMethod(kotlinFunction, environment)
         }
 


### PR DESCRIPTION

Pull Request type
----

- [x ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Java datafetcher methods with an argument were incorrectly called as being kotlin functions. While this _mostly_ works, it causes an incorrect wrapping of InvocationException if an exception occurs.
The code was prepared for calling Java functions using regular Java Reflection, but the assumption was that `kotlinFunction != null` would be false. This is not true (for reasons I don't understand, that's Kotlin internals).

The correct check also verifies if the class has Kotlin metadata, which is the correct way to verify if we're dealing with Kotlin code.