### PR TITLE
Disable problematic autoconfigs from spring-graphql by default

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/ExcludeAutoConfigurationsEnvironmentPostProcessor.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/ExcludeAutoConfigurationsEnvironmentPostProcessor.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.springgraphql.autoconfig
+
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources
+import org.springframework.boot.env.EnvironmentPostProcessor
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.MapPropertySource
+import org.springframework.core.env.MutablePropertySources
+import java.util.*
+import java.util.stream.Collectors
+
+/**
+ * Globally disable AutoConfig's which cause problems in the Netflix environment
+ */
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+class ExcludeAutoConfigurationsEnvironmentPostProcessor : EnvironmentPostProcessor {
+
+    override fun postProcessEnvironment(environment: ConfigurableEnvironment, application: SpringApplication) {
+        val existingExcludes = extractAllExcludes(environment.propertySources)
+        val disabled = DISABLE_AUTOCONFIG_PROPERTIES
+            .asSequence()
+            .filter { !environment.getProperty(it.key, Boolean::class.java, false) }
+            .map { it.value }.plus(existingExcludes)
+            .filter { it.isNotEmpty() }
+            .joinToString(",")
+
+        environment.propertySources
+            .addFirst(
+                MapPropertySource(
+                    "disableRefreshScope",
+                    Collections.singletonMap<String, Any>(
+                        "spring.autoconfigure.exclude",
+                        disabled
+                    )
+                )
+            )
+    }
+
+    private fun extractAllExcludes(propertySources: MutablePropertySources): String {
+        return propertySources.stream()
+            .filter { src -> !ConfigurationPropertySources.isAttachedConfigurationPropertySource(src) }
+            .map { src ->
+                Binder(ConfigurationPropertySources.from(src))
+                    .bind(EXCLUDE, Array<String>::class.java)
+                    .map {
+                        it.toList()
+                    }.orElse(emptyList())
+            }.flatMap { it.stream() }
+            .collect(Collectors.joining(","))
+    }
+
+    companion object {
+        private val DISABLE_AUTOCONFIG_PROPERTIES = mapOf(
+            Pair(
+                "dgs.springgraphql.autoconfiguration.graphqlobservation.enabled",
+                "org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration"
+            ),
+            Pair(
+                "dgs.springgraphql.autoconfiguration.graphqlwebmvcsecurity.enabled",
+                "org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration"
+            )
+        )
+
+        private const val EXCLUDE = "spring.autoconfigure.exclude"
+    }
+}

--- a/graphql-dgs-spring-graphql/src/main/resources/META-INF/spring.factories
+++ b/graphql-dgs-spring-graphql/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,3 @@
-org.springframework.boot.env.EnvironmentPostProcessor=com.netflix.graphql.dgs.springgraphql.autoconfig.DgsSpringGraphQLEnvironmentPostProcessor
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  com.netflix.graphql.dgs.springgraphql.autoconfig.DgsSpringGraphQLEnvironmentPostProcessor,\
+  com.netflix.graphql.dgs.springgraphql.autoconfig.ExcludeAutoConfigurationsEnvironmentPostProcessor

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/ExcludeAutoConfigurationsEnvironmentPostProcessorTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/ExcludeAutoConfigurationsEnvironmentPostProcessorTest.kt
@@ -1,0 +1,52 @@
+package com.netflix.graphql.dgs.springgraphql.autoconfig
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.SpringApplication
+import org.springframework.core.env.MapPropertySource
+import org.springframework.core.env.StandardEnvironment
+
+class ExcludeAutoConfigurationsEnvironmentPostProcessorTest {
+    @Test
+    fun `disables unwanted auto-configurations`() {
+        val env = StandardEnvironment()
+        ExcludeAutoConfigurationsEnvironmentPostProcessor().postProcessEnvironment(env, SpringApplication())
+        assertThat(env.getProperty("spring.autoconfigure.exclude")).contains("org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration", "org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration")
+    }
+
+    @Test
+    fun `Security autoconfig can be enabled`() {
+        val env = StandardEnvironment()
+        env.propertySources.addLast(MapPropertySource("application-props", mapOf(Pair("dgs.springgraphql.autoconfiguration.graphqlwebmvcsecurity.enabled", "true"))))
+
+        ExcludeAutoConfigurationsEnvironmentPostProcessor().postProcessEnvironment(env, SpringApplication())
+        assertThat(env.getProperty("spring.autoconfigure.exclude"))
+            .contains("org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration")
+            .doesNotContain("org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration")
+    }
+
+    @Test
+    fun `Observation autoconfig can be enabled`() {
+        val env = StandardEnvironment()
+        env.propertySources.addLast(MapPropertySource("application-props", mapOf(Pair("dgs.springgraphql.autoconfiguration.graphqlobservation.enabled", "true"))))
+
+        ExcludeAutoConfigurationsEnvironmentPostProcessor().postProcessEnvironment(env, SpringApplication())
+        assertThat(env.getProperty("spring.autoconfigure.exclude"))
+            .contains("org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration")
+            .doesNotContain("org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration")
+    }
+
+    @Test
+    fun `does not override existing excludes`() {
+        val env = StandardEnvironment()
+        env.propertySources.addLast(MapPropertySource("application-props", mapOf(Pair("spring.autoconfigure.exclude", "someexclude"))))
+
+        ExcludeAutoConfigurationsEnvironmentPostProcessor().postProcessEnvironment(env, SpringApplication())
+        assertThat(env.getProperty("spring.autoconfigure.exclude"))
+            .contains(
+                "someexclude",
+                "org.springframework.boot.actuate.autoconfigure.observation.graphql.GraphQlObservationAutoConfiguration",
+                "org.springframework.boot.autoconfigure.graphql.security.GraphQlWebMvcSecurityAutoConfiguration"
+            )
+    }
+}


### PR DESCRIPTION

Pull Request type
----

- [ ] Bugfix
- [ x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
* GraphQlObservationAutoConfiguration: Unneeded since DGS already takes care of metrics
* GraphQlWebMvcSecurityAutoConfiguration: This changes how security errors are handled, which would break the expectations from the errors spec.

This uses the `spring.autoconfigure.exclude` property to exclude the autoconfigs, while not overriding what the user might have excluded already.

The PR also introduces properties to explicitly enable the autoconfigs if wanted.