### PR TITLE
Fix DGS Micrometer timer configuration

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsProperties.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsProperties.kt
@@ -1,7 +1,6 @@
 package com.netflix.graphql.dgs.metrics.micrometer
 
 import org.springframework.boot.actuate.autoconfigure.metrics.AutoTimeProperties
-import org.springframework.boot.actuate.autoconfigure.metrics.PropertiesAutoTimer
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.boot.context.properties.bind.DefaultValue
@@ -9,16 +8,15 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 @ConfigurationProperties("management.metrics.dgs-graphql")
 data class DgsGraphQLMetricsProperties(
     /** Auto-timed queries settings. */
-    var autotimeProperties: AutoTimeProperties = AutoTimeProperties(),
-    /** Auto-timer. */
     @NestedConfigurationProperty
-    var autotime: PropertiesAutoTimer = PropertiesAutoTimer(autotimeProperties),
+    var autotime: AutoTimeProperties = AutoTimeProperties(),
     /** Settings that can be used to limit some of the tag metrics used by DGS. */
     @NestedConfigurationProperty
     var tags: TagsProperties = TagsProperties(),
     /** Settings to selectively enable/disable gql timers.*/
     @NestedConfigurationProperty
     var resolver: ResolverMetricProperties = ResolverMetricProperties(),
+    @NestedConfigurationProperty
     var query: QueryMetricProperties = QueryMetricProperties()
 
 ) {

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMicrometerAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMicrometerAutoConfiguration.kt
@@ -12,6 +12,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.metrics.PropertiesAutoTimer
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -53,12 +54,13 @@ open class DgsGraphQLMicrometerAutoConfiguration {
         optQuerySignatureRepository: Optional<QuerySignatureRepository>
     ): DgsGraphQLMetricsInstrumentation {
         return DgsGraphQLMetricsInstrumentation(
-            dgsSchemaProvider,
-            meterRegistrySupplier,
-            tagsProvider,
-            properties,
-            limitedTagMetricResolver,
-            optQuerySignatureRepository
+            schemaProvider = dgsSchemaProvider,
+            registrySupplier = meterRegistrySupplier,
+            tagsProvider = tagsProvider,
+            properties = properties,
+            limitedTagMetricResolver = limitedTagMetricResolver,
+            optQuerySignatureRepository = optQuerySignatureRepository,
+            autoTimer = PropertiesAutoTimer(properties.autotime)
         )
     }
 
@@ -125,9 +127,9 @@ open class DgsGraphQLMicrometerAutoConfiguration {
             optCacheManager: Optional<CacheManager>
         ): QuerySignatureRepository {
             return CacheableQuerySignatureRepository(
-                properties,
-                meterRegistrySupplier,
-                optCacheManager
+                autoTimer = PropertiesAutoTimer(properties.autotime),
+                meterRegistrySupplier = meterRegistrySupplier,
+                optionalCacheManager = optCacheManager
             )
         }
 
@@ -137,7 +139,7 @@ open class DgsGraphQLMicrometerAutoConfiguration {
             properties: DgsGraphQLMetricsProperties,
             meterRegistrySupplier: DgsMeterRegistrySupplier
         ): QuerySignatureRepository {
-            return SimpleQuerySignatureRepository(properties, meterRegistrySupplier)
+            return SimpleQuerySignatureRepository(PropertiesAutoTimer(properties.autotime), meterRegistrySupplier)
         }
     }
 

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/utils/CacheableQuerySignatureRepository.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/utils/CacheableQuerySignatureRepository.kt
@@ -18,12 +18,12 @@ package com.netflix.graphql.dgs.metrics.micrometer.utils
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.netflix.graphql.dgs.Internal
-import com.netflix.graphql.dgs.metrics.micrometer.DgsGraphQLMetricsProperties
 import com.netflix.graphql.dgs.metrics.micrometer.DgsMeterRegistrySupplier
 import graphql.language.Document
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.boot.actuate.metrics.AutoTimer
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
 import org.springframework.cache.caffeine.CaffeineCacheManager
@@ -53,10 +53,10 @@ import java.util.*
  */
 @Internal
 open class CacheableQuerySignatureRepository(
-    properties: DgsGraphQLMetricsProperties,
+    autoTimer: AutoTimer,
     meterRegistrySupplier: DgsMeterRegistrySupplier,
     private val optionalCacheManager: Optional<CacheManager>
-) : SimpleQuerySignatureRepository(properties, meterRegistrySupplier) {
+) : SimpleQuerySignatureRepository(autoTimer, meterRegistrySupplier) {
 
     private lateinit var cache: Cache
 

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/utils/SimpleQuerySignatureRepository.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/utils/SimpleQuerySignatureRepository.kt
@@ -19,7 +19,6 @@ package com.netflix.graphql.dgs.metrics.micrometer.utils
 import com.netflix.graphql.dgs.Internal
 import com.netflix.graphql.dgs.metrics.DgsMetrics.CommonTags
 import com.netflix.graphql.dgs.metrics.DgsMetrics.InternalMetric
-import com.netflix.graphql.dgs.metrics.micrometer.DgsGraphQLMetricsProperties
 import com.netflix.graphql.dgs.metrics.micrometer.DgsMeterRegistrySupplier
 import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters
 import graphql.language.Document
@@ -29,6 +28,7 @@ import io.micrometer.core.instrument.Timer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.InitializingBean
+import org.springframework.boot.actuate.metrics.AutoTimer
 import java.util.*
 
 /**
@@ -38,7 +38,7 @@ import java.util.*
  */
 @Internal
 open class SimpleQuerySignatureRepository(
-    private val properties: DgsGraphQLMetricsProperties,
+    private val autoTimer: AutoTimer,
     private val meterRegistrySupplier: DgsMeterRegistrySupplier
 ) : QuerySignatureRepository, InitializingBean {
 
@@ -77,7 +77,7 @@ open class SimpleQuerySignatureRepository(
             tags += CommonTags.JAVA_CLASS.tags(this)
             tags += CommonTags.JAVA_CLASS_METHOD.tags("get")
             timerSample.stop(
-                properties.autotime
+                autoTimer
                     .builder(InternalMetric.TIMED_METHOD.key)
                     .tags(tags)
                     .register(meterRegistry)


### PR DESCRIPTION
A recent update broke the documented autotime-related properties that live under "management.metrics.dgs-graphql.autotime", since it renamed the property on the DgsGraphQLMetricsProperties class from "autoTime" to "autoTimeProperties". Fix the naming to restore the old config prefix, and add a test case that covers it.

Additionally, move the AutoTimer / PropertiesAutoTimer out of DgsGraphQLMetricsProperties, and make it a dependency of DgsGraphQLMetricsInstrumentation and the other classes that depend on it.

Bug was introduced in 21e625a; this PR fixes #1249.