### PR TITLE
Use Jackson2ObjectMapperBuilder to construct Jackson mapper

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClients.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLClients.kt
@@ -22,14 +22,17 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 
 internal object GraphQLClients {
 
-    internal val objectMapper: ObjectMapper = ObjectMapper().registerModule(
-        KotlinModule.Builder()
-            .enable(KotlinFeature.NullIsSameAsDefault)
-            .build()
-    )
+    internal val objectMapper: ObjectMapper = Jackson2ObjectMapperBuilder.json()
+        .modulesToInstall(
+            KotlinModule.Builder()
+                .enable(KotlinFeature.NullIsSameAsDefault)
+                .build()
+        )
+        .build()
 
     internal val defaultHeaders: HttpHeaders = HttpHeaders.readOnlyHttpHeaders(
         HttpHeaders().apply {

--- a/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfiguration.kt
+++ b/graphql-dgs-spring-webmvc-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/webmvc/autoconfigure/DgsWebMvcAutoConfiguration.kt
@@ -18,7 +18,7 @@ package com.netflix.graphql.dgs.webmvc.autoconfigure
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.internal.DgsSchemaProvider
 import com.netflix.graphql.dgs.internal.method.ArgumentResolver
@@ -42,6 +42,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.method.annotation.RequestHeaderMapMethodArgumentResolver
 import org.springframework.web.method.annotation.RequestHeaderMethodArgumentResolver
@@ -60,7 +61,9 @@ open class DgsWebMvcAutoConfiguration {
     @Qualifier("dgsObjectMapper")
     @ConditionalOnMissingBean(name = ["dgsObjectMapper"])
     open fun dgsObjectMapper(): ObjectMapper {
-        return jacksonObjectMapper().registerModule(JavaTimeModule())
+        return Jackson2ObjectMapperBuilder.json()
+            .modulesToInstall(KotlinModule.Builder().build(), JavaTimeModule())
+            .build()
     }
 
     @Bean


### PR DESCRIPTION
Switch to using Spring's Jackson2ObjectMapperBuilder to construct the Jackson ObjectMapper instance in GraphQLClients and DgsWebMvcAutoConfiguration, since the builder will automatically install well-known modules (such as JavaTimeModule) if they are present on the class path.

Fixes #1461 
