### PR TITLE
Add mock provider support for interface, union, and enum types

### DIFF
--- a/graphql-dgs-mocking/build.gradle.kts
+++ b/graphql-dgs-mocking/build.gradle.kts
@@ -18,4 +18,6 @@ dependencies {
     api("com.graphql-java:graphql-java")
     implementation("net.datafaker:datafaker:2.+")
     implementation("org.slf4j:slf4j-api")
+
+    testImplementation("org.assertj:assertj-core")
 }

--- a/graphql-dgs-mocking/src/main/kotlin/com/netflix/graphql/mocking/MockGraphQLVisitor.kt
+++ b/graphql-dgs-mocking/src/main/kotlin/com/netflix/graphql/mocking/MockGraphQLVisitor.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.mocking
 
+import graphql.Scalars
+import graphql.introspection.Introspection
 import graphql.schema.*
 import graphql.util.TraversalControl
 import graphql.util.TraverserContext
@@ -24,64 +26,103 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class MockGraphQLVisitor(private val mockConfig: Map<String, Any?>, private val mockFetchers: MutableMap<FieldCoordinates, DataFetcher<*>>) : GraphQLTypeVisitorStub() {
-    private val logger: Logger = LoggerFactory.getLogger(this.javaClass)
-    private val providedRoots: MutableList<String?> = mutableListOf()
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(MockGraphQLVisitor::class.java)
+    }
+    private val additionalObjectTypes = mutableSetOf<GraphQLObjectType>()
+    private val providedRoots: MutableList<String> = mutableListOf()
     private val faker = Faker()
 
-    override fun visitGraphQLFieldDefinition(node: GraphQLFieldDefinition?, context: TraverserContext<GraphQLSchemaElement>?): TraversalControl {
-        val pathForNode = getPathForNode(context?.parentNodes, node)
+    override fun visitGraphQLFieldDefinition(node: GraphQLFieldDefinition, context: TraverserContext<GraphQLSchemaElement>): TraversalControl {
+        val parentNode = context.parentNode as GraphQLFieldsContainer
+        if (Introspection.isIntrospectionTypes(parentNode)) {
+            return TraversalControl.CONTINUE
+        }
 
-        if (mockConfig.keys.any { pathForNode?.startsWith(it) == true } && !providedRoots.any { pathForNode?.startsWith(it!!) == true && pathForNode.count { c -> c == '.' } != it?.count { c -> c == '.' } }) {
-            val type = if (node?.type is GraphQLNonNull) (node.type as GraphQLNonNull).wrappedType else node?.type
+        val pathForNode = getPathForNode(context.parentNodes, node)
+
+        if (parentNode in additionalObjectTypes || (mockConfig.keys.any { pathForNode.startsWith(it) } && !providedRoots.any { pathForNode.startsWith(it) && pathForNode.count { c -> c == '.' } != it.count { c -> c == '.' } })) {
+            if (parentNode is GraphQLInterfaceType) {
+                val schema = context.getVarFromParents(GraphQLSchema::class.java)
+                for (objType in schema.getImplementations(parentNode)) {
+                    if (objType !in context.visitedNodes()) {
+                        additionalObjectTypes += objType
+                    }
+                }
+                return TraversalControl.CONTINUE
+            }
+
+            val type = GraphQLTypeUtil.unwrapNonNull(node.type)
 
             val dataFetcher: DataFetcher<*> = if (mockConfig[pathForNode] != null) {
                 logger.info("Returning provided mock data for {}", pathForNode)
-                providedRoots.add(pathForNode)
+                providedRoots += pathForNode
                 getProvidedMockData(pathForNode)
             } else {
                 logger.info("Generating mock data for {}", pathForNode)
                 when (type) {
                     is GraphQLScalarType -> {
-                        DataFetcher { generateDataForScalar(type.name) }
+                        StaticDataFetcher(generateDataForScalar(type))
+                    }
+                    is GraphQLEnumType -> {
+                        StaticDataFetcher(type.values.random().value)
                     }
                     is GraphQLList -> {
-                        val wrappedType = when (type.wrappedType) {
-                            is GraphQLNamedType -> (type.wrappedType as GraphQLNamedType).name
-                            else -> return super.visitGraphQLFieldDefinition(node, context)
+                        val elementType = GraphQLTypeUtil.unwrapNonNull(type.wrappedType)
+                        if (elementType !is GraphQLNamedType) {
+                            return TraversalControl.CONTINUE
                         }
-
-                        val mockedValues = (0..faker.number().numberBetween(0, 10))
-                            .map { generateDataForScalar(wrappedType) }
-                            .toList()
-                        DataFetcher { mockedValues }
+                        val mockedValues: Collection<Any?> = when (elementType) {
+                            is GraphQLScalarType -> (0..faker.number().numberBetween(0, 10))
+                                .map { generateDataForScalar(elementType) }
+                            is GraphQLEnumType -> (0..faker.number().numberBetween(0, 3))
+                                .asSequence()
+                                .map { elementType.values.random().name }
+                                .toSet()
+                            else -> (0..faker.number().numberBetween(0, 10)).map { dummyObject(elementType) }
+                        }
+                        StaticDataFetcher(mockedValues)
                     }
-                    else -> DataFetcher { Object() }
+                    else -> StaticDataFetcher(dummyObject(type))
                 }
             }
 
-            mockFetchers[FieldCoordinates.coordinates((context?.parentNode as GraphQLObjectType).name, node?.name)] = dataFetcher
+            mockFetchers[FieldCoordinates.coordinates(parentNode, node)] = dataFetcher
         }
 
-        return super.visitGraphQLFieldDefinition(node, context)
+        return TraversalControl.CONTINUE
     }
 
-    private fun generateDataForScalar(type: String): Any {
-        return when (type) {
-            "String" -> faker.book().title()
-            "Boolean" -> faker.bool().bool()
-            "Int" -> faker.number().randomDigit()
-            "Float" -> faker.number().randomDouble(2, 0, 100000)
-            "ID" -> faker.number().digit()
-            else -> Object()
+    private fun dummyObject(type: GraphQLType): Any {
+        val displayName = GraphQLTypeUtil.simplePrint(type)
+        return object {
+            override fun toString(): String {
+                return "DummyObject{type=$displayName}"
+            }
+        }
+    }
+
+    private fun generateDataForScalar(scalarType: GraphQLScalarType): Any {
+        return when (scalarType) {
+            Scalars.GraphQLString -> faker.book().title()
+            Scalars.GraphQLBoolean -> faker.bool().bool()
+            Scalars.GraphQLInt -> faker.number().randomDigit()
+            Scalars.GraphQLFloat -> faker.number().randomDouble(2, 0, 100000)
+            Scalars.GraphQLID -> faker.number().digit()
+            else -> return dummyObject(scalarType)
         }
     }
 
     private fun getProvidedMockData(pathForNode: String?): DataFetcher<*> {
         return when (val provided = mockConfig[pathForNode]) {
             is DataFetcher<*> -> provided
-            else -> DataFetcher { provided }
+            else -> StaticDataFetcher(provided)
         }
     }
 
-    private val getPathForNode = { parents: List<GraphQLSchemaElement>?, node: GraphQLFieldDefinition? -> parents?.filterIsInstance<GraphQLFieldDefinition>()?.map { it.name }?.fold(node?.name) { n, result -> "$result.$n" } }
+    private fun getPathForNode(parents: List<GraphQLSchemaElement>, node: GraphQLFieldDefinition): String {
+        return (parents.asReversed().asSequence().filterIsInstance<GraphQLFieldDefinition>() + sequenceOf(node))
+            .map { it.name }
+            .joinToString(".")
+    }
 }


### PR DESCRIPTION
graphl-dgs-mocking did not support interface or union types, and would cause an exception to be thrown if it encountered these types while traversing the schema. Add support for both types, as well as enums.

fixes #1634 