### PR TITLE
Add flag for collecting metadata information for native image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,7 +174,7 @@ configure(subprojects.filterNot { it in internalBomModules }) {
              *   > compatibility for existing clients compiled against previous library versions.
              * Ref. https://kotlinlang.org/docs/kotlin-reference.pdf
              */
-            freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all-compatibility"
+            freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all-compatibility" + "-java-parameters"
             jvmTarget = "17"
         }
     }


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
We are trying to build a GraalVM native image using Spring native image support. 
When we add the DGS micrometer dependency, the native image build process fails complaining about missing parameter names in the compiled classes, which are needed for constructor binding to work correctly in native images.

This PR adds the required flag to the Gradle task.

Please see the detailed discussion [here](https://github.com/Netflix/dgs-framework/discussions/1882).

