### PR TITLE
GraphiQL: Allow to prefix a subpath to the /graphql endpoint

### DIFF
--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebfluxConfigurationProperties.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebfluxConfigurationProperties.kt
@@ -52,7 +52,9 @@ class DgsWebfluxConfigurationProperties(
         /** Path to the GraphiQL endpoint without trailing slash. */
         @DefaultValue("/graphiql") var path: String = "/graphiql",
         /** GraphiQL title */
-        @DefaultValue("Simple GraphiQL Example") var title: String = "Simple GraphiQL Example"
+        @DefaultValue("Simple GraphiQL Example") var title: String = "Simple GraphiQL Example",
+        /** Subpath that GraphiQL should include when calling the GraphQL endpoint */
+        @DefaultValue("") var subpath: String = ""
     )
 
     /**
@@ -67,8 +69,15 @@ class DgsWebfluxConfigurationProperties(
     fun validatePaths() {
         validatePath(this.path, "dgs.graphql.path")
         validatePath(this.graphiql.path, "dgs.graphql.graphiql.path")
+        validateOptionalPath(this.graphiql.subpath, "dgs.graphql.graphiql.subpath")
         validatePath(this.schemaJson.path, "dgs.graphql.schema-json.path")
         validatePath(this.websocket.path, "dgs.graphql.websocket.path")
+    }
+
+    private fun validateOptionalPath(path: String, pathProperty: String) {
+        if ("" != path) {
+            validatePath(path, pathProperty)
+        }
     }
 
     private fun validatePath(path: String, pathProperty: String) {

--- a/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphiQlConfigurer.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphiQlConfigurer.kt
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets
 
 class GraphiQlConfigurer(private val configProps: DgsWebfluxConfigurationProperties) : WebFluxConfigurer {
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
-        val graphqlPath = configProps.path
+        val graphqlPath = configProps.graphiql.subpath + configProps.path
         val graphiQLTitle = configProps.graphiql.title
         registry
             .addResourceHandler(configProps.graphiql.path + "/**")

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxConfigurationPropertiesValidationTest.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/DgsWebFluxConfigurationPropertiesValidationTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.webmvc.autoconfigure
+package com.netflix.graphql.dgs.webflux.autoconfiguration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Configuration
 
-class DgsWebMvcConfigurationPropertiesValidationTest {
+class DgsWebFluxConfigurationPropertiesValidationTest {
 
     private val context = ApplicationContextRunner().withConfiguration(
         AutoConfigurations.of(
@@ -148,6 +148,6 @@ class DgsWebMvcConfigurationPropertiesValidationTest {
     }
 
     @Configuration
-    @EnableConfigurationProperties(DgsWebMvcConfigurationProperties::class)
+    @EnableConfigurationProperties(DgsWebfluxConfigurationProperties::class)
     open class MockConfigPropsAutoConfiguration
 }

--- a/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphQlCustomSubpath.kt
+++ b/graphql-dgs-spring-webflux-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webflux/autoconfiguration/GraphQlCustomSubpath.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webflux.autoconfiguration
+
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.web.reactive.config.EnableWebFlux
+
+@AutoConfigureWebTestClient
+@EnableWebFlux
+@SpringBootTest(
+    classes = [DgsWebFluxAutoConfiguration::class, DgsAutoConfiguration::class, WebRequestTestWithCustomEndpoint.ExampleImplementation::class],
+    properties = ["dgs.graphql.graphiql.subpath=/server/mid"]
+)
+class GraphQlCustomSubpath(@Autowired private val webTestClient: WebTestClient) {
+
+    @Test
+    fun customGraphiQlSubpath() {
+        webTestClient.get().uri("/graphiql/index.html")
+            .exchange()
+            .expectStatus()
+            .is2xxSuccessful
+            .expectBody<String>()
+            .consumeWith { Assertions.assertThat(it.responseBody).contains("fetch(origin + '/server/mid/graphql"); }
+    }
+}

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationProperties.kt
@@ -39,7 +39,9 @@ data class DgsWebMvcConfigurationProperties(
         /** Path to the GraphiQL endpoint without trailing slash. */
         @DefaultValue("/graphiql") var path: String = "/graphiql",
         /** GraphiQL title */
-        @DefaultValue("Simple GraphiQL Example") var title: String = "Simple GraphiQL Example"
+        @DefaultValue("Simple GraphiQL Example") var title: String = "Simple GraphiQL Example",
+        /** Subpath that GraphiQL should include when calling the GraphQL endpoint */
+        @DefaultValue("") var subpath: String = ""
     )
 
     /**
@@ -54,7 +56,14 @@ data class DgsWebMvcConfigurationProperties(
     fun validatePaths() {
         validatePath(this.path, "dgs.graphql.path")
         validatePath(this.graphiql.path, "dgs.graphql.graphiql.path")
+        validateOptionalPath(this.graphiql.subpath, "dgs.graphql.graphiql.subpath")
         validatePath(this.schemaJson.path, "dgs.graphql.schema-json.path")
+    }
+
+    private fun validateOptionalPath(path: String, pathProperty: String) {
+        if ("" != path) {
+            validatePath(path, pathProperty)
+        }
     }
 
     private fun validatePath(path: String, pathProperty: String) {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLConfigurer.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLConfigurer.kt
@@ -49,7 +49,7 @@ open class GraphiQLConfigurer(
     }
 
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
-        val graphqlPath = servletContext.contextPath + configProps.path
+        val graphqlPath = servletContext.contextPath + configProps.graphiql.subpath + configProps.path
         logger.info("Configuring GraphiQL to use GraphQL endpoint at '{}'", graphqlPath)
         registry
             .addResourceHandler("/graphiql/**")

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcConfigurationPropertiesTest.kt
@@ -62,6 +62,12 @@ class DgsWebMvcConfigurationPropertiesTest {
     }
 
     @Test
+    fun graphiQLGraphQLSubpathDefault() {
+        val properties = bind(Collections.emptyMap())
+        assertThat(properties.graphiql.subpath).isEqualTo("")
+    }
+
+    @Test
     fun schemaJsonPathDefault() {
         val properties = bind(Collections.emptyMap())
         assertThat(properties.schemaJson.path).isEqualTo("/schema.json")

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLSubpathConfigWithCustomPathsTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLSubpathConfigWithCustomPathsTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.autoconfigure
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "dgs.graphql.path=/api",
+        "dgs.graphql.graphiql.path=/docs",
+        "dgs.graphql.graphiql.subpath=/server/mid"
+    ]
+)
+class GraphiQLSubpathConfigWithCustomPathsTest(@Autowired val restTemplate: TestRestTemplate) {
+
+    @Test
+    fun customGraphiQLSubpath() {
+        val entity = restTemplate.getForEntity(
+            "/docs",
+            String::class.java
+        )
+        assertTrue(entity.statusCode.is2xxSuccessful)
+        Assertions.assertThat(entity.body).isNotNull.contains("fetch(origin + '/server/mid/api'")
+    }
+}

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLSubpathConfigWithDefaultPathsTest.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/GraphiQLSubpathConfigWithDefaultPathsTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.webmvc.autoconfigure
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = ["dgs.graphql.graphiql.subpath=/server/mid"]
+)
+class GraphiQLSubpathConfigWithDefaultPathsTest(@Autowired val restTemplate: TestRestTemplate) {
+
+    @Test
+    fun defaultPaths() {
+        val entity = restTemplate.getForEntity(
+            "/graphiql",
+            String::class.java
+        )
+        assertTrue(entity.statusCode.is2xxSuccessful)
+        Assertions.assertThat(entity.body).isNotNull.contains("fetch(origin + '/server/mid/graphql'")
+    }
+}


### PR DESCRIPTION
Pull Request type
----

- [ t] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

**Current scenario**:
- Graphql server gets traffic redirected from `domain.com/backend/*`
- If we load GraphiQL at `domain.com/backend/graphiql`, it tries to run queries against `domain.com/graphql` (contextPath + graphql path)

**Proposed solution**:
Make the subpath configurable, for example
`dgs.graphql.graphiql.subpath: /backend`

So in the previous scenario, GraphiQL will run queries against `domain.com/backend/graphql`


**Alternatives considered**:
Maybe get the full path instead of servletContext.contextPath in GraphiQLConfigurer#addResourceHandlers, eliminating the need of a new property. I thought it could be cleaner but less customisable (and I'm not sure if it's possible in all cases).


Also, other names for the property that came to my mind:
- `dgs.graphql.graphiql.graphql-subpath`
- `dgs.graphql.graphiql.graphql-url-prefix`
_I discarded them because I thought it was a bit confusing having 'graphql' again in the same prop_

Relates to issue #831
----



