### PR TITLE
Fix DgsDataLoaderRegistryConsumer when wrapped with Micrometer

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -266,56 +266,6 @@ class MicrometerServletSmokeTest {
                     false
                 )
             )
-
-//        val meters = fetchMeters()
-
-//        assertThat(meters).containsOnlyKeys("gql.dataLoader", "gql.query", "gql.resolver")
-//
-//        assertThat(meters["gql.dataLoader"]).isNotNull.hasSize(2)
-//        assertThat(meters["gql.dataLoader"]?.map { it.id.tags })
-//            .containsAll(
-//                listOf(
-//                    Tags.of("gql.loaderBatchSize", "2").and("gql.loaderName", "reverser").toList(),
-//                    Tags.of("gql.loaderBatchSize", "2").and("gql.loaderName", "upperCaseLoader").toList()
-//                )
-//            )
-//
-//        assertThat(meters["gql.query"]).isNotNull.hasSize(1)
-//        assertThat(meters["gql.query"]?.first()?.id?.tags)
-//            .containsAll(
-//                Tags.of("execution-tag", "foo")
-//                    .and("contextual-tag", "foo")
-//                    .and("outcome", "success")
-//                    .and("gql.operation", "QUERY")
-//                    .and("gql.operation.name", "anonymous")
-//                    .and("gql.query.complexity", "10")
-//                    .and("gql.query.sig.hash", MOCKED_QUERY_SIGNATURE.hash)
-//            )
-//
-//        assertThat(meters["gql.resolver"]?.first()?.id?.tags)
-//            .containsAll(
-//                Tags.of("gql.field", "Query.transform")
-//                    .and("field-fetch-tag", "foo")
-//                    .and("contextual-tag", "foo")
-//                    .and("outcome", "success")
-//                    .and("gql.operation", "QUERY")
-//                    .and("gql.operation.name", "anonymous")
-//                    .and("gql.query.complexity", "10")
-//                    .and("gql.query.sig.hash", MOCKED_QUERY_SIGNATURE.hash)
-//            )
-//
-//        assertThat(meters["gql.dataLoader"]).isNotNull.hasSize(2)
-//        assertThat(meters["gql.dataLoader"]?.map { it.id.tags })
-//            .containsAll(
-//                listOf(
-//                    Tags.of("gql.loaderBatchSize", "2")
-//                        .and("gql.loaderName", "reverser")
-//                        .toList(),
-//                    Tags.of("gql.loaderBatchSize", "2")
-//                        .and("gql.loaderName", "upperCaseLoader")
-//                        .toList()
-//                )
-//            )
     }
 
     @Test

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsWrapWithContextDataLoaderCustomizer.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsWrapWithContextDataLoaderCustomizer.kt
@@ -17,9 +17,11 @@
 package com.netflix.graphql.dgs.internal
 
 import com.netflix.graphql.dgs.DgsDataLoaderCustomizer
+import com.netflix.graphql.dgs.DgsDataLoaderRegistryConsumer
 import org.dataloader.BatchLoader
 import org.dataloader.BatchLoaderEnvironment
 import org.dataloader.BatchLoaderWithContext
+import org.dataloader.DataLoaderRegistry
 import org.dataloader.MappedBatchLoader
 import org.dataloader.MappedBatchLoaderWithContext
 import java.util.concurrent.CompletionStage
@@ -42,14 +44,28 @@ class DgsWrapWithContextDataLoaderCustomizer : DgsDataLoaderCustomizer {
     }
 }
 
-internal class BatchLoaderWithContextWrapper<K, V>(private val original: BatchLoader<K, V>) : BatchLoaderWithContext<K, V> {
+internal class BatchLoaderWithContextWrapper<K, V>(private val original: BatchLoader<K, V>) :
+    BatchLoaderWithContext<K, V>, DgsDataLoaderRegistryConsumer {
     override fun load(keys: List<K>, environment: BatchLoaderEnvironment): CompletionStage<List<V>> {
         return original.load(keys)
     }
+
+    override fun setDataLoaderRegistry(dataLoaderRegistry: DataLoaderRegistry?) {
+        if (original is DgsDataLoaderRegistryConsumer) {
+            (original as DgsDataLoaderRegistryConsumer).setDataLoaderRegistry(dataLoaderRegistry)
+        }
+    }
 }
 
-internal class MappedBatchLoaderWithContextWrapper<K, V>(private val original: MappedBatchLoader<K, V>) : MappedBatchLoaderWithContext<K, V> {
+internal class MappedBatchLoaderWithContextWrapper<K, V>(private val original: MappedBatchLoader<K, V>) :
+    MappedBatchLoaderWithContext<K, V>, DgsDataLoaderRegistryConsumer {
     override fun load(keys: Set<K>, environment: BatchLoaderEnvironment): CompletionStage<Map<K, V>> {
         return original.load(keys)
+    }
+
+    override fun setDataLoaderRegistry(dataLoaderRegistry: DataLoaderRegistry?) {
+        if (original is DgsDataLoaderRegistryConsumer) {
+            (original as DgsDataLoaderRegistryConsumer).setDataLoaderRegistry(dataLoaderRegistry)
+        }
     }
 }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithRegistryConsumer.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/ExampleBatchLoaderWithRegistryConsumer.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import org.dataloader.BatchLoader
+import org.dataloader.DataLoaderRegistry
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+@DgsDataLoader(name = "exampleBatchLoaderWithRegistryConsumer")
+class ExampleBatchLoaderWithRegistryConsumer : BatchLoader<String, String>, DgsDataLoaderRegistryConsumer {
+
+    private var dataLoaderRegistry: DataLoaderRegistry? = null
+
+    override fun load(keys: MutableList<String>?): CompletionStage<MutableList<String>> {
+        if (dataLoaderRegistry == null) {
+            throw IllegalStateException("DataLoaderRegistry is not set")
+        }
+        return CompletableFuture.supplyAsync { mutableListOf("a", "b", "c") }
+    }
+
+    override fun setDataLoaderRegistry(dataLoaderRegistry: DataLoaderRegistry?) {
+        dataLoaderRegistry?.let {
+            this.dataLoaderRegistry = it
+        }
+    }
+}


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [x] Bugfix

Changes in this PR
----

When DgsDataLoader is declared as DgsDataLoaderRegistryConsumer and micrometer wrapper is on. Then `batchLoader is DgsDataLoaderRegistryConsumer` condition willl not work beacuse MappedBatchLoaderWithContextInstrumentationDriver is not DgsDataLoaderRegistryConsumer


Alternatives considered:
----

I see two viable solutions, first - the one that is in this pull request. This solution isn't the most beautiful but it works
Second - make interface DataLoaderProxy with one method `fun getOriginal(): DataLoader`. With that we can always get the original dataloader within DgsDataLoaderProvider and setup Registry there

