### PR TITLE
Allow websocketSubscriptionHandler Bean to be overridden. 

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxAutoConfiguration.kt
@@ -203,6 +203,7 @@ open class DgsWebFluxAutoConfiguration(private val configProps: DgsWebfluxConfig
     }
 
     @Bean
+    @ConditionalOnMissingBean
     open fun websocketSubscriptionHandler(dgsReactiveQueryExecutor: DgsReactiveQueryExecutor, webfluxConfigurationProperties: DgsWebfluxConfigurationProperties): SimpleUrlHandlerMapping {
         val simpleUrlHandlerMapping =
             SimpleUrlHandlerMapping(mapOf(webfluxConfigurationProperties.websocket.path to DgsReactiveWebsocketHandler(dgsReactiveQueryExecutor, webfluxConfigurationProperties.websocket.connectionInitTimeout)))


### PR DESCRIPTION
Pull request checklist
----

- [X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #


Currently the implementation of the WebsocketGraphQLTransportWSProtocolHandler does have any functionality to authenticate token in the connection_init message. This is a problem because the graphql-ws library from NPM only supports authentication method within the connection_init message i.e. 

```
  const wsLink = new GraphQLWsLink(
        createClient({
          url: WS_LINK,
          connectionParams: async () => {
            const credentials = await getCredentials();
            if (credentials) {
              return {
                Authorization: `Bearer ${credentials.accessToken}`,
              };
            }
          },
        }),
```

Therefore I needed to write my own WebsocketReactiveProtocolHandler which populates the security context if a CONNECTION_INIT message is sent. 

Alternatives considered
----

_Describe alternative implementation you have considered_

