### PR TITLE
Use micrometer context propagation for virtual thread executor

### DIFF
--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -848,6 +848,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3850,6 +3858,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -1733,6 +1733,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3428,6 +3436,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -5302,6 +5318,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -1561,7 +1561,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -1583,6 +1583,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -3436,7 +3444,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3452,6 +3460,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -5384,7 +5400,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -5406,6 +5422,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -827,6 +827,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2150,6 +2158,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3325,6 +3341,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -741,6 +741,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2106,6 +2114,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3256,6 +3271,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -852,6 +852,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2265,6 +2273,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3511,6 +3526,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -633,6 +633,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -1873,6 +1880,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2839,6 +2853,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-platform/build.gradle.kts
+++ b/graphql-dgs-platform/build.gradle.kts
@@ -96,6 +96,9 @@ dependencies {
          api("org.apache.logging.log4j:log4j-api:2.23.1") {
             because("Refer to CVE-2021-44228; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228")
          }
+        api("io.micrometer:context-propagation") {
+            version { require("1.1.1") }
+        }
     }
 }
 

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -1058,6 +1058,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2326,6 +2334,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3417,6 +3432,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -230,7 +230,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10"
+            "locked": "1.7.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
@@ -804,7 +804,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10"
+            "locked": "1.7.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
@@ -1405,7 +1405,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10"
+            "locked": "1.7.11"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -1423,6 +1423,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -2842,7 +2850,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10"
+            "locked": "1.7.11"
         },
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
@@ -2854,6 +2862,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -3359,7 +3374,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10"
+            "locked": "1.7.11"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -4207,7 +4222,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10"
+            "locked": "1.7.11"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -4225,6 +4240,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("org.springframework:spring-web")
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.apache.commons:commons-lang3")
+    implementation("io.micrometer:context-propagation")
 
     compileOnly("com.github.ben-manes.caffeine:caffeine")
     compileOnly("io.micrometer:micrometer-core")

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -118,6 +118,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -492,6 +498,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -961,6 +973,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -2302,6 +2321,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2792,6 +2818,12 @@
             "locked": "0.0.20131108.vaadin1",
             "transitive": [
                 "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -3547,6 +3579,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -1287,6 +1287,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2734,6 +2742,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -4161,6 +4177,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
@@ -1892,7 +1892,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -1917,8 +1917,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]
@@ -3711,7 +3714,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3730,8 +3733,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]
@@ -5774,7 +5780,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -5799,8 +5805,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]

--- a/graphql-dgs-spring-graphql-example-java/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java/dependencies.lock
@@ -2012,7 +2012,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2037,8 +2037,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]
@@ -3924,7 +3927,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3943,8 +3946,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]
@@ -6179,7 +6185,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.10",
+            "locked": "1.7.11",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6204,8 +6210,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]

--- a/graphql-dgs-spring-graphql-starter/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter/dependencies.lock
@@ -1174,8 +1174,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]
@@ -2590,8 +2593,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]
@@ -3926,8 +3932,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.graphql:spring-graphql"
             ]

--- a/graphql-dgs-spring-graphql/build.gradle.kts
+++ b/graphql-dgs-spring-graphql/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(project(":graphql-dgs-reactive"))
     implementation("org.springframework:spring-web")
     implementation("org.springframework.boot:spring-boot-autoconfigure")
-    implementation("io.micrometer:context-propagation:1.1.0")
+    implementation("io.micrometer:context-propagation")
     implementation("org.springframework.graphql:spring-graphql:1.2.6")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/graphql-dgs-spring-graphql/dependencies.lock
+++ b/graphql-dgs-spring-graphql/dependencies.lock
@@ -142,7 +142,10 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0"
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
@@ -507,7 +510,10 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0"
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
@@ -961,8 +967,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -2333,8 +2342,10 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -2818,7 +2829,10 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0"
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
@@ -3627,8 +3641,11 @@
             ]
         },
         "io.micrometer:context-propagation": {
-            "locked": "1.1.0",
+            "locked": "1.1.1",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "org.springframework.graphql:spring-graphql"
             ]
         },

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -1426,6 +1426,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3001,6 +3009,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -4741,6 +4756,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -1018,6 +1018,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2367,6 +2375,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3654,6 +3669,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -675,6 +675,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -1933,6 +1940,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2958,6 +2972,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
@@ -710,6 +710,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -1996,6 +2003,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3037,6 +3051,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
@@ -784,6 +784,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2093,6 +2100,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3199,6 +3213,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -710,6 +710,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -1996,6 +2003,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3037,6 +3051,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -784,6 +784,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2093,6 +2100,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3199,6 +3213,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -878,6 +878,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2212,6 +2219,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3415,6 +3429,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -842,6 +842,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2109,6 +2116,13 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3185,6 +3199,13 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -1594,6 +1594,14 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -3232,6 +3240,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -5003,6 +5019,14 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs/build.gradle.kts
+++ b/graphql-dgs/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
     implementation("com.apollographql.federation:federation-graphql-java-support")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+    implementation("io.micrometer:context-propagation")
+    "java21Implementation"("io.micrometer:context-propagation:1.1.1") //Version should come from our BOM, but this doesn't work with the multi release JAR plugin.
 
 
     testImplementation("org.springframework.security:spring-security-core")

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -145,6 +145,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -394,6 +400,9 @@
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.15.4"
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1"
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -479,6 +488,9 @@
     "java21RuntimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.15.4"
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1"
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
@@ -709,6 +721,12 @@
             "locked": "0.0.20131108.vaadin1",
             "transitive": [
                 "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -1440,6 +1458,12 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -2259,6 +2283,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -2682,6 +2712,12 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -4080,6 +4116,12 @@
                 "com.github.mifmif:generex"
             ]
         },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.4",
             "transitive": [
@@ -4462,6 +4504,12 @@
             "locked": "0.0.20131108.vaadin1",
             "transitive": [
                 "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {
@@ -5193,6 +5241,12 @@
             "locked": "1.11-8",
             "transitive": [
                 "com.github.mifmif:generex"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "io.micrometer:micrometer-commons": {

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/internal/VirtualThreadTaskExecutor.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/internal/VirtualThreadTaskExecutor.java
@@ -16,6 +16,7 @@
 
 package com.netflix.graphql.dgs.internal;
 
+import io.micrometer.context.ContextSnapshotFactory;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.core.task.AsyncTaskExecutor;
 
@@ -27,7 +28,7 @@ import java.util.concurrent.Future;
  * The actual implementation is in the java21 source folder, using the multi-release JAR feature.
  */
 public class VirtualThreadTaskExecutor implements AsyncTaskExecutor {
-    public VirtualThreadTaskExecutor() {
+    public VirtualThreadTaskExecutor(ContextSnapshotFactory contextSnapshotFactory) {
     }
 
     @Override

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/CompletableFutureWrapperTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/CompletableFutureWrapperTest.kt
@@ -32,39 +32,39 @@ class CompletableFutureWrapperTest {
 
     @Test
     fun `A Kotlin String function should be wrapped`() {
-        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor())
+        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor(null))
         assertThat(completableFutureWrapper.shouldWrapInCompletableFuture(fun(): String { return "hello" }.reflect()!!)).isTrue()
     }
 
     @Test
     fun `A Kotlin CompletableFuture function should not be wrapped`() {
-        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor())
+        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor(null))
         assertThat(completableFutureWrapper.shouldWrapInCompletableFuture(fun(): CompletableFuture<String> { return CompletableFuture() }.reflect()!!)).isFalse()
     }
 
     @Test
     fun `A Kotlin Mono function should not be wrapped`() {
-        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor())
+        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor(null))
         assertThat(completableFutureWrapper.shouldWrapInCompletableFuture(fun(): Mono<String> { return Mono.just("hi") }.reflect()!!)).isFalse()
     }
 
     @Test
     fun `A Java String method should be wrapped`() {
-        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor())
+        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor(null))
         val stringMethod = String::class.java.getMethod("toString")
         assertThat(completableFutureWrapper.shouldWrapInCompletableFuture(stringMethod)).isTrue()
     }
 
     @Test
     fun `A Java CompletableFuture method should not be wrapped`() {
-        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor())
+        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor(null))
         val cfMethod = CompletableFuture::class.java.getMethod("thenApplyAsync", Function::class.java)
         assertThat(completableFutureWrapper.shouldWrapInCompletableFuture(cfMethod)).isFalse()
     }
 
     @Test
     fun `A Java Mono method should not be wrapped`() {
-        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor())
+        val completableFutureWrapper = CompletableFutureWrapper(VirtualThreadTaskExecutor(null))
         val monoMethod = Mono::class.java.getMethod("empty")
         assertThat(completableFutureWrapper.shouldWrapInCompletableFuture(monoMethod)).isFalse()
     }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Set up a Micrometer `ContextSnapshotFactory` and use this to wrap tasks in `VirtualThreadTaskExecutor`. This enables context propagation using the micrometer context-propagation library.
By default it registers the SLF4j MDC propagation that comes out of the box with micrometer context. A user can provide more accessors by either registering them in `META-INF/services`, which is the SPI Micrometer uses, or you can override the bean definition that's now in the DGS autoconfiguration:

```
@Bean
    @ConditionalOnMissingBean
    open fun dgsMicrometerContextRegistry(): ContextRegistry {
        return ContextRegistry.getInstance()
            .registerThreadLocalAccessor(Slf4jThreadLocalAccessor())
    }
```

WIth this PR, a datafetcher that runs on a virtual thread, has context propagated, so you can for example rely on MDC.