### PR TITLE
Stop writing --info logs with gradle check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Check
         run: |
-          ./gradlew --info --no-watch-fs check
+          ./gradlew --no-watch-fs check
 
       - name: Publish Locally
         run: |


### PR DESCRIPTION
Wondering if this is related to the build hangs.
