### PR TITLE
Set InputArgumentResolver to highest priority so it is matched first

### DIFF
--- a/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/FileUploadMutation.java
+++ b/graphql-dgs-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/FileUploadMutation.java
@@ -66,6 +66,13 @@ public class FileUploadMutation {
         return !parts.isEmpty();
     }
 
+    @DgsData(parentType = "Mutation", field = "uploadTest")
+    public boolean uploadTest(@InputArgument MultipartFile input, DataFetchingEnvironment dfe) {
+        MultipartFile file = input;
+        if (file == null || file.isEmpty()) return false;
+        return true;
+    }
+
     static class FileUploadInput {
         private String description;
         private List<MultipartFile> files;

--- a/graphql-dgs-example-shared/src/main/resources/schema/schema.graphqls
+++ b/graphql-dgs-example-shared/src/main/resources/schema/schema.graphqls
@@ -58,6 +58,7 @@ type Mutation {
     addRating(input: RatingInput):Rating
     uploadFile(input: FileUploadInput!): Boolean
     updateCookie(value: String): String
+    uploadTest(input: Upload!): Boolean
 }
 
 input RatingInput {

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsInputArgumentConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsInputArgumentConfiguration.kt
@@ -22,10 +22,13 @@ import com.netflix.graphql.dgs.internal.method.*
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 
 @Configuration
 open class DgsInputArgumentConfiguration {
     @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     open fun inputArgumentResolver(inputObjectMapper: InputObjectMapper): ArgumentResolver {
         return InputArgumentResolver(inputObjectMapper)
     }

--- a/graphql-dgs-spring-graphql-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/FileUploadMutation.java
+++ b/graphql-dgs-spring-graphql-example-java/src/main/java/com/netflix/graphql/dgs/example/datafetcher/FileUploadMutation.java
@@ -66,6 +66,14 @@ public class FileUploadMutation {
         return !parts.isEmpty();
     }
 
+    @DgsData(parentType = "Mutation", field = "uploadTest")
+    public boolean uploadTest(@InputArgument MultipartFile input, DataFetchingEnvironment dfe) {
+        MultipartFile file = input;
+        MultipartFile inputTest = (MultipartFile) dfe.getArgument("input");
+        if (file == null || file.isEmpty()) return false;
+        return true;
+    }
+
     static class FileUploadInput {
         private String description;
         private List<MultipartFile> files;


### PR DESCRIPTION
This fixes issues with resolving MultipartFile with @InputArgument.

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Without the ordering on InputArgumentResolver, the HandlerMethodArgumentResolverAdapter for RequestParamMethodArgumentresolver was match due to this logic: https://github.com/spring-projects/spring-framework/blob/main/spring-web/src/main/java/org/springframework/web/method/annotation/RequestParamMethodArgumentResolver.java#L142

This breaks the use of `@InputArgument MultipartFile inputFile` in DGS data fetchers. The InputArgumentResolver handles this correctly and we should match that resolver. It was working previously prior to spring-graphql intgeration since we were getting lucky with the order.