### PR TITLE
fix issue 1569 -- parse custom scalars in _entities representations

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -204,7 +204,8 @@ open class DgsAutoConfiguration(
             entityFetcherRegistry = entityFetcherRegistry,
             defaultDataFetcherFactory = defaultDataFetcherFactory,
             methodDataFetcherFactory = methodDataFetcherFactory,
-            schemaWiringValidationEnabled = configProps.schemaWiringValidationEnabled
+            schemaWiringValidationEnabled = configProps.schemaWiringValidationEnabled,
+            enableEntityFetcherCustomScalarParsing = configProps.enableEntityFetcherCustomScalarParsing
         )
     }
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -28,7 +28,8 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 data class DgsConfigurationProperties(
     /** Location of the GraphQL schema files. */
     @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>,
-    @DefaultValue("true") val schemaWiringValidationEnabled: Boolean
+    @DefaultValue("true") val schemaWiringValidationEnabled: Boolean,
+    @DefaultValue("false") val enableEntityFetcherCustomScalarParsing: Boolean
 ) {
     companion object {
         const val PREFIX: String = "dgs.graphql"

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -25,11 +25,13 @@ import com.netflix.graphql.dgs.exceptions.MissingDgsEntityFetcherException
 import com.netflix.graphql.dgs.exceptions.MissingFederatedQueryArgument
 import com.netflix.graphql.dgs.internal.EntityFetcherRegistry
 import com.netflix.graphql.types.errors.TypedGraphQLError
+import graphql.GraphQLContext
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherExceptionHandlerParameters
 import graphql.execution.DataFetcherResult
 import graphql.execution.ExecutionStepInfo
 import graphql.execution.ResultPath
+import graphql.schema.Coercing
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.DataFetchingEnvironmentImpl
@@ -44,6 +46,7 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CompletionStage
+import java.util.stream.Collectors
 
 @DgsComponent
 open class DefaultDgsFederationResolver() :
@@ -78,6 +81,26 @@ open class DefaultDgsFederationResolver() :
         }
     }
 
+    private fun valuesWithMappedScalars(graphQLContext: GraphQLContext, values: Map<String, Any>, scalarMappings: Map<List<String>, Coercing<*, *>>, currentPath: MutableList<String>): Map<String, Any> {
+        return values.entries.stream()
+            .map {
+                currentPath.add(it.key)
+
+                val newValue = if (scalarMappings[currentPath] != null) {
+                    scalarMappings[currentPath]!!.parseValue(it.value, graphQLContext, Locale.getDefault())
+                } else if (it.value is Map<*, *>) {
+                    valuesWithMappedScalars(graphQLContext, it.value as Map<String, Any>, scalarMappings, currentPath)
+                } else {
+                    it.value
+                }
+
+                currentPath.removeLast()
+
+                Pair(it.key, newValue)
+            }
+            .collect(Collectors.toMap({ it.first }, { it.second!! }))
+    }
+
     private fun dgsEntityFetchers(env: DataFetchingEnvironment): CompletableFuture<DataFetcherResult<List<Any?>>> {
         val resultList = env.getArgument<List<Map<String, Any>>>(_Entity.argumentName)
             .map { values ->
@@ -91,11 +114,17 @@ open class DefaultDgsFederationResolver() :
                         throw InvalidDgsEntityFetcher("@DgsEntityFetcher ${fetcher.first::class.java.name}.${fetcher.second.name} is invalid. A DgsEntityFetcher must accept an argument of type Map<String, Object>")
                     }
 
+                    val coercedValues = if (entityFetcherRegistry.entityFetcherInputMappings[typename] != null) {
+                        valuesWithMappedScalars(env.graphQlContext, values, entityFetcherRegistry.entityFetcherInputMappings[typename]!!, ArrayList())
+                    } else {
+                        values
+                    }
+
                     val result =
                         if (fetcher.second.parameterTypes.any { it.isAssignableFrom(DgsDataFetchingEnvironment::class.java) }) {
-                            fetcher.second.invoke(fetcher.first, values, DgsDataFetchingEnvironment(env))
+                            fetcher.second.invoke(fetcher.first, coercedValues, DgsDataFetchingEnvironment(env))
                         } else {
-                            fetcher.second.invoke(fetcher.first, values)
+                            fetcher.second.invoke(fetcher.first, coercedValues)
                         }
 
                     if (result == null) {

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/EntityFetcherRegistry.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/EntityFetcherRegistry.kt
@@ -16,8 +16,10 @@
 
 package com.netflix.graphql.dgs.internal
 
+import graphql.schema.Coercing
 import java.lang.reflect.Method
 
 class EntityFetcherRegistry {
     val entityFetchers = mutableMapOf<String, Pair<Any, Method>>()
+    val entityFetcherInputMappings = mutableMapOf<String, Map<List<String>, Coercing<*, *>>>()
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/SelectionSetUtil.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/utils/SelectionSetUtil.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.utils
+
+import com.netflix.graphql.dgs.Internal
+import graphql.language.Field
+import graphql.language.OperationDefinition
+import graphql.language.SelectionSet
+import graphql.parser.Parser
+import java.util.stream.Stream
+
+@Internal
+class SelectionSetUtil {
+
+    companion object {
+        fun toPaths(selectionSet: String): List<List<String>> {
+            val document = Parser.parse("{ $selectionSet }")
+            val operation = document.definitions[0] as OperationDefinition
+            return toPaths(operation.selectionSet, ArrayList())
+        }
+
+        private fun toPaths(selectionSet: SelectionSet, nesting: MutableList<String>): List<List<String>> {
+            val results = ArrayList<List<String>>()
+
+            for (selection in selectionSet.selections) {
+                if (selection is Field) {
+                    if (selection.selectionSet == null) {
+                        results.add(Stream.concat(nesting.stream(), Stream.of(selection.name)).toList())
+                    } else {
+                        nesting.add(selection.name)
+                        results.addAll(toPaths(selection.selectionSet, nesting))
+                        nesting.removeLast()
+                    }
+                }
+            }
+
+            return results
+        }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/SelectionSetUtilTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/SelectionSetUtilTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal
+
+import com.netflix.graphql.dgs.internal.utils.SelectionSetUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class SelectionSetUtilTest {
+    @Test
+    fun `toPaths handles nested structures`() {
+        val paths = SelectionSetUtil.toPaths(
+            """
+            outer {
+              fieldA
+              fieldB
+            }
+            fieldC
+            """.trimIndent()
+        )
+
+        assertThat(paths).isEqualTo(
+            listOf(
+                listOf("outer", "fieldA"),
+                listOf("outer", "fieldB"),
+                listOf("fieldC")
+            )
+        )
+    }
+
+    @Test
+    fun `ignores spread selections`() {
+        val paths = SelectionSetUtil.toPaths(
+            """
+            outer {
+              fieldA
+              fieldB
+              ... on SomeType {
+                hopefullyIgnored
+              }
+              ... on SomeOtherType {
+                alsoIgnored {
+                  nested
+                }
+              }
+            }
+            fieldC
+            """.trimIndent()
+        )
+
+        assertThat(paths).isEqualTo(
+            listOf(
+                listOf("outer", "fieldA"),
+                listOf("outer", "fieldB"),
+                listOf("fieldC")
+            )
+        )
+    }
+}


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This PR addresses #1569 by parsing custom scalars that are contained within entity representations (based on the `@key` fields in the local schema). 

This functionality is turned off by default, as it can cause backwards compatibility issues:
- in a future version it will be turned on by default
- currently it can be enabled by setting the `dgs.graphql.enableEntityFetcherCustomScalarParsing` property to `true`


