### PR TITLE
Allow connection directive to be applied to Unions and Interfaces

### DIFF
--- a/graphql-dgs-pagination/src/main/kotlin/com/netflix/graphql/dgs/pagination/DgsPaginationTypeDefinitionRegistry.kt
+++ b/graphql-dgs-pagination/src/main/kotlin/com/netflix/graphql/dgs/pagination/DgsPaginationTypeDefinitionRegistry.kt
@@ -40,7 +40,10 @@ class DgsPaginationTypeDefinitionRegistry {
             val directive = DirectiveDefinition.newDirectiveDefinition()
                 .name(CONNECTION_DIRECTIVE_NAME)
                 .description(createDescription("Connection"))
-                .directiveLocation(DirectiveLocation.newDirectiveLocation().name(Introspection.DirectiveLocation.OBJECT.name).build()).build()
+                .directiveLocation(DirectiveLocation.newDirectiveLocation().name(Introspection.DirectiveLocation.OBJECT.name).build())
+                .directiveLocation(DirectiveLocation.newDirectiveLocation().name(Introspection.DirectiveLocation.INTERFACE.name).build())
+                .directiveLocation(DirectiveLocation.newDirectiveLocation().name(Introspection.DirectiveLocation.UNION.name).build())
+                .build()
             typeDefinitionRegistry.add(directive)
         }
 


### PR DESCRIPTION
DgsPaginationTypeDefinitionRegistry generated a connection directive which could only be applied to Object types; update it to allow Union and Interfaces as well.

There were tests for this scenario but they didn't catch the problem because they never built a GraphQLSchema. To avoid such issues, switch all of the tests to fully build a GraphQLSchema.

Fixes #1317.