### PR TITLE
Update set up for ScheduledExecutorService.

### DIFF
--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -243,6 +243,12 @@
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -770,6 +776,12 @@
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -940,6 +952,12 @@
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -45,6 +45,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -233,6 +239,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -449,6 +461,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -932,6 +950,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1226,6 +1250,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1438,6 +1468,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -48,6 +48,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -241,6 +247,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -468,6 +480,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -1012,6 +1030,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1355,6 +1379,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1584,6 +1614,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -40,6 +40,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -170,6 +176,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -305,6 +317,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -659,6 +677,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -844,6 +868,12 @@
             ],
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -978,6 +1008,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars"
             ],
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -34,6 +34,12 @@
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -123,6 +129,12 @@
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -241,6 +253,12 @@
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -644,6 +662,12 @@
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -778,6 +802,12 @@
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -952,6 +982,12 @@
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -34,6 +34,12 @@
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -123,6 +129,12 @@
         },
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -241,6 +253,12 @@
         },
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -644,6 +662,12 @@
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -778,6 +802,12 @@
         },
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -952,6 +982,12 @@
         },
         "com.graphql-java:graphql-java-extended-validation": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -31,6 +31,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -117,6 +123,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -206,6 +218,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -494,6 +512,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -618,6 +642,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -703,6 +733,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -55,6 +55,14 @@ dependencies {
             }
 
         }
+        api("com.graphql-java:java-dataloader") {
+            version {
+                strictly("[3.2.2]")
+                prefer("3.2.2")
+                reject("[3.2.1]")
+            }
+
+        }
         api("com.graphql-java:graphql-java-extended-scalars") {
             version {
                  strictly("[21.0]")

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -34,6 +34,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -133,6 +139,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -231,6 +243,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -558,6 +576,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -691,6 +715,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -807,6 +837,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -42,6 +42,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -216,6 +222,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -411,6 +423,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -829,6 +847,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -975,6 +999,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -1167,6 +1197,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -34,6 +34,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -150,6 +156,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -270,6 +282,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -579,6 +597,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -720,6 +744,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -830,6 +860,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -69,6 +69,8 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.context.request.WebRequest
 import java.util.*
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 
 /**
  * Framework auto configuration based on open source Spring only, without Netflix integrations.
@@ -153,9 +155,16 @@ open class DgsAutoConfiguration(
         return DefaultDataLoaderOptionsProvider()
     }
 
+    @Bean(destroyMethod = "shutdown")
+    @ConditionalOnMissingBean
+    @Qualifier("dgsScheduledExecutorService")
+    open fun dgsScheduledExecutorService(): ScheduledExecutorService {
+        return Executors.newSingleThreadScheduledExecutor()
+    }
+
     @Bean
-    open fun dgsDataLoaderProvider(applicationContext: ApplicationContext, dataloaderOptionProvider: DgsDataLoaderOptionsProvider): DgsDataLoaderProvider {
-        return DgsDataLoaderProvider(applicationContext, dataloaderOptionProvider)
+    open fun dgsDataLoaderProvider(applicationContext: ApplicationContext, dataloaderOptionProvider: DgsDataLoaderOptionsProvider, @Qualifier("dgsScheduledExecutorService") dgsScheduledExecutorService: ScheduledExecutorService): DgsDataLoaderProvider {
+        return DgsDataLoaderProvider(applicationContext, dataloaderOptionProvider, dgsScheduledExecutorService, configProps.dataloaderTickerModeEnabled)
     }
 
     /**

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -29,7 +29,9 @@ data class DgsConfigurationProperties(
     /** Location of the GraphQL schema files. */
     @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>,
     @DefaultValue("true") val schemaWiringValidationEnabled: Boolean,
-    @DefaultValue("false") val enableEntityFetcherCustomScalarParsing: Boolean
+    @DefaultValue("false") val enableEntityFetcherCustomScalarParsing: Boolean,
+    /** Data loader properties.*/
+    @DefaultValue("false") val dataloaderTickerModeEnabled: Boolean
 ) {
     companion object {
         const val PREFIX: String = "dgs.graphql"

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -39,6 +39,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -181,6 +187,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -344,6 +356,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -747,6 +765,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -968,6 +992,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1127,6 +1157,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -41,6 +41,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -156,6 +162,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -276,6 +288,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -642,6 +660,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -817,6 +841,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -955,6 +985,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -37,6 +37,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -145,6 +151,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -252,6 +264,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -580,6 +598,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -730,6 +754,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -846,6 +876,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -34,6 +34,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -130,6 +136,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -224,6 +236,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -518,6 +536,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -642,6 +666,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -739,6 +769,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
@@ -31,6 +31,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -128,6 +134,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -236,6 +248,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -567,6 +585,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -726,6 +750,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -830,6 +860,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
@@ -41,6 +41,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -149,6 +155,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -255,6 +267,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -570,6 +588,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -718,6 +742,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -827,6 +857,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -31,6 +31,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -128,6 +134,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -236,6 +248,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -567,6 +585,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -726,6 +750,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -830,6 +860,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -41,6 +41,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -149,6 +155,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -255,6 +267,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -570,6 +588,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -718,6 +742,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -827,6 +857,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -44,6 +44,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -163,6 +169,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -278,6 +290,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -604,6 +622,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -768,6 +792,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -880,6 +910,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -41,6 +41,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -155,6 +161,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -267,6 +279,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -579,6 +597,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -724,6 +748,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs"
@@ -833,6 +863,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -39,6 +39,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -187,6 +193,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -356,6 +368,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
@@ -774,6 +792,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1010,6 +1034,12 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1175,6 +1205,12 @@
                 "com.netflix.graphql.dgs:graphql-error-types"
             ],
             "locked": "21.2"
+        },
+        "com.graphql-java:java-dataloader": {
+            "firstLevelTransitive": [
+                "com.netflix.graphql.dgs:graphql-dgs"
+            ],
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "firstLevelTransitive": [

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api(project(":graphql-dgs-mocking"))
 
     api("com.graphql-java:graphql-java")
+    api("com.graphql-java:java-dataloader")
     api("com.jayway.jsonpath:json-path")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -39,6 +39,9 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.7.0"
         },
@@ -190,6 +193,9 @@
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.7.0"
         },
@@ -281,6 +287,9 @@
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.7.0"
@@ -408,6 +417,9 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.7.0"
         },
@@ -499,6 +511,9 @@
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.7.0"
@@ -788,6 +803,9 @@
             ],
             "locked": "21.2"
         },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.7.0"
         },
@@ -888,6 +906,9 @@
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
         },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
+        },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.7.0"
         },
@@ -979,6 +1000,9 @@
         },
         "com.graphql-java:graphql-java-extended-scalars": {
             "locked": "21.0"
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.7.0"

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt
@@ -39,12 +39,13 @@ import graphql.execution.ExecutionStrategy
 import graphql.execution.instrumentation.Instrumentation
 import graphql.execution.preparsed.PreparsedDocumentProvider
 import graphql.schema.GraphQLSchema
+import org.dataloader.registries.ScheduledDataLoaderRegistry
 import org.intellij.lang.annotations.Language
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.util.StringUtils
-import java.util.Optional
+import java.util.*
 import java.util.concurrent.CompletableFuture
 
 object BaseDgsQueryExecutor {
@@ -118,7 +119,11 @@ object BaseDgsQueryExecutor {
                 .extensions(extensions.orEmpty())
                 .build()
             graphQLContextFuture.complete(executionInput.graphQLContext)
-            graphQL.executeAsync(executionInput)
+            graphQL.executeAsync(executionInput).whenComplete { _, _ ->
+                if (dataLoaderRegistry is ScheduledDataLoaderRegistry) {
+                    dataLoaderRegistry.close()
+                }
+            }
         } catch (e: Exception) {
             logger.error("Encountered an exception while handling query {}", query, e)
             val errors: List<GraphQLError> = if (e is GraphQLError) listOf<GraphQLError>(e) else emptyList()


### PR DESCRIPTION
This PR has the following changes:
1. Inject a ScheduledExecutorService bean for use across requests, qualified with @DgsScheduledExecutorService
2. Update to use the latest java-dataloader 3.2.2 to pick up [this fix] to avoid instantiating a new service per request (https://github.com/graphql-java/java-dataloader/pull/135)
3. Make the tickerMode configurable, default set to false