### PR TITLE
Avoid overhead in loading DataLoaderInstrumentationExtensionProviders

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsAutoConfiguration.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.autoconfig
 
+import com.netflix.graphql.dgs.DataLoaderInstrumentationExtensionProvider
 import com.netflix.graphql.dgs.DgsDataLoaderOptionsProvider
 import com.netflix.graphql.dgs.DgsDefaultPreparsedDocumentProvider
 import com.netflix.graphql.dgs.DgsFederationResolver
@@ -166,8 +167,20 @@ open class DgsAutoConfiguration(
     }
 
     @Bean
-    open fun dgsDataLoaderProvider(applicationContext: ApplicationContext, dataloaderOptionProvider: DgsDataLoaderOptionsProvider, @Qualifier("dgsScheduledExecutorService") dgsScheduledExecutorService: ScheduledExecutorService): DgsDataLoaderProvider {
-        return DgsDataLoaderProvider(applicationContext, dataloaderOptionProvider, dgsScheduledExecutorService, dataloaderConfigProps.scheduleDuration, dataloaderConfigProps.tickerModeEnabled)
+    open fun dgsDataLoaderProvider(
+        applicationContext: ApplicationContext,
+        dataloaderOptionProvider: DgsDataLoaderOptionsProvider,
+        @Qualifier("dgsScheduledExecutorService") dgsScheduledExecutorService: ScheduledExecutorService,
+        extensionProviders: List<DataLoaderInstrumentationExtensionProvider>
+    ): DgsDataLoaderProvider {
+        return DgsDataLoaderProvider(
+            applicationContext = applicationContext,
+            extensionProviders = extensionProviders,
+            dataLoaderOptionsProvider = dataloaderOptionProvider,
+            scheduledExecutorService = dgsScheduledExecutorService,
+            scheduleDuration = dataloaderConfigProps.scheduleDuration,
+            enableTickerMode = dataloaderConfigProps.tickerModeEnabled
+        )
     }
 
     /**

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/MultiDataLoaderInstrumentationProvidersProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/MultiDataLoaderInstrumentationProvidersProviderTest.kt
@@ -71,8 +71,16 @@ internal class MultiDataLoaderInstrumentationProvidersProviderTest {
     class TailDataLoaderInstrumentationExtensionProvider(acc: MultiValueMap<String, String>) :
         BaseDataLoaderInstrumentationExtensionProvider(acc, "tail")
 
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     open class TestLocalConfiguration {
+
+        @Bean
+        open fun dgsDataLoaderProvider(applicationContext: ApplicationContext, extensionProviders: List<DataLoaderInstrumentationExtensionProvider>): DgsDataLoaderProvider {
+            return DgsDataLoaderProvider(
+                applicationContext = applicationContext,
+                extensionProviders = extensionProviders
+            )
+        }
 
         @Bean
         open fun testAcc(): MultiValueMap<String, String> {
@@ -118,11 +126,6 @@ internal class MultiDataLoaderInstrumentationProvidersProviderTest {
             acc: MultiValueMap<String, String>
         ): DataLoaderInstrumentationExtensionProvider {
             return TailDataLoaderInstrumentationExtensionProvider(acc)
-        }
-
-        @Bean
-        open fun dgsDataLoaderProvider(applicationContext: ApplicationContext): DgsDataLoaderProvider {
-            return DgsDataLoaderProvider(applicationContext)
         }
     }
 


### PR DESCRIPTION
DgsDataLoaderProvider was querying the ApplicationContext to find DataLoaderInstrumentationExtensionProvider instances on every invocation of its buildRegistryWithContextSupplier method; switch to wiring them up once in DgsAutoConfiguration.