### PR TITLE
Fix handling of UnknownOperationException

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultDgsQueryExecutor.kt
@@ -101,7 +101,7 @@ class DefaultDgsQueryExecutor(
         if (result.errors.size > 0) {
             val nullValueError = result.errors.find { it is NonNullableFieldWasNullError }
             if (nullValueError != null) {
-                logger.error(nullValueError.message)
+                logger.error("{}", nullValueError.message)
             }
         }
 


### PR DESCRIPTION
When GraphQL.executeAsync throws UnknownOperationException, or any exception implementing GraphQLError, set the status to BAD_REQUEST / 400 in BaseDgsQueryExecutor. Fixes #1751.