### PR TITLE
Conditional on bean name for dgsAsyncTaskExecutor

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -312,7 +312,7 @@ open class DgsAutoConfiguration(
     @Bean
     @Qualifier("dgsAsyncTaskExecutor")
     @ConditionalOnJava21
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(name = ["dgsAsyncTaskExecutor"])
     @ConditionalOnProperty(name = ["dgs.graphql.virtualthreads.enabled"], havingValue = "true", matchIfMissing = false)
     open fun virtualThreadsTaskExecutor(): AsyncTaskExecutor {
         LOG.info("Enabling virtual threads for DGS")


### PR DESCRIPTION
Check for bean name in the conditional for the virtualThreadTaskExecutor. Otherwise it will match on any AsyncTaskExecutor, which comes out of the box with spring.


