### PR TITLE
Add request size metric

### DIFF
--- a/graphql-dgs-spring-boot-micrometer/build.gradle.kts
+++ b/graphql-dgs-spring-boot-micrometer/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
     implementation("com.netflix.spectator:spectator-api:1.7.+")
     implementation("com.github.ben-manes.caffeine:caffeine")
     implementation("org.springframework:spring-context-support")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     compileOnly(project(":graphql-dgs-spring-boot-starter"))

--- a/graphql-dgs-spring-boot-micrometer/build.gradle.kts
+++ b/graphql-dgs-spring-boot-micrometer/build.gradle.kts
@@ -7,6 +7,8 @@ dependencies {
     implementation("com.netflix.spectator:spectator-api:1.7.+")
     implementation("com.github.ben-manes.caffeine:caffeine")
     implementation("org.springframework:spring-context-support")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     compileOnly(project(":graphql-dgs-spring-boot-starter"))
     compileOnly("org.springframework.boot:spring-boot-actuator-autoconfigure")

--- a/graphql-dgs-spring-boot-micrometer/build.gradle.kts
+++ b/graphql-dgs-spring-boot-micrometer/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
     implementation("com.netflix.spectator:spectator-api:1.7.+")
     implementation("com.github.ben-manes.caffeine:caffeine")
     implementation("org.springframework:spring-context-support")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     compileOnly(project(":graphql-dgs-spring-boot-starter"))
     compileOnly("org.springframework.boot:spring-boot-actuator-autoconfigure")

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
@@ -41,6 +41,18 @@ object DgsMetrics {
          * This is useful if you want to find data loaders that might be responsible for poor query performance.
          */
         DATA_LOADER("gql.dataLoader"),
+
+        /**
+         * _DistributionSummary_ that captures the size of a graphql query in a request.
+         * Measures size in bytes of the query and variables.
+         */
+        QUERY_REQUEST_SIZE("gql.query.request.size"),
+
+        /**
+         * _DistributionSummary_ that captures the size of the result of a graphql query returned in a response.
+         * Measures size in bytes of the data, errors, and extensions.
+         */
+        QUERY_RESPONSE_SIZE("gql.query.response.size"),
     }
 
     /** Defines the tags applied to the [GqlMetric] emitted by the framework. */

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/DgsMetrics.kt
@@ -43,16 +43,10 @@ object DgsMetrics {
         DATA_LOADER("gql.dataLoader"),
 
         /**
-         * _DistributionSummary_ that captures the size of a graphql query in a request.
-         * Measures size in bytes of the query and variables.
+         * _DistributionSummary_ that captures the size of a graphql request.
+         * Measures size in bytes of a graphql http request body.
          */
-        QUERY_REQUEST_SIZE("gql.query.request.size"),
-
-        /**
-         * _DistributionSummary_ that captures the size of the result of a graphql query returned in a response.
-         * Measures size in bytes of the data, errors, and extensions.
-         */
-        QUERY_RESPONSE_SIZE("gql.query.response.size"),
+        REQUEST_SIZE("gql.request.size"),
     }
 
     /** Defines the tags applied to the [GqlMetric] emitted by the framework. */

--- a/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/main/kotlin/com/netflix/graphql/dgs/metrics/micrometer/DgsGraphQLMetricsInstrumentation.kt
@@ -35,6 +35,14 @@ import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Timer
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.actuate.metrics.AutoTimer
@@ -44,14 +52,6 @@ import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import kotlin.jvm.optionals.getOrNull
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 
 class DgsGraphQLMetricsInstrumentation(
     private val schemaProvider: DgsSchemaProvider,
@@ -257,8 +257,10 @@ class DgsGraphQLMetricsInstrumentation(
         )
     }
 
-    private suspend fun captureGqlQueryRequestSizeMetric(executionInput: ExecutionInput,
-                                                         state: MetricsInstrumentationState) = coroutineScope {
+    private suspend fun captureGqlQueryRequestSizeMetric(
+        executionInput: ExecutionInput,
+        state: MetricsInstrumentationState
+    ) = coroutineScope {
         val tags = buildList { addAll(state.tags()) }
 
         val requestSizeMeter = DistributionSummary.builder(GqlMetric.QUERY_REQUEST_SIZE.key)
@@ -278,8 +280,11 @@ class DgsGraphQLMetricsInstrumentation(
         }
     }
 
-    private suspend fun captureGqlQueryResponseSizeMetric(executionResult: ExecutionResult, parameters: InstrumentationExecutionParameters,
-                                                  state: MetricsInstrumentationState) = coroutineScope {
+    private suspend fun captureGqlQueryResponseSizeMetric(
+        executionResult: ExecutionResult,
+        parameters: InstrumentationExecutionParameters,
+        state: MetricsInstrumentationState
+    ) = coroutineScope {
         val tags = buildList {
             addAll(state.tags())
             addAll(tagsProvider.getExecutionTags(state, parameters, executionResult, null))

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -781,8 +781,10 @@ class MicrometerServletSmokeTest {
 
         // Check metrics are present.
         assertThat(meters).containsKeys(
-            "gql.query.request.size", "gql.query.request.size.percentile",
-            "gql.query.response.size", "gql.query.response.size.percentile"
+            "gql.query.request.size",
+            "gql.query.request.size.percentile",
+            "gql.query.response.size",
+            "gql.query.response.size.percentile"
         )
 
         // Check expected percentiles: .90, .95, .99
@@ -824,7 +826,7 @@ class MicrometerServletSmokeTest {
                         |{
                         |   "errors":[
                         |      {"message":"Exception triggered.",
-                        |          "locations":[],"path":["triggerBadRequestFailure"],
+                        |          "path":["triggerBadRequestFailure"],
                         |          "extensions":{"errorType":"BAD_REQUEST"}}
                         |   ],
                         |   "data":{"triggerBadRequestFailure":null}
@@ -838,8 +840,10 @@ class MicrometerServletSmokeTest {
 
         // Check metrics are present.
         assertThat(meters).containsKeys(
-            "gql.query.request.size", "gql.query.request.size.percentile",
-            "gql.query.response.size", "gql.query.response.size.percentile"
+            "gql.query.request.size",
+            "gql.query.request.size.percentile",
+            "gql.query.response.size",
+            "gql.query.response.size.percentile"
         )
 
         // Check metric name and expected tags.


### PR DESCRIPTION
Pull request checklist
----

- [x] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [x] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [x] Make sure the PR doesn't introduce backward compatibility issues
- [x] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
Added micrometer DistributionSummmary metric for graphQL request size. 

```
Metric Name: gql.request.size
Tags: [
	- tag(gql.operation={operationTypeValue})
	- tag(gql.operation.name={operationNameValue})
	- tag(gql.query.complexity={qComplexityValue})
	- tag(gql.query.sig.hash={sigHashValue})
	]

```

This metric is useful in measuring the request size for a graphql operation.
The request size measurement is the size in bytes of the request body, obtained via the Content-Length header in the graphql request. This avoids needing to de/serialize data. A graphql request body contains: query, variables, and operationname.
Via this approach, the Content-Type header for the response is not available at this point in the request processing. This change is scoped to the request size metric, as it is a metric that is useful in correlating graphql request sizes to graphql operations.

Tested via smoke tests and manual testing on ExampleApp.

Side note: An alternative approach considered was adding a web filter which would allow for more efficient measurement of both the request and response sizes but it is not standardized for graphql clients to send operation-name as a header. Presently getting the operation-name in the filter would require deserializing the http request body to get the "operationName" field.