### PR TITLE
Fix classification type in GraphQLErrorExtensions

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLError.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLError.kt
@@ -41,7 +41,7 @@ data class GraphQLErrorExtensions(
     @JsonProperty val errorDetail: String? = null,
     @JsonProperty val origin: String = "",
     @JsonProperty val debugInfo: GraphQLErrorDebugInfo = GraphQLErrorDebugInfo(),
-    @JsonProperty val classification: String = ""
+    @JsonProperty val classification: Any = ""
 )
 
 data class GraphQLErrorDebugInfo(


### PR DESCRIPTION
GraphQLErrorExtensions' classification property had a type of String, but in practice an ErrorClassification may be mapped to any JSON serializable type; this is actually the case in practice when using libraries such as graphql-java-extended-validation, which may return a Map for its ErrorClassification. Switch the type to Any, so that such responses can be deserialized, and add a simple test case.

Fixes #1146