### PR TITLE
Disable compiler warnings from javadoc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -185,6 +185,12 @@ configure(subprojects.filterNot { it in internalBomModules }) {
         }
     }
 
+    tasks.withType<Javadoc>().configureEach {
+        options {
+            (this as CoreJavadocOptions).addStringOption("Xdoclint:none", "-quiet")
+        }
+    }
+
     kotlinter {
         reporters = arrayOf("checkstyle", "plain")
         experimentalRules = false


### PR DESCRIPTION
Get rid of the many warnings during the build which come from Javadoc. Most of them are from the example code, and not useful at all.