### PR TITLE
Introduce optional log level property on DgsException

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DefaultDataFetcherExceptionHandler.kt
@@ -23,6 +23,7 @@ import graphql.execution.DataFetcherExceptionHandlerParameters
 import graphql.execution.DataFetcherExceptionHandlerResult
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.slf4j.event.Level
 import org.springframework.util.ClassUtils
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -62,7 +63,9 @@ open class DefaultDataFetcherExceptionHandler : DataFetcherExceptionHandler {
     }
 
     protected open fun logException(handlerParameters: DataFetcherExceptionHandlerParameters, error: GraphQLError, exception: Throwable) {
-        logger.error(
+        val logLevel = if (exception is DgsException) exception.logLevel else Level.ERROR
+
+        logger.atLevel(logLevel).log(
             "Exception while executing data fetcher for {}: {}",
             handlerParameters.path,
             exception.message,

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/DgsException.kt
@@ -19,12 +19,22 @@ package com.netflix.graphql.dgs.exceptions
 import com.netflix.graphql.types.errors.ErrorType
 import com.netflix.graphql.types.errors.TypedGraphQLError
 import graphql.execution.ResultPath
+import org.slf4j.event.Level
 
 abstract class DgsException(
     override val message: String,
     override val cause: Exception? = null,
-    val errorType: ErrorType = ErrorType.UNKNOWN
+    val errorType: ErrorType = ErrorType.UNKNOWN,
+    val logLevel: Level = Level.ERROR
 ) : RuntimeException(message, cause) {
+
+    // Explicit constructor without logLevel for Java backward compatibility
+    constructor(
+        message: String,
+        cause: Exception? = null,
+        errorType: ErrorType = ErrorType.UNKNOWN
+    ) : this(message, cause, errorType, Level.ERROR)
+
     companion object {
         const val EXTENSION_CLASS_KEY = "class"
     }

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/exception/DgsExceptionJavaTest.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/exception/DgsExceptionJavaTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.exception;
+
+import com.netflix.graphql.dgs.exceptions.DgsException;
+import com.netflix.graphql.types.errors.ErrorType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DgsExceptionJavaTest {
+
+    @Test
+    void createExceptionWithoutLogLevel() {
+        assertThat(new MyException("test", new IllegalArgumentException("test"), ErrorType.UNAVAILABLE).getLogLevel()).isEqualTo(Level.ERROR);
+    }
+
+    @Test
+    void createExceptionWithExplicitLogLevel() {
+        assertThat(new MyExceptionWithLevel("test", new IllegalArgumentException("test"), ErrorType.UNAVAILABLE, Level.DEBUG).getLogLevel()).isEqualTo(Level.DEBUG);
+    }
+
+    static class MyException extends DgsException {
+        public MyException(@NotNull String message, @Nullable Exception cause, @NotNull ErrorType errorType) {
+            super(message, cause, errorType);
+        }
+    }
+
+    static class MyExceptionWithLevel extends DgsException {
+        public MyExceptionWithLevel(@NotNull String message, @Nullable Exception cause, @NotNull ErrorType errorType, Level level) {
+            super(message, cause, errorType, level);
+        }
+    }
+}


### PR DESCRIPTION
Introduce optional log level property on DgsException and log exception on that level in the default exception handler. This can be used to lower the log level for specific exceptions.

This change is due to per-field throttling, which we're adding internally. Logging stack traces is relatively expensive, defeating the purpose of throttling.
