### PR TITLE
Avoid wrapping checked Exceptions in DataFetcherInvoker

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/CompletableFutureWrapper.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/CompletableFutureWrapper.kt
@@ -38,10 +38,8 @@ internal class CompletableFutureWrapper(private val taskExecutor: AsyncTaskExecu
      * Wrap the call to a data fetcher in CompletableFuture to enable parallel behavior.
      * Used when virtual threads are enabled.
      */
-    fun wrapInCompletableFuture(function: () -> Any?): Any? {
-        return CompletableFuture.supplyAsync({
-            return@supplyAsync function.invoke()
-        }, taskExecutor)
+    fun wrapInCompletableFuture(function: () -> Any?): CompletableFuture<Any?> {
+        return CompletableFuture.supplyAsync({ function() }, taskExecutor)
     }
 
     /**


### PR DESCRIPTION
DataFetcherInvoker implements the DataFetcher interface, and its "get" method declares that it throws Exception, which means propagating checked exceptions is not a problem. Howver, we were leveraging the Spring helper method, ReflectionUtils.handleReflectionException, which is designed to be called from methods that do not throw any checked exceptions, so we were ending up wrapping them unnecessarily in UndeclaredThrowableException. This caused an unnecessary layer of indirection that would need to be dealt with for example in a DataFetcherExceptionHandler.

To avoid the problem, stop using the Spring utility to invoke methods reflectively in DataFetcherInvoker, and leverage our own helper method that never throws UndeclaredThrowableException.

Fixes #1098 