### PR TITLE
Dataloader improvements

### DIFF
--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/GreetingsDataLoader.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/dataLoader/GreetingsDataLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.example.shared.dataLoader;
+
+import com.netflix.graphql.dgs.DgsDataLoader;
+import com.netflix.graphql.dgs.DgsDispatchPredicate;
+import org.dataloader.BatchLoader;
+import org.dataloader.registries.DispatchPredicate;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+@DgsDataLoader(name = "greetings")
+public class GreetingsDataLoader implements BatchLoader<String, String> {
+    @Override
+    public CompletionStage<List<String>> load(List<String> keys) {
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return CompletableFuture.supplyAsync(() -> keys.stream().map(key -> "Greetings, " + key + "!").collect(Collectors.toList()));
+    }
+}
+

--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/HelloDataFetcher.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/HelloDataFetcher.java
@@ -50,7 +50,19 @@ public class HelloDataFetcher {
     @DgsData(parentType = "Query", field = "messageFromBatchLoader")
     public CompletableFuture<String> getMessage(DataFetchingEnvironment env) {
         DataLoader<String, String> dataLoader = env.getDataLoader("messages");
+        DataLoader<String, String> dataLoaderB = env.getDataLoader("greetings");
         return dataLoader.load("a");
+    }
+
+    @DgsData(parentType = "Query", field = "messageFromBatchLoaderWithGreetings")
+    public CompletableFuture<String> getGreetings(DataFetchingEnvironment env) {
+        DataLoader<String, String> dataLoaderA = env.getDataLoader("messages");
+        DataLoader<String, String> dataLoaderB = env.getDataLoader("greetings");
+        return dataLoaderB.load("a").thenCompose(key -> {
+            CompletableFuture<String> loadA = dataLoaderA.load(key);
+            dataLoaderA.dispatch();
+            return loadA;
+        });
     }
 
     @DgsData(parentType = "Query", field = "messageFromBatchLoaderWithScheduledDispatch")

--- a/graphql-dgs-example-shared/src/main/resources/schema/schema.graphqls
+++ b/graphql-dgs-example-shared/src/main/resources/schema/schema.graphqls
@@ -6,6 +6,7 @@ type Query {
     withDataLoaderGraphQLContext: String
     movies: [Movie]
     messageFromBatchLoader: String
+    messageFromBatchLoaderWithGreetings: String
     messagesWithExceptionFromBatchLoader: [Message]
     messageFromBatchLoaderWithScheduledDispatch: String
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -164,7 +164,7 @@ open class DgsAutoConfiguration(
 
     @Bean
     open fun dgsDataLoaderProvider(applicationContext: ApplicationContext, dataloaderOptionProvider: DgsDataLoaderOptionsProvider, @Qualifier("dgsScheduledExecutorService") dgsScheduledExecutorService: ScheduledExecutorService): DgsDataLoaderProvider {
-        return DgsDataLoaderProvider(applicationContext, dataloaderOptionProvider, dgsScheduledExecutorService, configProps.dataloaderTickerModeEnabled)
+        return DgsDataLoaderProvider(applicationContext, dataloaderOptionProvider, dgsScheduledExecutorService, configProps.dataloaderScheduleDuration, configProps.dataloaderTickerModeEnabled)
     }
 
     /**

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -78,10 +78,11 @@ import java.util.concurrent.ScheduledExecutorService
  */
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
 @AutoConfiguration
-@EnableConfigurationProperties(DgsConfigurationProperties::class)
+@EnableConfigurationProperties(DgsConfigurationProperties::class, DgsDataloaderConfigurationProperties::class)
 @ImportAutoConfiguration(classes = [JacksonAutoConfiguration::class, DgsInputArgumentConfiguration::class])
 open class DgsAutoConfiguration(
-    private val configProps: DgsConfigurationProperties
+    private val configProps: DgsConfigurationProperties,
+    private val dataloaderConfigProps: DgsDataloaderConfigurationProperties
 ) {
 
     companion object {
@@ -164,7 +165,7 @@ open class DgsAutoConfiguration(
 
     @Bean
     open fun dgsDataLoaderProvider(applicationContext: ApplicationContext, dataloaderOptionProvider: DgsDataLoaderOptionsProvider, @Qualifier("dgsScheduledExecutorService") dgsScheduledExecutorService: ScheduledExecutorService): DgsDataLoaderProvider {
-        return DgsDataLoaderProvider(applicationContext, dataloaderOptionProvider, dgsScheduledExecutorService, configProps.dataloaderScheduleDuration, configProps.dataloaderTickerModeEnabled)
+        return DgsDataLoaderProvider(applicationContext, dataloaderOptionProvider, dgsScheduledExecutorService, dataloaderConfigProps.scheduleDuration, dataloaderConfigProps.tickerModeEnabled)
     }
 
     /**

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsConfigurationProperties.kt
@@ -19,6 +19,7 @@ package com.netflix.graphql.dgs.autoconfig
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider.Companion.DEFAULT_SCHEMA_LOCATION
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
+import java.time.Duration
 
 /**
  * Configuration properties for DGS framework.
@@ -31,9 +32,11 @@ data class DgsConfigurationProperties(
     @DefaultValue("true") val schemaWiringValidationEnabled: Boolean,
     @DefaultValue("false") val enableEntityFetcherCustomScalarParsing: Boolean,
     /** Data loader properties.*/
-    @DefaultValue("false") val dataloaderTickerModeEnabled: Boolean
+    @DefaultValue("false") val dataloaderTickerModeEnabled: Boolean,
+    @DefaultValue(DATALOADER_DEFAULT_SCHEDULE_DURATION) val dataloaderScheduleDuration: Duration
 ) {
     companion object {
         const val PREFIX: String = "dgs.graphql"
+        const val DATALOADER_DEFAULT_SCHEDULE_DURATION = "10ms"
     }
 }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsDataloaderConfigurationProperties.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsDataloaderConfigurationProperties.kt
@@ -16,23 +16,21 @@
 
 package com.netflix.graphql.dgs.autoconfig
 
-import com.netflix.graphql.dgs.internal.DgsSchemaProvider.Companion.DEFAULT_SCHEMA_LOCATION
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
+import java.time.Duration
 
 /**
  * Configuration properties for DGS framework.
  */
-@ConfigurationProperties(prefix = DgsConfigurationProperties.PREFIX)
+@ConfigurationProperties(prefix = DgsDataloaderConfigurationProperties.DATALOADER_PREFIX)
 @Suppress("ConfigurationProperties")
-data class DgsConfigurationProperties(
-    /** Location of the GraphQL schema files. */
-    @DefaultValue(DEFAULT_SCHEMA_LOCATION) val schemaLocations: List<String>,
-    @DefaultValue("true") val schemaWiringValidationEnabled: Boolean,
-    @DefaultValue("false") val enableEntityFetcherCustomScalarParsing: Boolean
+data class DgsDataloaderConfigurationProperties(
+    @DefaultValue("false") val tickerModeEnabled: Boolean,
+    @DefaultValue(DATALOADER_DEFAULT_SCHEDULE_DURATION) val scheduleDuration: Duration
 ) {
-
     companion object {
-        const val PREFIX: String = "dgs.graphql"
+        const val DATALOADER_PREFIX: String = "dgs.graphql.dataloader"
+        const val DATALOADER_DEFAULT_SCHEDULE_DURATION = "10ms"
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -38,6 +38,7 @@ import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.context.ApplicationContext
 import org.springframework.util.ReflectionUtils
+import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.function.Supplier
@@ -50,6 +51,7 @@ class DgsDataLoaderProvider(
     private val applicationContext: ApplicationContext,
     private val dataLoaderOptionsProvider: DgsDataLoaderOptionsProvider = DefaultDataLoaderOptionsProvider(),
     private val scheduledExecutorService: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    private val scheduleDuration: Duration = Duration.ofMillis(10),
     private val enableTickerMode: Boolean = false
 ) {
 
@@ -69,9 +71,7 @@ class DgsDataLoaderProvider(
     fun <T> buildRegistryWithContextSupplier(contextSupplier: Supplier<T>): DataLoaderRegistry {
         // We need to set the default predicate to 20ms and individually override with DISPATCH_ALWAYS or the custom dispatch predicate, if specified
         // The data loader ends up applying the overall dispatch predicate when the custom dispatch predicate is not true otherwise.
-        val registry = ScheduledDataLoaderRegistry.newScheduledRegistry().scheduledExecutorService(scheduledExecutorService).tickerMode(enableTickerMode).dispatchPredicate(
-            DispatchPredicate.DISPATCH_NEVER
-        ).build()
+        val registry = ScheduledDataLoaderRegistry.newScheduledRegistry().scheduledExecutorService(scheduledExecutorService).tickerMode(enableTickerMode).schedule(scheduleDuration).dispatchPredicate(DispatchPredicate.DISPATCH_NEVER).build()
 
         val totalTime = measureTimeMillis {
             val extensionProviders = applicationContext


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This PR adds a new set of data loader properties. 
1. Renames the configuration property for enabling the ticker mode from `dgs.graphql.dataloaderTickerModeEnabled` to `dgs.graphql.dataloader.ticker-mode-enabled`
2. A new property for configuring the schedule duration of dataloaders `dgs.graphql.dataloader.scheduleDuration` when ticker mode is enabled.
