### PR TITLE
Add support for custom object mapper in GraphQLResponse

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -133,7 +133,13 @@ data class GraphQLResponse(
     fun hasErrors(): Boolean = errors.isNotEmpty()
 
     companion object {
-        val logger: Logger = LoggerFactory.getLogger(GraphQLResponse::class.java)
+        private val logger: Logger = LoggerFactory.getLogger(GraphQLResponse::class.java)
+
+        private val DEFAULT_MAPPER: ObjectMapper = jacksonObjectMapper()
+            .registerModule(JavaTimeModule())
+            .registerModule(ParameterNamesModule())
+            .registerModule(Jdk8Module())
+            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
 
         private val DEFAULT_MAPPER: ObjectMapper = jacksonObjectMapper()
             .registerModule(JavaTimeModule())

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -38,12 +38,19 @@ import org.slf4j.LoggerFactory
  * Representation of a GraphQL response, which may contain GraphQL errors.
  * This class gives convenient JSON parsing methods to get data out of the response.
  */
-data class GraphQLResponse(@Language("json") val json: String, val headers: Map<String, List<String>>) {
+data class GraphQLResponse(
+    @Language("json") val json: String,
+    val headers: Map<String, List<String>>,
+    val mapper: ObjectMapper
+) {
 
     /**
      * A JsonPath DocumentContext. Typically, only used internally.
      */
-    val parsed: DocumentContext = JsonPath.using(jsonPathConfig).parse(json)
+    val parsed: DocumentContext = JsonPath.using(Configuration.builder()
+        .jsonProvider(JacksonJsonProvider(mapper))
+        .mappingProvider(JacksonMappingProvider(mapper)).build()
+        .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL)).parse(json)
 
     /**
      * Map representation of data
@@ -53,6 +60,14 @@ data class GraphQLResponse(@Language("json") val json: String, val headers: Map<
     val errors: List<GraphQLError> = parsed.read("errors", jsonTypeRef<List<GraphQLError>>()) ?: emptyList()
 
     constructor(@Language("json") json: String) : this(json, emptyMap())
+    constructor(@Language("json") json: String, headers: Map<String, List<String>>) : this(json,
+        headers,
+        // default object mapper instead no instance is passed in the constructor
+        jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .registerModule(ParameterNamesModule())
+        .registerModule(Jdk8Module())
+        .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE))
 
     /**
      * Deserialize data into the given class.
@@ -118,18 +133,7 @@ data class GraphQLResponse(@Language("json") val json: String, val headers: Map<
     fun hasErrors(): Boolean = errors.isNotEmpty()
 
     companion object {
-        private val logger: Logger = LoggerFactory.getLogger(GraphQLResponse::class.java)
-
-        private val mapper: ObjectMapper = jacksonObjectMapper()
-            .registerModule(JavaTimeModule())
-            .registerModule(ParameterNamesModule())
-            .registerModule(Jdk8Module())
-            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
-
-        private val jsonPathConfig: Configuration = Configuration.builder()
-            .jsonProvider(JacksonJsonProvider(mapper))
-            .mappingProvider(JacksonMappingProvider(mapper)).build()
-            .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL)
+        val logger: Logger = LoggerFactory.getLogger(GraphQLResponse::class.java)
 
         fun getDataPath(path: String): String {
             return if (path == "data" || path.startsWith("data.")) {

--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -141,12 +141,6 @@ data class GraphQLResponse(
             .registerModule(Jdk8Module())
             .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
 
-        private val DEFAULT_MAPPER: ObjectMapper = jacksonObjectMapper()
-            .registerModule(JavaTimeModule())
-            .registerModule(ParameterNamesModule())
-            .registerModule(Jdk8Module())
-            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
-
         fun getDataPath(path: String): String {
             return if (path == "data" || path.startsWith("data.")) {
                 path

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
@@ -18,6 +18,9 @@
 
 package com.netflix.graphql.dgs.client
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import graphql.relay.DefaultPageInfo
+import graphql.relay.PageInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -256,5 +259,16 @@ class GraphQLResponseTest {
         val response = GraphQLResponse("""{"data": {"submitReview": {"submittedBy": "abc@netflix.com"}}}""")
         val result = response.dataAsObject(Response::class.java)
         assertEquals(Response(submitReview = mapOf("submittedBy" to "abc@netflix.com")), result)
+    }
+
+    @Test
+    fun injectObjectMapper() {
+        val customObjectMapper = ObjectMapper()
+        val graphQLResponse =
+            GraphQLResponse(
+                """{"data": {"submitReview": {"submittedBy": "abc@netflix.com"}}}""",
+                emptyMap(),
+                customObjectMapper)
+        assertEquals(customObjectMapper, graphQLResponse.mapper)
     }
 }

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/GraphQLResponseTest.kt
@@ -18,9 +18,6 @@
 
 package com.netflix.graphql.dgs.client
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import graphql.relay.DefaultPageInfo
-import graphql.relay.PageInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -259,16 +256,5 @@ class GraphQLResponseTest {
         val response = GraphQLResponse("""{"data": {"submitReview": {"submittedBy": "abc@netflix.com"}}}""")
         val result = response.dataAsObject(Response::class.java)
         assertEquals(Response(submitReview = mapOf("submittedBy" to "abc@netflix.com")), result)
-    }
-
-    @Test
-    fun injectObjectMapper() {
-        val customObjectMapper = ObjectMapper()
-        val graphQLResponse =
-            GraphQLResponse(
-                """{"data": {"submitReview": {"submittedBy": "abc@netflix.com"}}}""",
-                emptyMap(),
-                customObjectMapper)
-        assertEquals(customObjectMapper, graphQLResponse.mapper)
     }
 }


### PR DESCRIPTION
The default object mapper is not enough to satisfy all deserialization scenarios.
One such scenario is where we need object mapper with custom deserializer for graphql.relay.PageInfo.

Pull request checklist
----

- [ ] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_

