### PR TITLE
fix: cancel timer thread after websocket connection init task runs

### DIFF
--- a/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLTransportWSProtocolHandler.kt
+++ b/graphql-dgs-subscriptions-websockets/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/websockets/WebsocketGraphQLTransportWSProtocolHandler.kt
@@ -68,16 +68,18 @@ class WebsocketGraphQLTransportWSProtocolHandler(
 
     override fun afterConnectionEstablished(session: WebSocketSession) {
         contexts[session.id] = Context()
+        val timer = Timer()
+
         val timerTask = object : TimerTask() {
             override fun run() {
                 if (contexts[session.id]?.getConnectionInitReceived() == false) {
                     session.close(CloseStatus(CloseCode.ConnectionInitialisationTimeout.code))
                     contexts.remove(session.id)
                 }
+                timer.cancel()
             }
         }
 
-        val timer = Timer()
         timer.schedule(timerTask, connectionInitTimeout.toMillis())
     }
 


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first - issue https://github.com/Netflix/dgs-framework/issues/1805
- [ ] Make sure the PR doesn't introduce backward compatibility issues
- [ ] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Timer threads remain after `afterConnectionEstablished` timerTask completes resulting in a growing number of idle timer threads
Issue https://github.com/Netflix/dgs-framework/issues/1805

Alternatives considered
----


