### PR TITLE
Reconfigure BOM usage to use Spring Dependency Recommender plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ plugins {
     `java-library`
     id("nebula.dependency-recommender") version "11.0.0"
 
-    id("nebula.netflixoss") version "11.4.0"
+    id("nebula.netflixoss") version "11.5.0"
     id("org.jmailen.kotlinter") version "3.11.1"
     id("me.champeau.jmh") version "0.7.2"
     id("me.champeau.mrjar") version "0.1.1"
@@ -73,7 +73,6 @@ allprojects {
         mavenBom(mapOf("module" to "com.fasterxml.jackson:jackson-bom:2.15.+"))
     }
 }
-
 val internalBomModules by extra(
     listOf(
         project(":graphql-dgs-platform"),
@@ -96,13 +95,13 @@ configure(subprojects.filterNot { it in internalBomModules }) {
      *  Kotlin-JVM: runtimeOnlyDependenciesMetadata, implementationDependenciesMetadata should be marked with isCanBeResolved=false
      *  https://youtrack.jetbrains.com/issue/KT-34394
      */
-    tasks.named("generateLock") {
-        doFirst {
-            project.configurations.filter { it.name.contains("DependenciesMetadata") }.forEach {
-                it.isCanBeResolved = false
-            }
-        }
-    }
+//    tasks.named("generateLock") {
+//        doFirst {
+//            project.configurations.filter { it.name.contains("DependenciesMetadata") }.forEach {
+//                it.isCanBeResolved = false
+//            }
+//        }
+//    }
 
     val springBootVersion = extra["sb.version"] as String
     val jmhVersion = "1.37"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,9 @@ plugins {
     `java-library`
     id("nebula.dependency-recommender") version "11.0.0"
 
-    id("nebula.netflixoss") version "11.5.0"
+    id("nebula.netflixoss") version "11.4.0"
+    id("io.spring.dependency-management") version "1.1.5"
+
     id("org.jmailen.kotlinter") version "3.11.1"
     id("me.champeau.jmh") version "0.7.2"
     id("me.champeau.mrjar") version "0.1.1"
@@ -64,14 +66,6 @@ allprojects {
             force("org.springframework.graphql:spring-graphql:1.2.6")
         }
     }
-
-    dependencyRecommendations {
-        mavenBom(mapOf("module" to "org.jetbrains.kotlin:kotlin-bom:${Versions.KOTLIN_VERSION}"))
-
-        mavenBom(mapOf("module" to "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
-        mavenBom(mapOf("module" to "org.springframework.cloud:spring-cloud-dependencies:2023.0.+"))
-        mavenBom(mapOf("module" to "com.fasterxml.jackson:jackson-bom:2.15.+"))
-    }
 }
 val internalBomModules by extra(
     listOf(
@@ -85,9 +79,9 @@ configure(subprojects.filterNot { it in internalBomModules }) {
     apply {
         plugin("java-library")
         plugin("kotlin")
-//        plugin("kotlin-kapt")
         plugin("org.jmailen.kotlinter")
         plugin("me.champeau.jmh")
+        plugin("io.spring.dependency-management")
     }
 
     /**
@@ -105,6 +99,17 @@ configure(subprojects.filterNot { it in internalBomModules }) {
 
     val springBootVersion = extra["sb.version"] as String
     val jmhVersion = "1.37"
+
+
+    dependencyManagement {
+        imports {
+            mavenBom("org.jetbrains.kotlin:kotlin-bom:${Versions.KOTLIN_VERSION}")
+
+            mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+            mavenBom("org.springframework.cloud:spring-cloud-dependencies:2023.0.+")
+            mavenBom("com.fasterxml.jackson:jackson-bom:2.15.+")
+        }
+    }
 
     dependencies {
         // Apply the BOM to applicable subprojects.

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,48 +1,18 @@
 {
-    "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
     "apiDependenciesMetadata": {
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "implementationDependenciesMetadata": {
@@ -94,29 +64,12 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
     "jmhApiDependenciesMetadata": {
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
             "transitive": [
@@ -129,15 +82,8 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -174,12 +120,6 @@
             "transitive": [
                 "org.openjdk.jmh:jmh-generator-asm"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhImplementationDependenciesMetadata": {
@@ -230,9 +170,6 @@
         }
     },
     "jmhRuntimeClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
             "transitive": [
@@ -245,15 +182,8 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -290,26 +220,14 @@
             "transitive": [
                 "org.openjdk.jmh:jmh-generator-asm"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -329,10 +247,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -344,9 +260,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -356,35 +270,28 @@
             ]
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.9.24",
+            "locked": "1.6.10",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
-            "locked": "1.7.3",
+            "locked": "1.5.0",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -392,33 +299,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -427,27 +318,21 @@
             ]
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.9.24",
+            "locked": "1.6.10",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -455,53 +340,23 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
-            "locked": "1.9.24"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -516,20 +371,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -537,39 +388,23 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
-            "locked": "1.9.24"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -584,20 +419,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -605,39 +436,23 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.kotlin:kotlin-annotation-processing-gradle": {
-            "locked": "1.9.24"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
             "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -652,20 +467,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -673,12 +484,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKaptWorkerDependencies": {
@@ -696,24 +501,16 @@
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -726,28 +523,22 @@
             "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
-            "locked": "1.9.24",
+            "locked": "1.6.10",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -755,108 +546,28 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testImplementationDependenciesMetadata": {
@@ -865,30 +576,14 @@
         }
     },
     "testRuntimeClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     }
 }

--- a/graphql-dgs-client/build.gradle.kts
+++ b/graphql-dgs-client/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
     implementation("com.graphql-java:graphql-java")
 
-    implementation("org.jetbrains:annotations")
+    implementation("org.jetbrains:annotations:24.1.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework:spring-test")

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -1,28 +1,82 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
         }
     },
     "compileClasspath": {
@@ -33,8 +87,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -44,8 +97,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -55,36 +107,31 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -100,11 +147,10 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -117,8 +163,7 @@
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
@@ -136,14 +181,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-web"
             ]
         },
@@ -151,32 +194,24 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "13.0",
+            "locked": "24.1.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
@@ -185,27 +220,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-web",
                 "org.springframework:spring-webflux"
             ]
@@ -213,7 +239,6 @@
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-web",
                 "org.springframework:spring-webflux"
@@ -222,22 +247,242 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
+            "locked": "6.1.6"
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
             ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-beans",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.jetbrains:annotations": {
+            "locked": "24.1.0"
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-beans",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -288,18 +533,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -310,8 +546,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -321,8 +556,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -332,36 +566,31 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -377,11 +606,10 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -394,8 +622,7 @@
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
@@ -413,14 +640,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-web"
             ]
         },
@@ -428,7 +653,6 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
@@ -444,28 +668,21 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "13.0",
+            "locked": "24.1.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
@@ -508,27 +725,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-web",
                 "org.springframework:spring-webflux"
             ]
@@ -536,7 +744,6 @@
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-web",
                 "org.springframework:spring-webflux"
@@ -545,21 +752,67 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -567,15 +820,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -592,8 +843,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -603,8 +853,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -615,7 +864,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -623,7 +871,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -634,7 +881,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -648,15 +894,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -685,7 +929,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -693,8 +937,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -716,7 +959,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -853,48 +1095,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -902,25 +1142,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -939,8 +1179,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -952,15 +1191,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -968,22 +1205,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -1003,8 +1237,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -1013,15 +1246,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1029,8 +1260,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1038,23 +1268,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1070,23 +1297,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1095,21 +1319,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -1123,28 +1344,24 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1152,22 +1369,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1175,16 +1389,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1203,7 +1415,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1216,8 +1427,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1227,18 +1437,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1246,35 +1454,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1283,19 +1486,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1306,9 +1504,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1327,12 +1523,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1343,19 +1537,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1366,12 +1556,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1392,36 +1580,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
@@ -1432,7 +1616,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1443,24 +1626,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1468,16 +1648,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1495,14 +1673,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1560,21 +1736,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1588,15 +1761,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1609,20 +1780,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -1632,7 +1798,6 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1640,46 +1805,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1687,17 +1839,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1705,7 +1852,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1718,7 +1864,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1727,7 +1872,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1744,7 +1888,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1752,14 +1895,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1774,7 +1915,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1786,7 +1926,6 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
@@ -1798,7 +1937,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -1807,14 +1945,12 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1822,23 +1958,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1858,10 +1987,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1873,9 +2000,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1887,33 +2012,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1921,33 +2039,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1958,25 +2060,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1984,50 +2080,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2042,20 +2108,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2063,36 +2125,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2107,20 +2153,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2128,36 +2170,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2172,20 +2198,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2193,33 +2215,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2234,26 +2242,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2261,40 +2263,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -2305,8 +2273,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2316,8 +2283,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2327,36 +2293,31 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2372,11 +2333,10 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2389,8 +2349,7 @@
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
@@ -2408,14 +2367,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2423,8 +2380,7 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2436,32 +2392,24 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "13.0",
+            "locked": "24.1.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
@@ -2476,8 +2424,7 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2485,27 +2432,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2514,14 +2452,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2533,59 +2469,39 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2595,8 +2511,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2606,8 +2521,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2618,7 +2532,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2626,7 +2539,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2634,22 +2546,19 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2666,14 +2575,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -2695,7 +2603,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2791,72 +2698,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2875,8 +2780,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -2888,15 +2792,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -2904,22 +2806,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -2939,8 +2838,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -2949,15 +2847,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -2965,8 +2861,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -2974,23 +2869,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -3006,23 +2898,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -3031,21 +2920,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -3056,28 +2942,24 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3085,7 +2967,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3094,16 +2975,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -3115,23 +2994,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3139,21 +3015,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -3168,14 +3041,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3183,19 +3054,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3211,12 +3076,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3227,18 +3090,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3249,13 +3108,11 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "13.0",
+            "locked": "24.1.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
@@ -3264,7 +3121,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3273,24 +3129,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3306,14 +3159,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3339,21 +3190,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3363,15 +3211,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3380,18 +3226,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -3401,7 +3242,6 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -3409,46 +3249,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3456,17 +3283,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3474,7 +3296,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3486,7 +3307,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -3494,7 +3314,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3510,7 +3329,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3518,21 +3336,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -3543,28 +3358,852 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "io.projectreactor:reactor-test",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.jetbrains:annotations": {
+            "locked": "24.1.0"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3573,15 +4212,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3598,8 +4235,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3609,8 +4245,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3621,7 +4256,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3629,7 +4263,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3640,7 +4273,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3654,15 +4286,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3691,7 +4321,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3699,8 +4329,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -3722,7 +4351,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3859,48 +4487,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3908,25 +4534,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3945,8 +4571,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -3958,15 +4583,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -3974,22 +4597,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -4009,8 +4629,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -4019,15 +4638,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -4035,8 +4652,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -4044,23 +4660,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -4076,23 +4689,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -4101,21 +4711,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -4129,28 +4736,24 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4158,22 +4761,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -4181,16 +4781,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -4209,30 +4807,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4240,35 +4834,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4277,19 +4866,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -4300,9 +4884,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4321,12 +4903,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4337,19 +4917,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4360,12 +4936,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -4386,36 +4960,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
@@ -4426,7 +4996,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4437,24 +5006,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -4462,16 +5028,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4489,14 +5053,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4525,21 +5087,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4553,15 +5112,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4574,20 +5131,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web",
@@ -4597,7 +5149,6 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -4605,46 +5156,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4652,17 +5190,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4670,7 +5203,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4683,7 +5215,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -4692,7 +5223,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4709,7 +5239,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4717,14 +5246,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4739,7 +5266,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -4751,7 +5277,6 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
@@ -4763,7 +5288,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -4772,14 +5296,12 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4787,7 +5309,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -1,43 +1,31 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -47,8 +35,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -58,8 +45,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -69,7 +55,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -77,7 +62,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -85,7 +69,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -93,7 +76,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -109,14 +91,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -139,8 +120,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -259,14 +239,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -285,8 +263,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -298,15 +275,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -314,22 +289,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -349,8 +321,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -359,15 +330,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -375,8 +344,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -384,23 +352,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -416,23 +381,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -441,21 +403,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -466,35 +425,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -511,9 +463,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -526,14 +476,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -543,32 +491,25 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -576,45 +517,36 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -624,15 +556,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -645,21 +575,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -668,14 +595,596 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-example-shared": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-webflux-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -728,33 +1237,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -764,8 +1262,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -775,8 +1272,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -786,7 +1282,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -794,7 +1289,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -802,7 +1296,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -810,7 +1303,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -826,14 +1318,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -856,8 +1347,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -976,14 +1466,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -1002,8 +1490,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -1015,15 +1502,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -1031,22 +1516,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -1066,8 +1548,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -1076,15 +1557,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1092,8 +1571,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1101,23 +1579,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1133,23 +1608,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1158,21 +1630,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -1183,14 +1652,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -1207,23 +1674,18 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -1240,9 +1702,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1289,14 +1749,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1306,32 +1764,25 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1339,45 +1790,36 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1387,15 +1829,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1408,21 +1848,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -1431,15 +1868,64 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -1447,15 +1933,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1473,8 +1957,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1484,8 +1967,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1497,7 +1979,6 @@
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1506,7 +1987,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1516,7 +1996,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1528,8 +2007,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -1537,7 +2015,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1566,7 +2043,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -1576,8 +2053,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -1601,7 +2077,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1738,48 +2213,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1787,25 +2260,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1837,8 +2310,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -1851,15 +2323,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -1867,22 +2337,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -1903,8 +2370,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -1914,15 +2380,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1930,8 +2394,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1939,23 +2402,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1972,23 +2432,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1997,15 +2454,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -2017,8 +2472,7 @@
         "io.projectreactor.netty:reactor-netty": {
             "locked": "1.1.18",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
@@ -2026,15 +2480,13 @@
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -2048,36 +2500,31 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -2085,16 +2532,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2113,7 +2558,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2126,8 +2570,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -2137,32 +2580,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2171,19 +2610,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2194,9 +2628,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2215,12 +2647,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2231,19 +2661,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2254,12 +2680,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2281,36 +2705,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2322,7 +2742,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2333,24 +2752,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2358,16 +2774,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2385,14 +2799,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2450,21 +2862,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2478,15 +2887,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2497,20 +2904,15 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -2519,41 +2921,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2561,24 +2955,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2591,7 +2979,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2599,7 +2986,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2615,21 +3001,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2641,7 +3024,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -2652,21 +3034,18 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2674,23 +3053,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -2710,10 +3082,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -2725,9 +3095,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2739,33 +3107,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2773,33 +3134,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -2810,25 +3155,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2836,50 +3175,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2894,20 +3203,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2915,36 +3220,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2959,20 +3248,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2980,36 +3265,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3024,20 +3293,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3045,33 +3310,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -3086,26 +3337,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3113,55 +3358,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3179,8 +3388,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3190,8 +3398,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3203,7 +3410,6 @@
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3212,7 +3418,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3222,7 +3427,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3234,8 +3438,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -3243,7 +3446,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3272,7 +3474,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3282,8 +3484,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -3306,8 +3507,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -3437,14 +3637,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -3476,8 +3674,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -3490,15 +3687,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -3506,22 +3701,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -3542,8 +3734,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -3553,15 +3744,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -3569,8 +3758,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -3578,23 +3766,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -3611,23 +3796,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -3636,15 +3818,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -3656,8 +3836,7 @@
         "io.projectreactor.netty:reactor-netty": {
             "locked": "1.1.18",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
@@ -3665,15 +3844,13 @@
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -3687,14 +3864,12 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -3713,44 +3888,35 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3769,41 +3935,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3821,36 +3979,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3868,14 +4022,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3889,15 +4041,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -3906,19 +4056,14 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -3926,45 +4071,36 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3977,7 +4113,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -3985,7 +4120,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -3999,14 +4133,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -4018,7 +4150,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -4029,53 +4160,34 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -4085,8 +4197,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4096,8 +4207,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4107,7 +4217,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4115,7 +4224,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4123,7 +4231,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4131,7 +4238,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4147,14 +4253,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -4178,7 +4283,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4304,72 +4408,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4388,8 +4490,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -4401,15 +4502,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -4417,22 +4516,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -4452,8 +4548,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -4462,15 +4557,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -4478,8 +4571,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -4487,23 +4579,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -4519,23 +4608,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -4544,21 +4630,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -4569,28 +4652,24 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4599,16 +4678,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -4620,23 +4697,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4651,14 +4725,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4666,12 +4738,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -4689,11 +4757,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4704,18 +4770,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4726,9 +4788,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -4741,7 +4801,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4750,24 +4809,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4783,14 +4839,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4816,21 +4870,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4840,15 +4891,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4857,18 +4906,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -4877,41 +4921,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4919,24 +4955,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4946,15 +4976,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4969,28 +4997,24 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -4999,21 +5023,816 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-example-shared": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-webflux-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -5022,15 +5841,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -5048,8 +5865,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -5059,8 +5875,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -5072,7 +5887,6 @@
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5081,7 +5895,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5091,7 +5904,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5103,8 +5915,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -5112,7 +5923,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5141,7 +5951,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -5151,8 +5961,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -5176,7 +5985,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5313,48 +6121,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -5362,25 +6168,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -5412,8 +6218,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -5426,15 +6231,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -5442,22 +6245,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -5478,8 +6278,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -5489,15 +6288,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -5505,8 +6302,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -5514,23 +6310,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -5547,23 +6340,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -5572,15 +6362,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -5592,8 +6380,7 @@
         "io.projectreactor.netty:reactor-netty": {
             "locked": "1.1.18",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
@@ -5601,15 +6388,13 @@
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -5623,36 +6408,31 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -5660,16 +6440,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -5688,44 +6466,38 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5734,19 +6506,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -5757,9 +6524,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -5778,12 +6543,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -5794,19 +6557,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -5817,12 +6576,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -5844,36 +6601,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -5885,7 +6638,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5896,24 +6648,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -5921,16 +6670,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -5948,14 +6695,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5984,21 +6729,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -6012,15 +6754,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -6031,20 +6771,15 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -6053,41 +6788,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -6095,24 +6822,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -6125,7 +6846,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -6133,7 +6853,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -6149,21 +6868,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6175,7 +6891,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -6186,21 +6901,18 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6208,7 +6920,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -1,43 +1,31 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -47,8 +35,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -58,8 +45,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -69,7 +55,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -77,7 +62,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -85,7 +69,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -93,7 +76,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -109,10 +91,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -121,14 +100,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -151,8 +129,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -279,21 +256,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -302,7 +276,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -312,31 +285,27 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -344,21 +313,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -367,9 +333,6 @@
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -387,9 +350,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -402,14 +363,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -419,8 +378,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -429,21 +387,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -451,62 +406,44 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -514,7 +451,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -525,7 +461,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -533,7 +468,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -546,7 +480,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -554,14 +487,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -570,14 +501,502 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-example-shared": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-jakarta9"
+            ]
+        },
+        "io.micrometer:micrometer-jakarta9": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-actuator": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -630,33 +1049,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -666,8 +1074,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -677,8 +1084,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -688,7 +1094,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -696,7 +1101,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -704,7 +1108,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -712,7 +1115,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -728,10 +1130,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -740,14 +1139,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -770,8 +1168,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -898,21 +1295,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -921,7 +1315,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -931,14 +1324,12 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -956,18 +1347,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -975,21 +1364,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -998,9 +1384,6 @@
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -1018,9 +1401,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1067,14 +1448,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1084,8 +1463,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -1094,21 +1472,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -1116,62 +1491,44 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1179,7 +1536,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1190,7 +1546,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -1198,7 +1553,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1211,7 +1565,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1219,14 +1572,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -1235,15 +1586,64 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -1251,15 +1651,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1277,8 +1675,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1288,8 +1685,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1302,7 +1698,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1311,7 +1706,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1324,7 +1718,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1337,8 +1730,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -1346,7 +1738,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1365,8 +1756,7 @@
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.8",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -1388,7 +1778,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -1398,8 +1788,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -1423,7 +1812,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1561,7 +1949,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -1575,8 +1963,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -1592,22 +1979,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -1616,42 +2000,41 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1659,25 +2042,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1696,8 +2079,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -1709,15 +2091,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -1725,22 +2105,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -1760,8 +2137,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -1770,15 +2146,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1786,8 +2160,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1795,23 +2168,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1827,23 +2197,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1852,21 +2219,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -1880,28 +2244,24 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1909,22 +2269,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1933,16 +2290,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1961,7 +2316,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1974,8 +2328,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1985,18 +2338,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2004,35 +2355,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2047,15 +2393,13 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2063,9 +2407,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2076,9 +2417,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2099,12 +2438,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2115,19 +2452,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2138,12 +2471,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2164,36 +2495,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2205,7 +2532,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2216,24 +2542,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2241,16 +2564,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2274,14 +2595,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2339,21 +2658,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2368,8 +2684,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -2378,7 +2693,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2387,14 +2701,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -2406,20 +2718,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -2428,15 +2735,11 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -2444,27 +2747,21 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -2472,27 +2769,21 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2500,17 +2791,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2518,7 +2804,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -2534,7 +2819,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
@@ -2543,15 +2827,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2570,7 +2852,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2578,21 +2859,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2605,7 +2883,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -2617,7 +2894,6 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
@@ -2625,7 +2901,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -2635,14 +2910,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2650,23 +2923,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -2686,10 +2952,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -2701,9 +2965,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2715,33 +2977,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2749,33 +3004,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -2786,25 +3025,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2812,50 +3045,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2870,20 +3073,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2891,36 +3090,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2935,20 +3118,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2956,36 +3135,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3000,20 +3163,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3021,33 +3180,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -3062,26 +3207,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3089,55 +3228,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3155,8 +3258,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3166,8 +3268,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3180,7 +3281,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3189,7 +3289,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3202,7 +3301,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3215,8 +3313,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -3224,7 +3321,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3243,8 +3339,7 @@
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.8",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -3266,7 +3361,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3276,8 +3371,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -3300,8 +3394,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -3438,7 +3531,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3446,8 +3539,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -3463,22 +3555,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -3487,7 +3576,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3499,14 +3587,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3514,15 +3600,13 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3540,30 +3624,26 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3571,21 +3651,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -3601,17 +3678,12 @@
                 "io.micrometer:micrometer-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3632,41 +3704,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3683,36 +3747,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3736,14 +3796,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3758,8 +3816,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -3768,21 +3825,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -3794,48 +3848,37 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -3843,24 +3886,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3868,7 +3905,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -3883,7 +3919,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
@@ -3892,15 +3927,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -3916,7 +3949,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3924,14 +3956,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
@@ -3944,7 +3974,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -3955,7 +3984,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -3965,7 +3993,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
@@ -3973,38 +4000,21 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -4014,8 +4024,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4025,8 +4034,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4036,7 +4044,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4044,7 +4051,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4052,7 +4058,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4060,7 +4065,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4076,10 +4080,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -4088,14 +4089,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -4119,7 +4119,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4253,21 +4252,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -4276,66 +4272,65 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4354,8 +4349,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -4367,15 +4361,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -4383,22 +4375,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -4418,8 +4407,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -4428,15 +4416,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -4444,8 +4430,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -4453,23 +4438,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -4485,23 +4467,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -4510,21 +4489,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -4536,28 +4512,24 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4565,7 +4537,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4574,16 +4545,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -4595,23 +4564,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4619,21 +4585,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -4648,14 +4611,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4669,12 +4630,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -4693,11 +4650,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4708,18 +4663,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4730,9 +4681,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -4745,7 +4694,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4754,24 +4702,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4787,14 +4732,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4820,21 +4763,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4844,8 +4784,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -4854,7 +4793,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4863,14 +4801,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -4878,18 +4814,13 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4898,15 +4829,11 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -4914,46 +4841,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4961,17 +4875,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4979,7 +4888,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4991,7 +4899,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -4999,7 +4906,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -5015,7 +4921,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -5023,21 +4928,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -5048,52 +4950,39 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "4.4.0",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -5101,11 +4990,9 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -5115,8 +5002,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -5124,12 +5010,8 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5137,8 +5019,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5146,34 +5026,13 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5185,22 +5044,11 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names"
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.github.curious-odd-man:rgxgen": {
-            "locked": "2.0",
-            "transitive": [
-                "net.datafaker:datafaker"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -5208,25 +5056,14 @@
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.25.2",
-            "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support"
-            ]
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:graphql-java-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -5250,7 +5087,960 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-example-shared": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-jakarta9"
+            ]
+        },
+        "io.micrometer:micrometer-jakarta9": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "io.projectreactor:reactor-test",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-actuator": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
+            ]
+        },
+        "com.github.curious-odd-man:rgxgen": {
+            "locked": "2.0",
+            "transitive": [
+                "net.datafaker:datafaker"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.2",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.graphql-java:graphql-java-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5388,7 +6178,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -5402,8 +6192,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -5419,22 +6208,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -5443,42 +6229,41 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -5486,25 +6271,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -5523,8 +6308,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -5536,15 +6320,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -5552,22 +6334,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -5587,8 +6366,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -5597,15 +6375,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -5613,8 +6389,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -5622,23 +6397,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -5654,23 +6426,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -5679,21 +6448,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -5707,28 +6473,24 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -5736,22 +6498,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -5760,16 +6519,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -5788,30 +6545,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -5819,35 +6572,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5862,15 +6610,13 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -5878,9 +6624,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -5891,9 +6634,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -5914,12 +6655,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -5930,19 +6669,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -5953,12 +6688,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -5979,36 +6712,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -6020,7 +6749,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6031,24 +6759,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -6056,16 +6781,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -6089,14 +6812,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6125,21 +6846,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -6154,8 +6872,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -6164,7 +6881,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -6173,14 +6889,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -6192,20 +6906,15 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -6214,15 +6923,11 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -6230,27 +6935,21 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -6258,27 +6957,21 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -6286,17 +6979,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -6304,7 +6992,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -6320,7 +7007,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
@@ -6329,15 +7015,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -6356,7 +7040,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -6364,21 +7047,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6391,7 +7071,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -6403,7 +7082,6 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
@@ -6411,7 +7089,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -6421,14 +7098,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6436,7 +7111,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -1,28 +1,18 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
@@ -30,23 +20,20 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -58,13 +45,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -86,8 +72,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -155,14 +140,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -170,12 +153,8 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -186,9 +165,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -201,49 +178,35 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -254,22 +217,226 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-context"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6"
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -320,18 +487,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -339,23 +497,20 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -367,13 +522,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -395,8 +549,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -464,14 +617,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -479,8 +630,7 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "net.sf.jopt-simple:jopt-simple": {
@@ -495,9 +645,6 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
@@ -507,9 +654,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -556,49 +701,35 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -609,21 +740,67 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -631,15 +808,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -655,8 +830,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -664,8 +838,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -673,16 +846,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -690,8 +861,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -717,7 +887,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -725,8 +895,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -749,7 +918,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -832,48 +1000,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -881,25 +1047,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -909,43 +1075,37 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -953,16 +1113,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -981,7 +1139,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -994,8 +1151,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1005,32 +1161,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1039,19 +1191,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1062,9 +1209,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1077,12 +1222,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1093,19 +1236,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1116,12 +1255,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1142,32 +1279,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1182,7 +1315,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1193,24 +1325,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1218,16 +1347,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1245,14 +1372,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1310,21 +1435,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1338,15 +1460,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1357,39 +1477,29 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1397,24 +1507,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1424,15 +1528,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1446,21 +1548,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1469,14 +1568,12 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1484,23 +1581,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1520,10 +1610,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1535,9 +1623,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1549,33 +1635,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1583,33 +1662,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1620,25 +1683,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1646,50 +1703,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1704,20 +1731,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1725,36 +1748,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1769,20 +1776,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1790,36 +1793,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1834,20 +1821,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1855,33 +1838,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1896,26 +1865,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1923,55 +1886,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1987,8 +1914,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1996,8 +1922,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2005,16 +1930,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -2022,8 +1945,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2049,7 +1971,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2057,8 +1979,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -2080,8 +2001,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2157,14 +2077,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2173,14 +2091,12 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -2199,44 +2115,35 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2249,41 +2156,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2300,32 +2199,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2346,14 +2241,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2367,15 +2260,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -2384,41 +2275,30 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2428,15 +2308,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2448,14 +2326,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2464,69 +2340,48 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2538,13 +2393,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -2567,7 +2421,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2642,72 +2495,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2716,35 +2567,30 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2753,16 +2599,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2774,23 +2618,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2805,14 +2646,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2820,12 +2659,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -2837,11 +2672,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2852,18 +2685,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2874,9 +2703,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2889,7 +2716,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2898,24 +2724,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2931,14 +2754,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2964,21 +2785,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2988,15 +2806,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3005,38 +2821,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3044,24 +2850,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3070,15 +2870,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3092,41 +2890,539 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor:reactor-test"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3135,15 +3431,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3159,8 +3453,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3168,8 +3461,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3177,16 +3469,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -3194,8 +3484,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -3221,7 +3510,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3229,8 +3518,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -3253,7 +3541,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3336,48 +3623,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3385,25 +3670,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3413,43 +3698,37 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3457,16 +3736,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3485,44 +3762,38 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3531,19 +3802,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3554,9 +3820,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3569,12 +3833,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3585,19 +3847,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3608,12 +3866,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3634,32 +3890,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3674,7 +3926,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3685,24 +3936,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3710,16 +3958,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3737,14 +3983,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3773,21 +4017,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3801,15 +4042,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3820,39 +4059,29 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3860,24 +4089,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3887,15 +4110,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3909,21 +4130,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3932,14 +4150,12 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3947,7 +4163,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -1,42 +1,34 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -57,8 +49,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -92,28 +83,21 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -125,47 +109,33 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -173,15 +143,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -191,14 +159,154 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework:spring-core"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
                 "org.springframework:spring-core"
             ]
         }
@@ -251,32 +359,19 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -297,8 +392,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -332,14 +426,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
@@ -355,17 +447,12 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -411,47 +498,33 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -459,15 +532,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -477,15 +548,64 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -493,15 +613,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -519,8 +637,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -530,8 +647,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -542,7 +658,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -551,7 +666,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -562,7 +676,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -573,8 +686,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -582,7 +694,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -611,7 +722,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -620,8 +731,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -644,7 +754,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -746,48 +855,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -795,25 +902,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -823,21 +930,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -845,22 +949,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -868,16 +969,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -896,7 +995,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -909,8 +1007,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -920,18 +1017,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -939,35 +1034,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -976,19 +1066,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -999,9 +1084,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1016,12 +1099,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1032,19 +1113,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1055,12 +1132,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1081,36 +1156,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -1122,7 +1193,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1133,24 +1203,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1158,16 +1225,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1185,14 +1250,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1250,21 +1313,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1278,15 +1338,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1295,20 +1353,15 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -1317,27 +1370,21 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -1345,21 +1392,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1367,17 +1411,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1385,7 +1424,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -1398,7 +1436,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1407,7 +1444,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1424,7 +1460,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1432,21 +1467,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1457,7 +1489,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -1468,7 +1499,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -1476,14 +1506,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1491,23 +1519,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1527,10 +1548,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1542,9 +1561,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1556,33 +1573,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1590,33 +1600,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1627,25 +1621,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1653,50 +1641,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1711,20 +1669,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1732,36 +1686,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1776,20 +1714,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1797,36 +1731,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1841,20 +1759,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1862,33 +1776,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1903,26 +1803,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1930,40 +1824,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -1980,8 +1840,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1989,8 +1848,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1998,24 +1856,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2041,15 +1896,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -2070,8 +1924,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2112,14 +1965,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2128,8 +1979,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2147,20 +1997,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2169,41 +2013,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2220,32 +2056,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2266,8 +2098,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2277,40 +2108,27 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2320,15 +2138,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2339,59 +2155,39 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2399,8 +2195,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2410,14 +2205,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -2440,7 +2234,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2534,71 +2327,69 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2607,28 +2398,24 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2637,16 +2424,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2658,23 +2443,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2689,14 +2471,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2704,12 +2484,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -2723,11 +2499,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2738,18 +2512,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2760,9 +2530,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2775,7 +2543,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2784,24 +2551,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2817,14 +2581,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2850,21 +2612,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2874,15 +2633,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2891,38 +2648,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2930,24 +2677,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -2955,15 +2696,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2976,35 +2715,532 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3013,15 +3249,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3039,8 +3273,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3050,8 +3283,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3062,7 +3294,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3071,7 +3302,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3082,7 +3312,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3093,8 +3322,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -3102,7 +3330,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3131,7 +3358,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3140,8 +3367,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -3164,7 +3390,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3266,48 +3491,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3315,25 +3538,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3343,21 +3566,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3365,22 +3585,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3388,16 +3605,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3416,30 +3631,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3447,35 +3658,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3484,19 +3690,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3507,9 +3708,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3524,12 +3723,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3540,19 +3737,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3563,12 +3756,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3589,36 +3780,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3630,7 +3817,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3641,24 +3827,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3666,16 +3849,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3693,14 +3874,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3729,21 +3908,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3757,15 +3933,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3774,20 +3948,15 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -3796,27 +3965,21 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -3824,21 +3987,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3846,17 +4006,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3864,7 +4019,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -3877,7 +4031,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3886,7 +4039,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3903,7 +4055,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3911,21 +4062,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3936,7 +4084,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -3947,7 +4094,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -3955,14 +4101,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3970,7 +4114,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -1,50 +1,27 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
+    "apiDependenciesMetadata": {
         "com.fasterxml:classmate": {
             "locked": "1.6.0",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -72,8 +49,131 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.el:jakarta.el-api": {
+            "locked": "4.0.0",
+            "transitive": [
+                "org.glassfish:jakarta.el"
+            ]
+        },
+        "jakarta.validation:jakarta.validation-api": {
+            "locked": "3.0.2",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.glassfish:jakarta.el": {
+            "locked": "4.0.2",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "8.0.1.Final",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.5.3.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "com.fasterxml:classmate": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-validation": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -107,14 +207,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
@@ -127,8 +225,7 @@
         "jakarta.validation:jakarta.validation-api": {
             "locked": "3.0.2",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "org.glassfish:jakarta.el": {
@@ -140,28 +237,21 @@
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.1.Final",
             "transitive": [
-                "com.graphql-java:graphql-java-extended-validation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java-extended-validation"
             ]
         },
         "org.jboss.logging:jboss-logging": {
             "locked": "3.5.3.Final",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -173,47 +263,33 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -221,15 +297,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -239,14 +313,198 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework:spring-core"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml:classmate": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-validation": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "jakarta.el:jakarta.el-api": {
+            "locked": "4.0.0",
+            "transitive": [
+                "org.glassfish:jakarta.el"
+            ]
+        },
+        "jakarta.validation:jakarta.validation-api": {
+            "locked": "3.0.2",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.glassfish:jakarta.el": {
+            "locked": "4.0.2",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "8.0.1.Final",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.5.3.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
                 "org.springframework:spring-core"
             ]
         }
@@ -299,40 +557,26 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.fasterxml:classmate": {
             "locked": "1.6.0",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -360,8 +604,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -395,14 +638,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
@@ -415,8 +656,7 @@
         "jakarta.validation:jakarta.validation-api": {
             "locked": "3.0.2",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "net.sf.jopt-simple:jopt-simple": {
@@ -440,28 +680,21 @@
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.1.Final",
             "transitive": [
-                "com.graphql-java:graphql-java-extended-validation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java-extended-validation"
             ]
         },
         "org.jboss.logging:jboss-logging": {
             "locked": "3.5.3.Final",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -507,47 +740,33 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -555,15 +774,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -573,15 +790,64 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -589,15 +855,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -615,8 +879,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -626,8 +889,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -638,7 +900,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -647,7 +908,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -658,7 +918,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -669,8 +928,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -678,7 +936,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -697,8 +954,7 @@
         "com.fasterxml:classmate": {
             "locked": "1.6.0",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -714,7 +970,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -724,8 +980,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -755,7 +1010,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -857,48 +1111,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -906,25 +1158,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -934,21 +1186,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -962,29 +1211,25 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.validation:jakarta.validation-api": {
             "locked": "3.0.2",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -992,16 +1237,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1020,7 +1263,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1033,8 +1275,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1044,18 +1285,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1063,35 +1302,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1106,33 +1340,26 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.1.Final",
             "transitive": [
-                "com.graphql-java:graphql-java-extended-validation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java-extended-validation"
             ]
         },
         "org.jboss.logging:jboss-logging": {
             "locked": "3.5.3.Final",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1143,9 +1370,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1160,12 +1385,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1176,19 +1399,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1199,12 +1418,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1225,36 +1442,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -1266,7 +1479,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1277,24 +1489,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1302,16 +1511,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1329,14 +1536,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1394,21 +1599,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1422,15 +1624,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1439,20 +1639,15 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -1461,27 +1656,21 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -1489,21 +1678,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1511,17 +1697,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1529,7 +1710,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -1542,7 +1722,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1551,7 +1730,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1568,7 +1746,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1576,21 +1753,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1601,7 +1775,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -1612,7 +1785,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -1620,14 +1792,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1635,23 +1805,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1671,10 +1834,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1686,9 +1847,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1700,33 +1859,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1734,33 +1886,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1771,25 +1907,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1797,50 +1927,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1855,20 +1955,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1876,36 +1972,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1920,20 +2000,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1941,36 +2017,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1985,20 +2045,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2006,33 +2062,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2047,26 +2089,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2074,40 +2110,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -2124,8 +2126,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2133,8 +2134,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2142,24 +2142,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2175,8 +2172,7 @@
         "com.fasterxml:classmate": {
             "locked": "1.6.0",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -2192,7 +2188,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2200,8 +2196,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -2229,8 +2224,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2271,14 +2265,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2287,8 +2279,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.el:jakarta.el-api": {
@@ -2300,8 +2291,7 @@
         "jakarta.validation:jakarta.validation-api": {
             "locked": "3.0.2",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2319,8 +2309,7 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.glassfish:jakarta.el": {
@@ -2332,27 +2321,20 @@
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.1.Final",
             "transitive": [
-                "com.graphql-java:graphql-java-extended-validation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java-extended-validation"
             ]
         },
         "org.jboss.logging:jboss-logging": {
             "locked": "3.5.3.Final",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2361,41 +2343,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2412,32 +2386,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2458,8 +2428,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2469,40 +2438,27 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2512,15 +2468,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2531,59 +2485,39 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2591,8 +2525,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2604,20 +2537,18 @@
         "com.fasterxml:classmate": {
             "locked": "1.6.0",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -2647,7 +2578,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2741,71 +2671,69 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2814,21 +2742,18 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -2841,14 +2766,12 @@
         "jakarta.validation:jakarta.validation-api": {
             "locked": "3.0.2",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2857,16 +2780,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2878,23 +2799,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2909,14 +2827,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2930,26 +2846,20 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.1.Final",
             "transitive": [
-                "com.graphql-java:graphql-java-extended-validation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java-extended-validation"
             ]
         },
         "org.jboss.logging:jboss-logging": {
             "locked": "3.5.3.Final",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -2963,11 +2873,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2978,18 +2886,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3000,9 +2904,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3015,7 +2917,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3024,24 +2925,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3057,14 +2955,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3090,21 +2986,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3114,15 +3007,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3131,38 +3022,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3170,24 +3051,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -3195,15 +3070,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3216,180 +3089,76 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "4.4.0",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-json"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-annotations",
-                "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+                "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.fasterxml:classmate": {
             "locked": "1.6.0",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.github.curious-odd-man:rgxgen": {
-            "locked": "2.0",
-            "transitive": [
-                "net.datafaker:datafaker"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.25.2",
-            "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:graphql-java-extended-scalars",
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -3419,7 +3188,640 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.el:jakarta.el-api": {
+            "locked": "4.0.0",
+            "transitive": [
+                "org.glassfish:jakarta.el"
+            ]
+        },
+        "jakarta.validation:jakarta.validation-api": {
+            "locked": "3.0.2",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.glassfish:jakarta.el": {
+            "locked": "4.0.2",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hibernate.validator:hibernate-validator": {
+            "locked": "8.0.1.Final",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation"
+            ]
+        },
+        "org.jboss.logging:jboss-logging": {
+            "locked": "3.5.3.Final",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.fasterxml:classmate": {
+            "locked": "1.6.0",
+            "transitive": [
+                "org.hibernate.validator:hibernate-validator"
+            ]
+        },
+        "com.github.curious-odd-man:rgxgen": {
+            "locked": "2.0",
+            "transitive": [
+                "net.datafaker:datafaker"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.2",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.graphql-java:graphql-java-extended-scalars",
+                "com.graphql-java:graphql-java-extended-validation",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.graphql-java:graphql-java-extended-validation",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-validation": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3521,48 +3923,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3570,25 +3970,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3598,21 +3998,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3626,29 +4023,25 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.validation:jakarta.validation-api": {
             "locked": "3.0.2",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3656,16 +4049,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3684,30 +4075,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3715,35 +4102,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3758,33 +4140,26 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hibernate.validator:hibernate-validator": {
             "locked": "8.0.1.Final",
             "transitive": [
-                "com.graphql-java:graphql-java-extended-validation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java-extended-validation"
             ]
         },
         "org.jboss.logging:jboss-logging": {
             "locked": "3.5.3.Final",
             "transitive": [
-                "org.hibernate.validator:hibernate-validator",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.hibernate.validator:hibernate-validator"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3795,9 +4170,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3812,12 +4185,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3828,19 +4199,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3851,12 +4218,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3877,36 +4242,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3918,7 +4279,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3929,24 +4289,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3954,16 +4311,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3981,14 +4336,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4017,21 +4370,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4045,15 +4395,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4062,20 +4410,15 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -4084,27 +4427,21 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -4112,21 +4449,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4134,17 +4468,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4152,7 +4481,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -4165,7 +4493,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -4174,7 +4501,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4191,7 +4517,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4199,21 +4524,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4224,7 +4546,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -4235,7 +4556,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -4243,14 +4563,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4258,7 +4576,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -1,34 +1,46 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
             "transitive": [
@@ -36,10 +48,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -55,15 +66,8 @@
         "net.datafaker:datafaker": {
             "locked": "2.2.2"
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -74,28 +78,67 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.github.curious-odd-man:rgxgen": {
+            "locked": "2.0",
+            "transitive": [
+                "net.datafaker:datafaker"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "net.datafaker:datafaker": {
+            "locked": "2.2.2"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "net.datafaker:datafaker"
             ]
         }
     },
@@ -147,24 +190,12 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
             "transitive": [
@@ -172,10 +203,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -203,15 +233,8 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -256,28 +279,70 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -285,19 +350,14 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -306,10 +366,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -323,7 +382,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -339,47 +397,45 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -387,25 +443,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -413,29 +469,25 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -443,16 +495,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -468,7 +518,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -485,32 +534,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -519,19 +564,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -539,20 +579,16 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -563,19 +599,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -586,10 +618,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -605,16 +635,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -629,7 +657,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -640,24 +667,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -665,16 +689,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -692,14 +714,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -755,21 +775,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -781,15 +798,13 @@
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -798,38 +813,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -837,24 +842,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -862,15 +861,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -883,28 +880,24 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -912,23 +905,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -948,10 +934,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -963,9 +947,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -977,33 +959,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1011,33 +986,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1048,25 +1007,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1074,50 +1027,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1132,20 +1055,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1153,36 +1072,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1197,20 +1100,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1218,36 +1117,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1262,20 +1145,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1283,33 +1162,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1324,26 +1189,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1351,46 +1210,9 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
             "transitive": [
@@ -1398,10 +1220,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1417,15 +1238,8 @@
         "net.datafaker:datafaker": {
             "locked": "2.2.2"
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -1436,63 +1250,35 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -1501,10 +1287,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1518,7 +1303,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1534,71 +1318,69 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1606,21 +1388,18 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1629,16 +1408,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1653,23 +1430,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1684,14 +1458,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1699,21 +1471,15 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1724,18 +1490,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1746,9 +1508,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1761,7 +1521,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1770,24 +1529,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1803,14 +1559,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1835,21 +1589,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1859,15 +1610,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1876,38 +1625,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1915,24 +1654,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -1940,15 +1673,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1961,28 +1692,24 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1990,28 +1717,22 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -2020,10 +1741,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2037,7 +1757,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2053,73 +1772,39 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-jvm"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-agent-api"
-            ]
-        },
-        "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
+                "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-core"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-dsl"
-            ]
-        },
-        "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2127,29 +1812,447 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.datafaker:datafaker": {
+            "locked": "2.2.2"
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "net.datafaker:datafaker",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.github.curious-odd-man:rgxgen": {
+            "locked": "2.0",
+            "transitive": [
+                "net.datafaker:datafaker"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-api"
+            ]
+        },
+        "io.mockk:mockk-agent-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-dsl-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-core-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-core"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-dsl-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-dsl"
+            ]
+        },
+        "io.mockk:mockk-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -2157,16 +2260,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2182,37 +2283,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2221,19 +2317,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2241,20 +2332,16 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2265,19 +2352,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2288,10 +2371,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2307,16 +2388,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2331,7 +2410,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2342,24 +2420,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2367,16 +2442,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2394,14 +2467,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2428,21 +2499,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2454,15 +2522,13 @@
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2471,38 +2537,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2510,24 +2566,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -2535,15 +2585,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2556,28 +2604,24 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2585,7 +2629,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -1,42 +1,20 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
+    "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -51,8 +29,81 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -86,28 +137,21 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -119,47 +163,33 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -167,15 +197,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -185,14 +213,148 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework:spring-core"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
                 "org.springframework:spring-core"
             ]
         }
@@ -245,32 +407,19 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -285,8 +434,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -320,14 +468,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
@@ -343,17 +489,12 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -399,47 +540,33 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -447,15 +574,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -465,15 +590,64 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -481,15 +655,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -505,8 +677,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -514,8 +685,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -523,24 +693,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -566,14 +733,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -589,7 +755,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -637,48 +802,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -686,25 +849,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -713,36 +876,31 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -750,16 +908,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -778,7 +934,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -795,32 +950,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -829,19 +980,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -851,9 +997,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -862,12 +1006,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -878,19 +1020,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -901,12 +1039,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -927,32 +1063,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -967,7 +1099,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -978,24 +1109,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1003,16 +1131,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1030,14 +1156,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1095,21 +1219,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1123,15 +1244,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1140,38 +1259,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1179,24 +1288,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1206,15 +1309,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1228,35 +1329,30 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1264,23 +1360,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1300,10 +1389,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1315,9 +1402,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1329,33 +1414,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1363,33 +1441,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1400,25 +1462,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1426,50 +1482,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1484,20 +1510,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1505,36 +1527,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1549,20 +1555,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1570,36 +1572,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1614,20 +1600,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1635,33 +1617,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1676,26 +1644,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1703,40 +1665,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -1753,8 +1681,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1762,8 +1689,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1771,24 +1697,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -1814,14 +1737,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1836,8 +1758,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -1878,14 +1799,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -1894,8 +1813,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1913,20 +1831,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1935,41 +1847,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1986,32 +1890,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2032,8 +1932,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2043,40 +1942,27 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2086,15 +1972,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2105,72 +1989,48 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2186,7 +2046,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2227,71 +2086,69 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2299,21 +2156,18 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2322,16 +2176,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2343,23 +2195,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2374,14 +2223,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2389,12 +2236,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -2402,11 +2245,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2417,18 +2258,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2439,9 +2276,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2454,7 +2289,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2463,24 +2297,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2496,14 +2327,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2528,21 +2357,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2552,15 +2378,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2569,38 +2393,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2608,24 +2422,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -2633,15 +2441,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2654,35 +2460,443 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -2691,15 +2905,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2715,8 +2927,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2724,8 +2935,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2733,24 +2943,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2776,14 +2983,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2799,7 +3005,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2847,48 +3052,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2896,25 +3099,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2923,36 +3126,31 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -2960,16 +3158,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2988,37 +3184,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3027,19 +3218,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3049,9 +3235,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3060,12 +3244,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3076,19 +3258,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3099,12 +3277,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3125,32 +3301,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3165,7 +3337,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3176,24 +3347,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3201,16 +3369,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3228,14 +3394,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3264,21 +3428,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3292,15 +3453,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3309,38 +3468,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3348,24 +3497,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3375,15 +3518,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3397,35 +3538,30 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3433,7 +3569,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-platform-dependencies/dependencies.lock
+++ b/graphql-dgs-platform-dependencies/dependencies.lock
@@ -3,19 +3,5 @@
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
         }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
     }
 }

--- a/graphql-dgs-platform/dependencies.lock
+++ b/graphql-dgs-platform/dependencies.lock
@@ -1,16 +1,3 @@
 {
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    }
+    
 }

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -1,94 +1,20 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.4.14",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-logging"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.4.14",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-annotations",
-                "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-kotlin"
-            ]
-        },
+    "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -103,8 +29,130 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -138,65 +186,51 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -205,39 +239,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -249,16 +275,14 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -272,14 +296,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -289,55 +311,40 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -347,15 +354,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -368,35 +373,343 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6"
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "locked": "1.2.2"
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.kotlin:reactor-kotlin-extensions"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib",
+                "org.jetbrains.kotlinx:atomicfu",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+            ]
+        },
+        "org.jetbrains.kotlinx:atomicfu": {
+            "locked": "0.21.0",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.7.3"
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
             ]
         }
     },
@@ -448,33 +761,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -482,31 +784,27 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -519,13 +817,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -540,8 +837,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -575,37 +871,30 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -622,30 +911,23 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -654,39 +936,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -698,16 +972,14 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -755,14 +1027,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -772,55 +1042,40 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -830,15 +1085,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -851,35 +1104,79 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -887,15 +1184,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -911,8 +1206,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -920,8 +1214,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -929,16 +1222,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -946,8 +1237,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -973,14 +1263,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -996,7 +1285,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1063,48 +1351,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1112,34 +1398,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
@@ -1147,43 +1430,37 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1191,16 +1468,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1219,7 +1494,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1232,8 +1506,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1243,32 +1516,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1277,19 +1546,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1300,9 +1564,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1313,12 +1575,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1329,19 +1589,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1352,12 +1608,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1378,32 +1632,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1418,7 +1668,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1429,24 +1678,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1454,16 +1700,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1481,14 +1725,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1546,21 +1788,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1574,15 +1813,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1591,39 +1828,29 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1631,24 +1858,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1658,15 +1879,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1680,21 +1899,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1703,14 +1919,12 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1718,23 +1932,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1754,10 +1961,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1769,9 +1974,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1783,33 +1986,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1817,33 +2013,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1854,25 +2034,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1880,50 +2054,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1938,20 +2082,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1959,36 +2099,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2003,20 +2127,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2024,36 +2144,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2068,20 +2172,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2089,33 +2189,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2130,26 +2216,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2157,40 +2237,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -2207,8 +2253,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2216,8 +2261,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2225,24 +2269,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2268,14 +2309,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2290,8 +2330,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2332,31 +2371,25 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2374,20 +2407,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2396,41 +2423,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2447,32 +2466,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2493,8 +2508,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2504,27 +2518,18 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2533,14 +2538,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2551,59 +2554,39 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2611,31 +2594,27 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2648,13 +2627,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2670,7 +2648,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2729,115 +2706,105 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
-                "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2846,16 +2813,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2867,23 +2832,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2898,14 +2860,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2913,19 +2873,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2936,12 +2890,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2952,19 +2904,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2975,10 +2923,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2990,16 +2936,14 @@
         "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3013,7 +2957,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3022,24 +2965,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3055,14 +2995,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3088,21 +3026,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3112,15 +3047,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3129,38 +3062,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3168,24 +3091,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -3193,15 +3110,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3214,35 +3129,550 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "locked": "1.2.2"
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.kotlin:reactor-kotlin-extensions",
+                "io.projectreactor:reactor-test"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib",
+                "org.jetbrains.kotlinx:atomicfu",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+            ]
+        },
+        "org.jetbrains.kotlinx:atomicfu": {
+            "locked": "0.21.0",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.7.3"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3251,15 +3681,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3275,8 +3703,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3284,8 +3711,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3293,16 +3719,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -3310,8 +3734,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -3337,14 +3760,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3360,7 +3782,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3427,48 +3848,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3476,34 +3895,31 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
@@ -3511,43 +3927,37 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3555,16 +3965,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3583,44 +3991,38 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3629,19 +4031,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3652,9 +4049,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3665,12 +4060,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3681,19 +4074,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3704,12 +4093,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3730,32 +4117,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3770,7 +4153,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3781,24 +4163,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3806,16 +4185,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3833,14 +4210,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3869,21 +4244,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3897,15 +4269,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3914,39 +4284,29 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3954,24 +4314,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3981,15 +4335,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4003,21 +4355,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4026,14 +4375,12 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4041,7 +4388,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -1,43 +1,34 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -47,8 +38,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -58,8 +48,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -69,7 +58,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -77,7 +65,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -85,7 +72,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -93,7 +79,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -109,10 +94,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -121,14 +103,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -144,8 +125,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -230,33 +210,25 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12"
+            "locked": "1.7.13"
         },
         "commons-codec:commons-codec": {
-            "locked": "1.16.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.16.1"
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.12.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.12.5"
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -265,37 +237,30 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.14.13",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.14.13"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -303,21 +268,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -326,9 +288,6 @@
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -341,9 +300,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -356,14 +313,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -373,8 +328,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -383,38 +337,28 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -422,37 +366,27 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -460,7 +394,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -472,22 +405,17 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -501,7 +429,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -509,14 +436,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -525,15 +450,574 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.7.13"
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.16.1"
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5"
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-context-support"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context-support"
+            ]
+        },
+        "org.springframework:spring-context-support": {
+            "locked": "6.1.6"
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-context-support",
+                "org.springframework:spring-expression"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
             ]
         }
     },
@@ -585,33 +1069,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -621,8 +1094,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -632,8 +1104,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -643,7 +1114,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -651,7 +1121,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -659,7 +1128,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -667,7 +1135,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -683,10 +1150,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -695,14 +1159,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -718,8 +1181,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -804,33 +1266,25 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12"
+            "locked": "1.7.13"
         },
         "commons-codec:commons-codec": {
-            "locked": "1.16.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.16.1"
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.12.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.12.5"
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -839,23 +1293,18 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.14.13",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.14.13"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -870,18 +1319,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -889,21 +1336,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -912,9 +1356,6 @@
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -927,9 +1368,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -976,14 +1415,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -993,8 +1430,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -1003,38 +1439,28 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -1042,37 +1468,27 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1080,7 +1496,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -1092,22 +1507,17 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1121,7 +1531,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1129,14 +1538,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -1145,15 +1552,64 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -1161,15 +1617,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1187,8 +1641,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1198,8 +1651,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1211,7 +1663,6 @@
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1220,7 +1671,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1232,7 +1682,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1243,8 +1692,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -1252,7 +1700,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1269,10 +1716,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -1293,7 +1737,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1301,8 +1745,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1319,7 +1762,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1405,7 +1847,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12"
+            "locked": "1.7.13"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -1414,10 +1856,7 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.16.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.16.1"
         },
         "io.micrometer:context-propagation": {
             "locked": "1.1.1",
@@ -1431,55 +1870,50 @@
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.12.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.12.5"
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1487,25 +1921,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1515,21 +1949,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1537,22 +1968,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1560,16 +1988,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1588,7 +2014,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1601,8 +2026,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1612,18 +2036,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1631,35 +2053,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1674,15 +2091,13 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -1690,9 +2105,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1703,9 +2115,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1720,12 +2130,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1736,19 +2144,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1759,12 +2163,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1785,36 +2187,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -1826,7 +2224,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1837,24 +2234,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1862,16 +2256,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1895,14 +2287,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1960,21 +2350,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1989,8 +2376,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -1999,7 +2385,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2008,34 +2393,25 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -2044,27 +2420,21 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -2072,21 +2442,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2094,17 +2461,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2112,7 +2474,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -2126,23 +2487,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2160,7 +2516,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2168,21 +2523,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2193,7 +2545,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -2204,7 +2555,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -2212,14 +2562,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2227,23 +2575,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -2263,10 +2604,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -2278,9 +2617,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2292,33 +2629,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2326,33 +2656,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -2363,25 +2677,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2389,50 +2697,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2447,20 +2725,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2468,36 +2742,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2512,20 +2770,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2533,36 +2787,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2577,20 +2815,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2598,33 +2832,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2639,26 +2859,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2666,40 +2880,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -2716,8 +2896,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2725,8 +2904,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2734,24 +2912,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2765,10 +2940,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -2789,14 +2961,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2811,8 +2982,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2844,13 +3014,10 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12"
+            "locked": "1.7.13"
         },
         "commons-codec:commons-codec": {
-            "locked": "1.16.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.16.1"
         },
         "io.micrometer:context-propagation": {
             "locked": "1.1.1",
@@ -2863,21 +3030,16 @@
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.12.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.12.5"
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2886,15 +3048,11 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.14.13",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.14.13"
         },
         "net.datafaker:datafaker": {
             "locked": "2.2.2",
@@ -2911,8 +3069,7 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.checkerframework:checker-qual": {
@@ -2927,16 +3084,11 @@
                 "io.micrometer:micrometer-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2945,41 +3097,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2996,32 +3140,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3048,8 +3188,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -3060,27 +3199,18 @@
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.spectator:spectator-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.spectator:spectator-api"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -3091,20 +3221,15 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -3116,59 +3241,39 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -3178,8 +3283,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3189,8 +3293,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3200,7 +3303,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3208,7 +3310,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3216,7 +3317,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3224,7 +3324,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3240,10 +3339,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -3252,14 +3348,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3276,7 +3371,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3362,7 +3456,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12"
+            "locked": "1.7.13"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -3371,88 +3465,80 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.16.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.16.1"
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.12.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.12.5"
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3461,21 +3547,18 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3483,7 +3566,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3492,16 +3574,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -3513,23 +3593,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3537,21 +3614,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -3566,14 +3640,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3587,12 +3659,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -3606,11 +3674,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3621,18 +3687,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3643,9 +3705,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3658,7 +3718,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3667,24 +3726,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3700,14 +3756,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3733,21 +3787,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3757,8 +3808,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -3767,7 +3817,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3776,32 +3825,23 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -3810,40 +3850,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3851,17 +3881,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3869,7 +3894,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -3881,22 +3905,17 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3912,7 +3931,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3920,21 +3938,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -3943,45 +3958,33 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "4.4.0",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -3989,11 +3992,9 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4003,8 +4004,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4012,11 +4012,8 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4024,8 +4021,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4033,31 +4028,13 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4069,21 +4046,11 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names"
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.github.curious-odd-man:rgxgen": {
-            "locked": "2.0",
-            "transitive": [
-                "net.datafaker:datafaker"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -4091,23 +4058,14 @@
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.25.2",
-            "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support"
-            ]
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -4124,7 +4082,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4210,7 +4167,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12"
+            "locked": "1.7.13"
         },
         "com.vaadin.external.google:android-json": {
             "locked": "0.0.20131108.vaadin1",
@@ -4219,10 +4176,695 @@
             ]
         },
         "commons-codec:commons-codec": {
-            "locked": "1.16.1",
+            "locked": "1.16.1"
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-observation"
             ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5"
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-context-support",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-context-support",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context-support": {
+            "locked": "6.1.6"
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-context-support",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.github.curious-odd-man:rgxgen": {
+            "locked": "2.0",
+            "transitive": [
+                "net.datafaker:datafaker"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.2",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.7.13"
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.16.1"
         },
         "io.micrometer:context-propagation": {
             "locked": "1.1.1",
@@ -4236,55 +4878,50 @@
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.12.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.12.5"
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4292,25 +4929,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4320,21 +4957,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4342,22 +4976,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -4365,16 +4996,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -4393,30 +5022,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4424,35 +5049,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4467,15 +5087,13 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -4483,9 +5101,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -4496,9 +5111,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4513,12 +5126,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4529,19 +5140,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4552,12 +5159,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -4578,36 +5183,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4619,7 +5220,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4630,24 +5230,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -4655,16 +5252,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4688,14 +5283,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4724,21 +5317,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4753,8 +5343,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -4763,7 +5352,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4772,34 +5360,25 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -4808,27 +5387,21 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -4836,21 +5409,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4858,17 +5428,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4876,7 +5441,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -4890,23 +5454,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-context-support": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4924,7 +5483,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4932,21 +5490,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4957,7 +5512,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -4968,7 +5522,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -4976,14 +5529,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4991,7 +5542,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -1,53 +1,41 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -56,13 +44,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -77,8 +64,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -128,21 +114,16 @@
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.12.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.12.5"
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -150,42 +131,32 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.13.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.13.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -195,18 +166,13 @@
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -219,14 +185,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -236,55 +200,40 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -293,15 +242,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -314,33 +261,306 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5"
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5"
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.13.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -393,43 +613,26 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -438,13 +641,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -459,8 +661,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -510,21 +711,16 @@
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
-            "locked": "1.12.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.12.5"
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
                 "io.micrometer:micrometer-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -532,22 +728,17 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -556,10 +747,7 @@
             ]
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.13.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.13.0"
         },
         "org.apache.commons:commons-math3": {
             "locked": "3.6.1",
@@ -568,18 +756,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -589,18 +775,13 @@
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -647,14 +828,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -664,55 +843,40 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -721,15 +885,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -742,34 +904,76 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -777,15 +981,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -801,8 +1003,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -812,8 +1013,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -824,7 +1024,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -832,7 +1031,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -841,7 +1039,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -850,15 +1047,13 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -875,10 +1070,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -899,14 +1091,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -922,7 +1113,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -979,48 +1169,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1028,25 +1216,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1055,21 +1243,18 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1077,15 +1262,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1093,16 +1276,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1121,7 +1302,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1132,10 +1312,7 @@
             ]
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.13.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.13.0"
         },
         "org.apache.commons:commons-math3": {
             "locked": "3.6.1",
@@ -1144,18 +1321,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1163,35 +1338,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1206,19 +1376,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1229,9 +1394,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1241,12 +1404,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1257,19 +1418,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1280,12 +1437,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1306,32 +1461,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1346,7 +1497,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1357,24 +1507,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1382,16 +1529,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1409,14 +1554,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1474,21 +1617,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1502,15 +1642,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1519,18 +1657,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -1539,40 +1672,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1580,17 +1703,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1598,7 +1716,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1610,7 +1727,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -1618,7 +1734,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1633,7 +1748,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1641,14 +1755,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1657,7 +1769,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -1666,14 +1777,12 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1681,23 +1790,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1717,10 +1819,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1732,9 +1832,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1746,33 +1844,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1780,33 +1871,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1817,25 +1892,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1843,50 +1912,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1901,20 +1940,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1922,36 +1957,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1966,20 +1985,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1987,36 +2002,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2031,20 +2030,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2052,33 +2047,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2093,26 +2074,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2120,55 +2095,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2184,8 +2123,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2193,8 +2131,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2202,16 +2139,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -2219,8 +2154,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2246,14 +2180,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2268,8 +2201,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2319,14 +2251,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2335,14 +2265,12 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -2361,43 +2289,32 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.13.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.13.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2407,41 +2324,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2458,32 +2367,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2504,14 +2409,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2525,55 +2428,40 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2583,15 +2471,13 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2603,14 +2489,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2618,46 +2502,28 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2665,8 +2531,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2676,8 +2541,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2687,7 +2551,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2695,7 +2558,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2703,7 +2565,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2711,7 +2572,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2727,10 +2587,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -2739,13 +2596,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2761,7 +2617,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2817,72 +2672,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2890,21 +2743,18 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2912,7 +2762,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2921,16 +2770,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2942,29 +2789,23 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.13.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.13.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2972,21 +2813,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -3001,14 +2839,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3022,12 +2858,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -3036,11 +2868,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3051,18 +2881,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3073,9 +2899,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3088,7 +2912,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3097,24 +2920,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3130,14 +2950,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3163,21 +2981,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3187,15 +3002,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3204,18 +3017,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -3224,40 +3032,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3265,17 +3063,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3283,7 +3076,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3294,7 +3086,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -3302,7 +3093,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3317,7 +3107,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3325,21 +3114,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -3348,21 +3134,591 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.13.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3371,15 +3727,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3395,8 +3749,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3406,8 +3759,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3418,7 +3770,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3426,7 +3777,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3435,7 +3785,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3444,15 +3793,13 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3469,10 +3816,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -3493,14 +3837,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3516,7 +3859,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3573,48 +3915,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3622,25 +3962,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3649,21 +3989,18 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3671,15 +4008,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3687,16 +4022,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3715,29 +4048,23 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
-            "locked": "3.13.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.13.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3745,35 +4072,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3788,19 +4110,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3811,9 +4128,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3823,12 +4138,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3839,19 +4152,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3862,12 +4171,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3888,32 +4195,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3928,7 +4231,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3939,24 +4241,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3964,16 +4263,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3991,14 +4288,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4027,21 +4322,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4055,15 +4347,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4072,18 +4362,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -4092,40 +4377,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4133,17 +4408,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4151,7 +4421,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4163,7 +4432,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -4171,7 +4439,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4186,7 +4453,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4194,14 +4460,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4210,7 +4474,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -4219,14 +4482,12 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4234,7 +4495,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -1,122 +1,35 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.4.14",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-logging"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.4.14",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
+    "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-json"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-annotations",
-                "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+                "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -132,8 +45,212 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -209,14 +326,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -225,31 +340,27 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -257,26 +368,20 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -288,9 +393,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -303,14 +406,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -320,32 +421,25 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -353,44 +447,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -398,7 +481,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -410,7 +492,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -419,7 +500,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -434,7 +514,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -442,21 +521,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -466,21 +542,418 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-websocket"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-websocket": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-messaging",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-messaging",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-messaging": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-websocket"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework:spring-websocket": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-websocket"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -533,33 +1006,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -569,8 +1031,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -580,8 +1041,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -591,7 +1051,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -599,7 +1058,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -607,7 +1065,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -615,7 +1072,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -631,14 +1087,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -654,8 +1109,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -731,14 +1185,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -747,14 +1199,12 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -772,18 +1222,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -791,26 +1239,20 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -822,9 +1264,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -871,14 +1311,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -888,32 +1326,25 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -921,44 +1352,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -966,7 +1386,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -978,7 +1397,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -987,7 +1405,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1002,7 +1419,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1010,21 +1426,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -1034,22 +1447,70 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -1057,15 +1518,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1083,8 +1542,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1094,8 +1552,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1106,7 +1563,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1115,7 +1571,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1126,7 +1581,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1137,8 +1591,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -1146,7 +1599,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1175,7 +1627,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1183,8 +1635,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1201,7 +1652,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1292,48 +1742,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1341,25 +1789,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1369,21 +1817,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1391,22 +1836,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1414,16 +1856,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1442,7 +1882,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1455,8 +1894,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1466,18 +1904,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1485,35 +1921,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1522,19 +1953,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1545,9 +1971,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1561,12 +1985,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1577,19 +1999,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1600,12 +2018,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1626,36 +2042,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -1667,7 +2079,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1678,24 +2089,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1703,16 +2111,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1730,14 +2136,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1795,21 +2199,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1823,15 +2224,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1840,20 +2239,15 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -1862,47 +2256,36 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1910,17 +2293,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1928,7 +2306,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -1941,7 +2318,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1950,7 +2326,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1967,7 +2342,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1975,21 +2349,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2000,7 +2371,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -2011,7 +2381,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -2019,14 +2388,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2034,23 +2401,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -2070,10 +2430,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -2085,9 +2443,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2099,33 +2455,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2133,33 +2482,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -2170,25 +2503,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2196,50 +2523,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2254,20 +2551,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2275,36 +2568,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2319,20 +2596,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2340,36 +2613,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2384,20 +2641,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2405,33 +2658,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2446,26 +2685,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2473,55 +2706,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2539,8 +2736,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2550,8 +2746,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2562,7 +2757,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2571,7 +2765,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2582,7 +2775,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2593,8 +2785,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -2602,7 +2793,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2631,7 +2821,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2639,8 +2829,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2656,8 +2845,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2741,14 +2929,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2758,14 +2944,12 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2773,8 +2957,7 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2792,30 +2975,26 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2823,35 +3002,27 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2865,41 +3036,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2916,36 +3079,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2963,14 +3122,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2984,34 +3141,27 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3019,44 +3169,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3064,7 +3203,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -3077,7 +3215,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3086,7 +3223,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -3101,7 +3237,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3109,14 +3244,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
@@ -3127,7 +3260,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -3138,7 +3270,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -3146,7 +3277,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
@@ -3154,38 +3284,21 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -3195,8 +3308,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3206,8 +3318,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3217,7 +3328,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3225,7 +3335,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3233,7 +3342,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3241,7 +3349,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3257,14 +3364,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3281,7 +3387,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3364,72 +3469,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3438,21 +3541,18 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3460,7 +3560,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3469,16 +3568,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -3490,23 +3587,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3514,21 +3608,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -3543,14 +3634,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3558,12 +3647,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -3576,11 +3661,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3591,18 +3674,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3613,9 +3692,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3628,7 +3705,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3637,24 +3713,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3670,14 +3743,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3703,21 +3774,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3727,15 +3795,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3744,18 +3810,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -3764,47 +3825,36 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3812,17 +3862,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3830,7 +3875,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -3842,7 +3886,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3851,7 +3894,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3868,7 +3910,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3876,28 +3917,24 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -3907,28 +3944,638 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-websocket"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-websocket": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-messaging",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-messaging",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-messaging": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-websocket"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework:spring-websocket": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-websocket"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3937,15 +4584,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3963,8 +4608,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3974,8 +4618,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3986,7 +4629,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3995,7 +4637,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4006,7 +4647,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4017,8 +4657,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -4026,7 +4665,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4055,7 +4693,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4063,8 +4701,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -4081,7 +4718,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4172,48 +4808,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4221,25 +4855,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4249,21 +4883,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -4271,22 +4902,19 @@
         "jakarta.servlet:jakarta.servlet-api": {
             "locked": "6.0.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -4294,16 +4922,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -4322,30 +4948,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4353,35 +4975,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4390,19 +5007,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -4413,9 +5025,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4429,12 +5039,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4445,19 +5053,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4468,12 +5072,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -4494,36 +5096,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4535,7 +5133,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4546,24 +5143,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -4571,16 +5165,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4598,14 +5190,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4634,21 +5224,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4662,15 +5249,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4679,20 +5264,15 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -4701,47 +5281,36 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework.boot:spring-boot-starter-websocket": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4749,17 +5318,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4767,7 +5331,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-messaging",
@@ -4780,7 +5343,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -4789,7 +5351,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4806,7 +5367,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4814,21 +5374,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-messaging": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4839,7 +5396,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -4850,7 +5406,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -4858,14 +5413,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-websocket"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4873,7 +5426,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
@@ -1,43 +1,31 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -47,8 +35,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -58,8 +45,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -69,7 +55,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -77,7 +62,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -85,7 +69,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -93,7 +76,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -109,10 +91,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -121,14 +100,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -145,8 +123,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -264,21 +241,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -287,7 +261,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -307,8 +280,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -320,15 +292,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -336,22 +306,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -371,8 +338,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -381,15 +347,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -397,8 +361,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -406,23 +369,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -438,23 +398,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -463,21 +420,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -488,7 +442,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -496,26 +449,23 @@
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -524,9 +474,6 @@
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -543,9 +490,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -558,14 +503,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -575,8 +518,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -585,21 +527,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -607,17 +546,12 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -625,23 +559,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -649,44 +578,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -697,7 +615,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -705,7 +622,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -718,21 +634,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -741,14 +654,655 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-example-shared": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-jakarta9"
+            ]
+        },
+        "io.micrometer:micrometer-jakarta9": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
+            "locked": "1.2.2"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-actuator": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-graphql": {
+            "locked": "3.2.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -801,33 +1355,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -837,8 +1380,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -848,8 +1390,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -859,7 +1400,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -867,7 +1407,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -875,7 +1414,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -883,7 +1421,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -899,10 +1436,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -911,14 +1445,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -935,8 +1468,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -1054,21 +1586,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -1077,7 +1606,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1097,8 +1625,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -1110,15 +1637,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -1126,22 +1651,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -1161,8 +1683,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -1171,15 +1692,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1187,8 +1706,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1196,23 +1714,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1228,23 +1743,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1253,21 +1765,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -1278,7 +1787,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -1286,12 +1794,11 @@
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -1306,18 +1813,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1326,9 +1831,6 @@
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -1345,9 +1847,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1394,14 +1894,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1411,8 +1909,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -1421,21 +1918,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -1443,17 +1937,12 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1461,23 +1950,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1485,44 +1969,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1533,7 +2006,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -1541,7 +2013,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1554,21 +2025,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -1577,15 +2045,64 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -1593,15 +2110,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1619,8 +2134,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1630,8 +2144,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1644,7 +2157,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1653,7 +2165,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1665,7 +2176,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1677,8 +2187,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -1686,7 +2195,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1705,8 +2213,7 @@
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.8",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -1728,7 +2235,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -1739,7 +2246,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -1764,7 +2270,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1892,7 +2397,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -1906,8 +2411,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -1925,22 +2429,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -1949,42 +2450,41 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1992,25 +2492,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2029,8 +2529,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -2042,15 +2541,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -2058,22 +2555,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -2093,8 +2587,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -2103,15 +2596,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -2119,8 +2610,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -2128,23 +2618,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -2160,23 +2647,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -2185,28 +2669,24 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -2221,7 +2701,6 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -2229,40 +2708,35 @@
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
@@ -2270,16 +2744,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2298,7 +2770,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2311,8 +2782,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -2322,32 +2792,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2362,15 +2828,13 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2378,9 +2842,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2391,9 +2852,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2413,12 +2872,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2429,19 +2886,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2452,12 +2905,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2479,36 +2930,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2520,7 +2967,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2531,24 +2977,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2556,16 +2999,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2589,14 +3030,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2654,21 +3093,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2683,8 +3119,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -2693,7 +3128,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2702,14 +3136,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -2720,19 +3152,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2741,23 +3168,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -2765,33 +3187,24 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2799,32 +3212,25 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -2838,7 +3244,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-websocket"
@@ -2847,15 +3252,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2872,21 +3275,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2899,7 +3299,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -2909,21 +3308,18 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2931,23 +3327,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -2967,10 +3356,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -2982,9 +3369,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2996,33 +3381,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3030,33 +3408,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -3067,25 +3429,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3093,50 +3449,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3151,20 +3477,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3172,36 +3494,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3216,20 +3522,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3237,36 +3539,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3281,20 +3567,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3302,33 +3584,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -3343,26 +3611,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3370,55 +3632,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3436,8 +3662,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3447,8 +3672,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3461,7 +3685,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3470,7 +3693,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3482,7 +3704,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3494,8 +3715,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -3503,7 +3723,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3522,8 +3741,7 @@
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.8",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -3545,7 +3763,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3556,7 +3774,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -3580,8 +3797,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -3708,7 +3924,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3716,8 +3932,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -3735,22 +3950,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -3759,7 +3971,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3779,8 +3990,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -3792,15 +4002,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -3808,22 +4016,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -3843,8 +4048,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -3853,15 +4057,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -3869,8 +4071,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -3878,23 +4079,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -3910,23 +4108,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -3935,28 +4130,24 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -3970,7 +4161,6 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -3978,18 +4168,16 @@
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "net.datafaker:datafaker": {
@@ -4007,30 +4195,26 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4046,17 +4230,12 @@
                 "io.micrometer:micrometer-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4076,41 +4255,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -4128,36 +4299,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4181,14 +4348,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4203,8 +4368,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -4213,21 +4377,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -4238,18 +4399,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4257,23 +4413,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -4281,45 +4432,34 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -4333,7 +4473,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-websocket"
@@ -4342,15 +4481,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -4365,14 +4502,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -4385,7 +4520,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -4395,53 +4529,34 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -4451,8 +4566,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4462,8 +4576,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4473,7 +4586,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4481,7 +4593,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4489,7 +4600,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4497,7 +4607,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4513,10 +4622,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -4525,14 +4631,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -4550,7 +4655,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4675,21 +4779,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -4698,66 +4799,65 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4776,8 +4876,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -4789,15 +4888,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -4805,22 +4902,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -4840,8 +4934,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -4850,15 +4943,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -4866,8 +4957,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -4875,23 +4965,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -4907,23 +4994,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -4932,21 +5016,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -4958,7 +5039,6 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -4966,49 +5046,43 @@
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -5020,23 +5094,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -5051,14 +5122,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5072,12 +5141,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -5095,11 +5160,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -5110,18 +5173,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -5132,9 +5191,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -5147,7 +5204,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5156,24 +5212,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -5189,14 +5242,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5222,21 +5273,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -5246,8 +5294,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -5256,7 +5303,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -5265,14 +5311,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -5280,18 +5324,13 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -5300,23 +5339,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -5324,33 +5358,24 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -5358,31 +5383,24 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -5393,7 +5411,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -5401,7 +5418,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -5416,28 +5432,24 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -5446,21 +5458,882 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-example-shared": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-jakarta9"
+            ]
+        },
+        "io.micrometer:micrometer-jakarta9": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "io.projectreactor:reactor-test",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
+            "locked": "1.2.2"
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-actuator": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-graphql": {
+            "locked": "3.2.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -5469,15 +6342,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -5495,8 +6366,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -5506,8 +6376,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -5520,7 +6389,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5529,7 +6397,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5541,7 +6408,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5553,8 +6419,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -5562,7 +6427,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5581,8 +6445,7 @@
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.8",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -5604,7 +6467,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -5615,7 +6478,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -5640,7 +6502,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5768,7 +6629,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -5782,8 +6643,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -5801,22 +6661,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -5825,42 +6682,41 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -5868,25 +6724,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -5905,8 +6761,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -5918,15 +6773,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -5934,22 +6787,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -5969,8 +6819,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -5979,15 +6828,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -5995,8 +6842,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -6004,23 +6850,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -6036,23 +6879,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -6061,28 +6901,24 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -6097,7 +6933,6 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -6105,40 +6940,35 @@
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
@@ -6146,16 +6976,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -6174,44 +7002,38 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6226,15 +7048,13 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -6242,9 +7062,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -6255,9 +7072,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -6277,12 +7092,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -6293,19 +7106,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -6316,12 +7125,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -6343,36 +7150,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -6384,7 +7187,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6395,24 +7197,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -6420,16 +7219,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -6453,14 +7250,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6489,21 +7284,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -6518,8 +7310,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -6528,7 +7319,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -6537,14 +7327,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -6555,19 +7343,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -6576,23 +7359,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -6600,33 +7378,24 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -6634,32 +7403,25 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -6673,7 +7435,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-websocket"
@@ -6682,15 +7443,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -6707,21 +7466,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6734,7 +7490,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -6744,21 +7499,18 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6766,7 +7518,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-graphql-example-java/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java/dependencies.lock
@@ -1,43 +1,31 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -47,8 +35,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -58,8 +45,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -69,7 +55,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -77,7 +62,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -85,7 +69,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -93,7 +76,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -109,10 +91,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -121,14 +100,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -145,8 +123,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -255,21 +232,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -278,7 +252,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -298,8 +271,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -311,15 +283,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -327,22 +297,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -362,8 +329,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -372,15 +338,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -388,8 +352,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -397,23 +360,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -429,23 +389,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -454,21 +411,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -479,7 +433,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -487,27 +440,24 @@
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -515,21 +465,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -538,9 +485,6 @@
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -556,9 +500,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -571,14 +513,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -588,8 +528,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -598,21 +537,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -620,17 +556,12 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -639,23 +570,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -664,50 +590,36 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -715,7 +627,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -727,7 +638,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webmvc"
             ]
@@ -736,7 +646,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -750,7 +659,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -758,14 +666,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -776,21 +682,695 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-example-shared": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-jakarta9"
+            ]
+        },
+        "io.micrometer:micrometer-jakarta9": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
+            "locked": "1.2.2"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-actuator": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-graphql": {
+            "locked": "3.2.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -843,33 +1423,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -879,8 +1448,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -890,8 +1458,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -901,7 +1468,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -909,7 +1475,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -917,7 +1482,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -925,7 +1489,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -941,10 +1504,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -953,14 +1513,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -977,8 +1536,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -1087,21 +1645,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -1110,7 +1665,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1130,8 +1684,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -1143,15 +1696,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -1159,22 +1710,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -1194,8 +1742,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -1204,15 +1751,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1220,8 +1765,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1229,23 +1773,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1261,23 +1802,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1286,21 +1824,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -1311,7 +1846,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -1319,13 +1853,12 @@
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -1340,18 +1873,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1359,21 +1890,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -1382,9 +1910,6 @@
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -1400,9 +1925,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1449,14 +1972,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1466,8 +1987,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -1476,21 +1996,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -1498,17 +2015,12 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -1517,23 +2029,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -1542,50 +2049,36 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1593,7 +2086,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1605,7 +2097,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webmvc"
             ]
@@ -1614,7 +2105,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1628,7 +2118,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1636,14 +2125,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -1654,22 +2141,70 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -1677,15 +2212,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1703,8 +2236,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1714,8 +2246,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1728,7 +2259,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1737,7 +2267,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1749,7 +2278,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1762,8 +2290,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -1771,7 +2298,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1790,8 +2316,7 @@
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.8",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -1813,7 +2338,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -1824,7 +2349,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -1850,7 +2374,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -2012,7 +2535,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -2026,8 +2549,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -2045,22 +2567,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -2069,42 +2588,41 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2112,25 +2630,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2149,8 +2667,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -2162,15 +2679,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -2178,22 +2693,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -2213,8 +2725,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -2223,15 +2734,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -2239,8 +2748,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -2248,23 +2756,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -2280,23 +2785,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -2305,28 +2807,24 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -2342,7 +2840,6 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test",
                 "org.springframework:spring-webflux"
@@ -2351,21 +2848,18 @@
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2373,19 +2867,17 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
@@ -2393,16 +2885,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2421,7 +2911,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2434,8 +2923,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -2445,18 +2933,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2464,35 +2950,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2507,15 +2988,13 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -2523,9 +3002,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2536,9 +3012,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2562,12 +3036,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2578,19 +3050,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2601,12 +3069,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2628,36 +3094,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2669,7 +3131,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2680,24 +3141,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2705,16 +3163,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2738,14 +3194,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2803,21 +3257,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2832,8 +3283,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -2842,7 +3292,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2851,14 +3300,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -2871,19 +3318,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -2893,23 +3335,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -2918,46 +3355,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2966,32 +3390,23 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.2.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.6"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2999,7 +3414,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -3014,7 +3428,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test",
                 "org.springframework:spring-context-support",
@@ -3025,15 +3438,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3051,7 +3462,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3059,14 +3469,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -3082,7 +3490,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -3094,7 +3501,6 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
@@ -3103,21 +3509,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3125,23 +3528,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -3161,10 +3557,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -3176,9 +3570,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -3190,33 +3582,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3224,33 +3609,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -3261,25 +3630,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3287,50 +3650,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3345,20 +3678,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3366,36 +3695,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3410,20 +3723,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3431,36 +3740,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3475,20 +3768,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3496,33 +3785,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -3537,26 +3812,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3564,55 +3833,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3630,8 +3863,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3641,8 +3873,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3655,7 +3886,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3664,7 +3894,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3676,7 +3905,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3689,8 +3917,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -3698,7 +3925,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3717,8 +3943,7 @@
         "com.github.ben-manes.caffeine:caffeine": {
             "locked": "3.1.8",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "com.github.curious-odd-man:rgxgen": {
@@ -3740,7 +3965,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3751,7 +3976,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -3775,8 +3999,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -3921,7 +4144,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -3929,8 +4152,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -3948,22 +4170,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -3972,7 +4191,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3992,8 +4210,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -4005,15 +4222,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -4021,22 +4236,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -4056,8 +4268,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -4066,15 +4277,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -4082,8 +4291,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -4091,23 +4299,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -4123,23 +4328,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -4148,28 +4350,24 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -4184,7 +4382,6 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -4192,19 +4389,17 @@
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "net.datafaker:datafaker": {
@@ -4222,30 +4417,26 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4253,21 +4444,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -4283,17 +4471,12 @@
                 "io.micrometer:micrometer-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4315,41 +4498,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -4367,36 +4542,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4420,14 +4591,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4442,8 +4611,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -4452,21 +4620,18 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -4478,18 +4643,13 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -4498,23 +4658,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -4523,51 +4678,37 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4575,7 +4716,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -4590,7 +4730,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-context-support",
                 "org.springframework:spring-webmvc",
@@ -4600,15 +4739,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -4624,7 +4761,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4632,7 +4768,6 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -4647,7 +4782,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -4659,7 +4793,6 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
@@ -4668,53 +4801,34 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -4724,8 +4838,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4735,8 +4848,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4746,7 +4858,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4754,7 +4865,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4762,7 +4872,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4770,7 +4879,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4786,10 +4894,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -4798,14 +4903,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -4831,7 +4935,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -4979,21 +5082,18 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -5002,66 +5102,65 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -5080,8 +5179,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -5093,15 +5191,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -5109,22 +5205,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -5144,8 +5237,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -5154,15 +5246,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -5170,8 +5260,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -5179,23 +5268,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -5211,23 +5297,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -5236,21 +5319,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -5262,7 +5342,6 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test",
                 "org.springframework:spring-webflux"
@@ -5271,21 +5350,18 @@
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -5293,28 +5369,25 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -5326,23 +5399,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -5350,21 +5420,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -5379,14 +5446,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5400,12 +5465,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -5426,11 +5487,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -5441,18 +5500,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -5463,9 +5518,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -5478,7 +5531,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5487,24 +5539,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -5520,14 +5569,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5553,21 +5600,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -5577,8 +5621,7 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -5587,7 +5630,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -5596,14 +5638,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -5611,18 +5651,13 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -5632,23 +5667,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -5657,46 +5687,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -5704,31 +5721,22 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.2.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.6"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -5736,7 +5744,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -5748,7 +5755,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test",
                 "org.springframework:spring-webmvc"
@@ -5758,7 +5764,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -5774,7 +5779,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -5782,14 +5786,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -5797,7 +5799,6 @@
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -5808,52 +5809,39 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "4.4.0",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -5861,11 +5849,9 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -5875,8 +5861,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -5884,12 +5869,8 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5897,8 +5878,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5906,33 +5885,13 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -5944,22 +5903,11 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names"
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.github.curious-odd-man:rgxgen": {
-            "locked": "2.0",
-            "transitive": [
-                "net.datafaker:datafaker"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -5967,25 +5915,14 @@
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.25.2",
-            "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support"
-            ]
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:graphql-java-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "com.netflix.graphql.dgs:graphql-dgs-pagination",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -6011,7 +5948,1004 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.graphql:spring-graphql-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-example-shared": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-extended-scalars": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-pagination": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-core": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-jakarta9"
+            ]
+        },
+        "io.micrometer:micrometer-jakarta9": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-core",
+                "io.micrometer:micrometer-jakarta9",
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "io.projectreactor:reactor-test",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework.graphql:spring-graphql-test",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
+            "locked": "1.2.2"
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-actuator-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-actuator",
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-actuator": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-graphql": {
+            "locked": "3.2.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.graphql:spring-graphql-test"
+            ]
+        },
+        "org.springframework.graphql:spring-graphql-test": {
+            "locked": "1.2.6"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework.graphql:spring-graphql-test",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.graphql:spring-graphql-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-example-shared",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "org.springframework.boot:spring-boot-actuator-autoconfigure",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
+            ]
+        },
+        "com.github.curious-odd-man:rgxgen": {
+            "locked": "2.0",
+            "transitive": [
+                "net.datafaker:datafaker"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.2",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.graphql-java:graphql-java-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-pagination",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework.graphql:spring-graphql-test"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -6173,7 +7107,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.7.12",
+            "locked": "1.7.13",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
@@ -6187,8 +7121,7 @@
         "commons-codec:commons-codec": {
             "locked": "1.16.1",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "io.micrometer:context-propagation": {
@@ -6206,22 +7139,19 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-core": {
             "locked": "1.12.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-jakarta9"
             ]
         },
         "io.micrometer:micrometer-jakarta9": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -6230,42 +7160,41 @@
             "transitive": [
                 "io.micrometer:micrometer-core",
                 "io.micrometer:micrometer-jakarta9",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -6273,25 +7202,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -6310,8 +7239,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -6323,15 +7251,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -6339,22 +7265,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -6374,8 +7297,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -6384,15 +7306,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -6400,8 +7320,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -6409,23 +7328,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -6441,23 +7357,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -6466,28 +7379,24 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -6503,7 +7412,6 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test",
                 "org.springframework:spring-webflux"
@@ -6512,21 +7420,18 @@
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -6534,19 +7439,17 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "name.nkonev.multipart-spring-graphql:multipart-spring-graphql": {
-            "locked": "1.2.1"
+            "locked": "1.2.2"
         },
         "net.bytebuddy:byte-buddy": {
             "locked": "1.14.13",
@@ -6554,16 +7457,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -6582,30 +7483,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -6613,35 +7510,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6656,15 +7548,13 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
         },
         "org.hdrhistogram:HdrHistogram": {
@@ -6672,9 +7562,6 @@
             "transitive": [
                 "io.micrometer:micrometer-core"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -6685,9 +7572,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -6711,12 +7596,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -6727,19 +7610,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -6750,12 +7629,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -6777,36 +7654,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -6818,7 +7691,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6829,24 +7701,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -6854,16 +7723,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -6887,14 +7754,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -6923,21 +7788,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -6952,8 +7814,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.spectator:spectator-api",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
@@ -6962,7 +7823,6 @@
                 "org.springframework.boot:spring-boot-actuator",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -6971,14 +7831,12 @@
         "org.springframework.boot:spring-boot-actuator": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-actuator-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-actuator-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator"
             ]
         },
@@ -6991,19 +7849,14 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
                 "org.springframework.boot:spring-boot-actuator-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-actuator",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
@@ -7013,23 +7866,18 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter",
-                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies"
+                "name.nkonev.multipart-spring-graphql:multipart-spring-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -7038,46 +7886,33 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -7086,32 +7921,23 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.graphql:spring-graphql-test"
             ]
         },
         "org.springframework.graphql:spring-graphql-test": {
-            "locked": "1.2.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.6"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -7119,7 +7945,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-context-support",
@@ -7134,7 +7959,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-example-shared",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework.graphql:spring-graphql-test",
                 "org.springframework:spring-context-support",
@@ -7145,15 +7969,13 @@
         "org.springframework:spring-context-support": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -7171,7 +7993,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -7179,14 +8000,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.graphql:spring-graphql-test"
             ]
@@ -7202,7 +8021,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework.boot:spring-boot-starter-webflux",
@@ -7214,7 +8032,6 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
@@ -7223,21 +8040,18 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -7245,7 +8059,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-graphql-starter-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter-test/dependencies.lock
@@ -1,34 +1,13 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
+    "apiDependenciesMetadata": {
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true,
             "transitive": [
@@ -41,15 +20,30 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
         "org.jetbrains:annotations": {
@@ -57,12 +51,26 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
+            ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
+            ]
         }
     },
     "jmh": {
@@ -113,24 +121,12 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true,
             "transitive": [
@@ -155,15 +151,10 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
         "org.jetbrains:annotations": {
@@ -205,37 +196,76 @@
             "transitive": [
                 "org.openjdk.jmh:jmh-generator-asm"
             ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
+            ]
         }
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -260,47 +290,45 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -308,25 +336,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -334,29 +362,25 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -364,16 +388,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -386,7 +408,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -403,32 +424,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -437,19 +454,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -457,21 +469,17 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -482,19 +490,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -505,10 +509,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -524,16 +526,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -548,7 +548,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -559,24 +558,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -584,16 +580,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -611,14 +605,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -674,14 +666,12 @@
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -691,15 +681,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -709,38 +697,28 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -749,24 +727,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -774,15 +746,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -795,51 +765,40 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -859,10 +818,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -874,9 +831,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -888,33 +843,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -922,33 +870,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -959,25 +891,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -985,50 +911,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1043,20 +939,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1064,36 +956,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1108,20 +984,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1129,36 +1001,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1173,20 +1029,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1194,33 +1046,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1235,26 +1073,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1262,46 +1094,9 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true,
             "transitive": [
@@ -1317,26 +1112,19 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1349,7 +1137,6 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1358,41 +1145,30 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -1400,15 +1176,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -1418,55 +1192,33 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1491,71 +1243,69 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1563,21 +1313,18 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1586,16 +1333,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -1607,23 +1352,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1638,14 +1380,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1653,22 +1393,16 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1679,18 +1413,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1701,9 +1431,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1716,7 +1444,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1725,24 +1452,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1758,14 +1482,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1790,14 +1512,12 @@
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1806,15 +1526,13 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1823,38 +1541,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1862,24 +1570,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -1887,15 +1589,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1908,62 +1608,51 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1988,73 +1677,39 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-jvm"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-agent-api"
-            ]
-        },
-        "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
+                "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-core"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-dsl"
-            ]
-        },
-        "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2062,29 +1717,427 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-api"
+            ]
+        },
+        "io.mockk:mockk-agent-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-dsl-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-core-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-core"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-dsl-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-dsl"
+            ]
+        },
+        "io.mockk:mockk-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -2092,16 +2145,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2114,37 +2165,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2153,19 +2199,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2173,21 +2214,17 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2198,19 +2235,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2221,10 +2254,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2240,16 +2271,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2264,7 +2293,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2275,24 +2303,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2300,16 +2325,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2327,14 +2350,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2361,14 +2382,12 @@
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2378,15 +2397,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2396,38 +2413,28 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2436,24 +2443,18 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -2461,15 +2462,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2482,35 +2481,30 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-graphql-starter/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter/dependencies.lock
@@ -1,43 +1,23 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
+    "apiDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -47,8 +27,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -58,8 +37,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -69,7 +47,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -77,7 +54,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -85,7 +61,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -93,7 +68,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -109,14 +83,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -133,8 +106,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -208,14 +180,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -225,35 +195,28 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -265,9 +228,352 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-graphql": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -280,14 +586,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -297,77 +601,59 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -377,7 +663,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -385,7 +670,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -397,28 +681,369 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-graphql": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -471,33 +1096,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -507,8 +1121,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -518,8 +1131,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -529,7 +1141,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -537,7 +1148,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -545,7 +1155,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -553,7 +1162,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -569,14 +1177,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -593,8 +1200,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -668,14 +1274,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -685,14 +1289,12 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -709,23 +1311,18 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -737,9 +1334,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -786,14 +1381,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -803,77 +1396,59 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -883,7 +1458,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -891,7 +1465,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -903,29 +1476,76 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -933,15 +1553,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -959,8 +1577,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -970,8 +1587,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -982,7 +1598,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -991,7 +1606,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1002,7 +1616,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1014,8 +1627,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -1023,7 +1635,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1052,7 +1663,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1061,7 +1672,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -1079,7 +1689,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1180,48 +1789,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1229,25 +1836,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1255,8 +1862,7 @@
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -1266,36 +1872,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1303,16 +1904,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1331,7 +1930,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1344,8 +1942,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1355,32 +1952,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1389,19 +1982,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1412,9 +2000,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1429,12 +2015,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1445,19 +2029,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1468,12 +2048,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1495,36 +2073,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -1536,7 +2110,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1547,24 +2120,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1572,16 +2142,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1599,14 +2167,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1664,21 +2230,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1692,15 +2255,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1710,54 +2271,40 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1765,32 +2312,25 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1801,7 +2341,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-websocket"
             ]
@@ -1810,7 +2349,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1825,21 +2363,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1851,7 +2386,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework:spring-websocket"
             ]
@@ -1859,14 +2393,12 @@
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1874,23 +2406,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1910,10 +2435,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1925,9 +2448,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1939,33 +2460,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1973,33 +2487,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -2010,25 +2508,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2036,50 +2528,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2094,20 +2556,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2115,36 +2573,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2159,20 +2601,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2180,36 +2618,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2224,20 +2646,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2245,33 +2663,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2286,26 +2690,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2313,55 +2711,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2379,8 +2741,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2390,8 +2751,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2402,7 +2762,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2411,7 +2770,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2422,7 +2780,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2434,8 +2791,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -2443,7 +2799,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2472,7 +2827,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2481,7 +2836,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -2498,8 +2852,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2593,14 +2946,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2608,8 +2959,7 @@
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -2619,14 +2969,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -2645,44 +2993,35 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2697,41 +3036,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2749,36 +3080,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2796,14 +3123,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2817,15 +3142,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -2833,64 +3156,48 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2901,7 +3208,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-websocket"
             ]
@@ -2910,7 +3216,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2923,14 +3228,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2942,7 +3245,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework:spring-websocket"
             ]
@@ -2950,46 +3252,28 @@
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2999,8 +3283,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3010,8 +3293,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3021,7 +3303,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3029,7 +3310,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3037,7 +3317,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3045,7 +3324,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3061,14 +3339,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -3086,7 +3363,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3167,72 +3443,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3242,28 +3516,24 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3272,16 +3542,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -3293,23 +3561,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3324,14 +3589,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3339,12 +3602,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -3357,11 +3616,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3372,18 +3629,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3394,9 +3647,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3409,7 +3660,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3418,24 +3668,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3451,14 +3698,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3484,21 +3729,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3508,15 +3750,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3525,53 +3765,39 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3579,31 +3805,24 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3613,7 +3832,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -3621,7 +3839,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3635,42 +3852,595 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-graphql": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-graphql": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3679,15 +4449,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3705,8 +4473,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3716,8 +4483,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3728,7 +4494,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3737,7 +4502,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3748,7 +4512,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3760,8 +4523,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -3769,7 +4531,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3798,7 +4559,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3807,7 +4568,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -3825,7 +4585,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3926,48 +4685,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3975,25 +4732,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4001,8 +4758,7 @@
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -4012,36 +4768,31 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -4049,16 +4800,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -4077,44 +4826,38 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4123,19 +4866,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -4146,9 +4884,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4163,12 +4899,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4179,19 +4913,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4202,12 +4932,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -4229,36 +4957,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -4270,7 +4994,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4281,24 +5004,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -4306,16 +5026,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4333,14 +5051,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4369,21 +5085,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4397,15 +5110,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4415,54 +5126,40 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4470,32 +5167,25 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -4506,7 +5196,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-websocket"
             ]
@@ -4515,7 +5204,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4530,21 +5218,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4556,7 +5241,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-graphql",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework:spring-websocket"
             ]
@@ -4564,14 +5248,12 @@
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4579,7 +5261,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-graphql-test/dependencies.lock
+++ b/graphql-dgs-spring-graphql-test/dependencies.lock
@@ -1,60 +1,38 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -66,7 +44,6 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -74,40 +51,27 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -115,15 +79,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -133,14 +95,96 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework:spring-core"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
                 "org.springframework:spring-core"
             ]
         }
@@ -193,38 +237,24 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
@@ -240,15 +270,8 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -294,7 +317,6 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -302,40 +324,27 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -343,15 +352,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -361,15 +368,64 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -377,25 +433,19 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -411,47 +461,45 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -459,25 +507,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -485,29 +533,25 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -515,16 +559,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -537,7 +579,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -554,32 +595,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -588,19 +625,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -608,20 +640,16 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -632,19 +660,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -655,10 +679,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -674,16 +696,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -698,7 +718,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -709,24 +728,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -734,16 +750,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -761,14 +775,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -824,14 +836,12 @@
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -841,15 +851,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -858,38 +866,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -897,24 +895,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -922,15 +914,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -943,51 +933,40 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1007,10 +986,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1022,9 +999,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1036,33 +1011,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1070,33 +1038,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1107,25 +1059,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1133,50 +1079,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1191,20 +1107,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1212,36 +1124,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1256,20 +1152,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1277,36 +1169,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1321,20 +1197,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1342,33 +1214,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1383,26 +1241,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1410,72 +1262,26 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -1487,7 +1293,6 @@
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1495,40 +1300,27 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-test-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -1536,15 +1328,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -1554,55 +1344,33 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1618,71 +1386,69 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1690,21 +1456,18 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1713,16 +1476,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -1734,23 +1495,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1765,14 +1523,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1780,21 +1536,15 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1805,18 +1555,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1827,9 +1573,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1842,7 +1586,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1851,24 +1594,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1884,14 +1624,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1916,14 +1654,12 @@
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1932,15 +1668,13 @@
             "transitive": [
                 "ch.qos.logback:logback-classic",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1949,38 +1683,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1988,24 +1712,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -2013,15 +1731,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2034,62 +1750,51 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
         },
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2105,73 +1810,39 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-jvm"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-agent-api"
-            ]
-        },
-        "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
+                "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-core"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-dsl"
-            ]
-        },
-        "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2179,29 +1850,417 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-api"
+            ]
+        },
+        "io.mockk:mockk-agent-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-dsl-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-core-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-core"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-dsl-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-dsl"
+            ]
+        },
+        "io.mockk:mockk-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -2209,16 +2268,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2231,37 +2288,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2270,19 +2322,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2290,20 +2337,16 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2314,19 +2357,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2337,10 +2376,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2356,16 +2393,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2380,7 +2415,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2391,24 +2425,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2416,16 +2447,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2443,14 +2472,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2477,14 +2504,12 @@
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2494,15 +2519,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2511,38 +2534,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2550,24 +2563,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -2575,15 +2582,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2596,35 +2601,30 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-graphql/dependencies.lock
+++ b/graphql-dgs-spring-graphql/dependencies.lock
@@ -1,28 +1,18 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
@@ -32,8 +22,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -41,8 +30,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -50,22 +38,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -79,13 +64,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -101,8 +85,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -150,14 +133,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -166,26 +147,17 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
+            "locked": "6.0.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -195,9 +167,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -210,46 +180,30 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.2.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.6"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -257,7 +211,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -269,7 +222,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webmvc"
             ]
@@ -278,7 +230,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -292,7 +243,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -300,35 +250,343 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6"
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6"
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -379,18 +637,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -400,8 +649,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -409,8 +657,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -418,22 +665,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -447,13 +691,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -469,8 +712,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -518,14 +760,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -534,16 +774,12 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -557,15 +793,10 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -575,9 +806,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -624,46 +853,30 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.2.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.6"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -671,7 +884,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -683,7 +895,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webmvc"
             ]
@@ -692,7 +903,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -706,7 +916,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -714,34 +923,74 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -749,15 +998,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -773,8 +1020,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -784,8 +1030,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -796,7 +1041,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -804,7 +1048,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -813,7 +1056,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -823,15 +1065,13 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -848,10 +1088,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -872,14 +1109,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -896,7 +1132,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -972,48 +1207,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1021,25 +1254,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1047,8 +1280,7 @@
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -1057,7 +1289,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -1065,14 +1296,12 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -1080,15 +1309,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1096,16 +1323,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1124,7 +1349,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1137,8 +1361,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1148,18 +1371,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1167,35 +1388,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1210,19 +1426,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1233,9 +1444,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1247,12 +1456,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1263,19 +1470,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1286,12 +1489,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1313,32 +1514,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1353,7 +1550,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1364,24 +1560,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1389,16 +1582,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1416,14 +1607,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1481,21 +1670,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1509,15 +1695,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1526,19 +1710,14 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -1546,15 +1725,11 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -1562,33 +1737,24 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1596,24 +1762,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1621,7 +1781,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1634,7 +1793,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webmvc"
             ]
@@ -1643,7 +1801,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1659,7 +1816,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1667,14 +1823,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1684,7 +1838,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webflux",
@@ -1692,22 +1845,17 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1715,23 +1863,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1751,10 +1892,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1766,9 +1905,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1780,33 +1917,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1814,33 +1944,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1851,25 +1965,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1877,50 +1985,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1935,20 +2013,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1956,36 +2030,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2000,20 +2058,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2021,36 +2075,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2065,20 +2103,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2086,33 +2120,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2127,26 +2147,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2154,40 +2168,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -2204,8 +2184,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2213,8 +2192,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2222,16 +2200,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -2239,8 +2215,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2266,14 +2241,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -2289,8 +2263,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2340,14 +2313,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2355,8 +2326,7 @@
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -2365,7 +2335,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -2384,20 +2353,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2407,41 +2370,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2459,32 +2414,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2505,8 +2456,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2516,46 +2466,30 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.graphql:spring-graphql": {
-            "locked": "1.2.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.6"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2566,7 +2500,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -2574,7 +2507,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2585,59 +2517,39 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2646,8 +2558,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2657,8 +2568,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2669,7 +2579,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2677,7 +2586,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2685,22 +2593,19 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2717,10 +2622,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -2729,13 +2631,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -2752,7 +2653,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2825,72 +2725,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2899,7 +2797,6 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -2907,14 +2804,12 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2922,7 +2817,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2931,16 +2825,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2952,23 +2844,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2976,21 +2865,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -3005,14 +2891,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3026,19 +2910,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3050,12 +2928,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3066,18 +2942,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3088,9 +2960,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3103,7 +2973,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3112,24 +2981,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3145,14 +3011,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3178,21 +3042,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3202,15 +3063,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3219,18 +3078,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -3238,15 +3092,11 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -3254,33 +3104,24 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3288,24 +3129,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3313,7 +3148,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3325,7 +3159,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webmvc"
             ]
@@ -3334,7 +3167,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3350,7 +3182,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3358,21 +3189,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webflux",
@@ -3380,53 +3208,38 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "4.4.0",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -3435,8 +3248,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3446,8 +3258,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3458,7 +3269,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3466,7 +3276,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3474,26 +3283,19 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3510,10 +3312,644 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.github.ben-manes.caffeine:caffeine"
             ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.springframework.graphql:spring-graphql"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-graphql": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.graphql:spring-graphql": {
+            "locked": "1.2.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-graphql"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.graphql:spring-graphql",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webflux",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6"
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -3534,14 +3970,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql"
             ]
         },
@@ -3558,7 +3993,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3634,48 +4068,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3683,25 +4115,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3709,8 +4141,7 @@
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -3719,7 +4150,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webflux"
             ]
@@ -3727,14 +4157,12 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3742,15 +4170,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3758,16 +4184,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3786,30 +4210,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3817,35 +4237,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3860,19 +4275,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3883,9 +4293,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3897,12 +4305,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3913,19 +4319,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3936,12 +4338,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3963,32 +4363,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -4003,7 +4399,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4014,24 +4409,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -4039,16 +4431,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4066,14 +4456,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4102,21 +4490,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4130,15 +4515,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4147,19 +4530,14 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
@@ -4167,15 +4545,11 @@
             ]
         },
         "org.springframework.boot:spring-boot-starter-graphql": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
@@ -4183,33 +4557,24 @@
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4217,24 +4582,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.graphql:spring-graphql": {
             "locked": "1.2.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-graphql"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4242,7 +4601,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4255,7 +4613,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.graphql:spring-graphql",
                 "org.springframework:spring-webmvc"
             ]
@@ -4264,7 +4621,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4280,7 +4636,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4288,14 +4643,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4305,7 +4658,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webflux",
@@ -4313,22 +4665,17 @@
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4336,7 +4683,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -1,96 +1,34 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.4.14",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-logging"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.4.14",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
+    "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson.core:jackson-annotations",
-                "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-kotlin"
+                "com.fasterxml.jackson.core:jackson-annotations"
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -105,8 +43,149 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -155,14 +234,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -181,8 +258,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -194,15 +270,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -210,22 +284,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -245,8 +316,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -255,15 +325,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -271,8 +339,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -280,23 +347,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -312,23 +376,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -337,29 +398,23 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.18",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.1.18"
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -368,42 +423,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -414,9 +460,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -429,14 +473,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -446,55 +488,40 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -504,15 +531,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -525,34 +550,484 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty": {
+            "locked": "1.1.18"
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6"
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -605,33 +1080,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -640,31 +1104,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -677,14 +1137,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -699,8 +1158,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -749,14 +1207,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -775,8 +1231,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -788,15 +1243,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -804,22 +1257,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -839,8 +1289,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -849,15 +1298,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -865,8 +1312,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -874,23 +1320,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -906,23 +1349,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -931,29 +1371,23 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.18",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.1.18"
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -962,14 +1396,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -986,30 +1418,23 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1020,9 +1445,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1069,14 +1492,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1086,55 +1507,40 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1144,15 +1550,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1165,35 +1569,79 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -1201,15 +1649,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1226,8 +1672,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1237,8 +1682,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1249,7 +1693,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1257,7 +1700,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1266,7 +1708,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1276,15 +1717,13 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1301,10 +1740,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -1325,15 +1761,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1349,7 +1784,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1431,48 +1865,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1480,25 +1912,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1530,8 +1962,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -1544,15 +1975,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -1560,22 +1989,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -1596,8 +2022,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -1607,15 +2032,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1623,8 +2046,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1632,23 +2054,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1665,23 +2084,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1690,15 +2106,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -1708,25 +2122,20 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.18",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.1.18"
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -1739,43 +2148,37 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1783,16 +2186,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1811,7 +2212,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1824,8 +2224,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1835,32 +2234,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1875,19 +2270,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1898,9 +2288,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1913,12 +2301,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1929,19 +2315,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1952,12 +2334,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1979,32 +2359,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2019,7 +2395,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2030,24 +2405,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2055,16 +2427,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2082,14 +2452,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2147,21 +2515,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2175,15 +2540,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2192,19 +2555,14 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -2213,40 +2571,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2254,24 +2602,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2283,7 +2625,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2291,7 +2632,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2307,21 +2647,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2331,7 +2668,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -2341,21 +2677,18 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2363,23 +2696,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -2399,10 +2725,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -2414,9 +2738,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2428,33 +2750,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2462,33 +2777,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -2499,25 +2798,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2525,50 +2818,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2583,20 +2846,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2604,36 +2863,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2648,20 +2891,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2669,36 +2908,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2713,20 +2936,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2734,33 +2953,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2775,26 +2980,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2802,55 +3001,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2867,8 +3030,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2876,8 +3038,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2885,16 +3046,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -2902,8 +3061,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2929,15 +3087,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2952,8 +3109,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -3009,14 +3165,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -3048,8 +3202,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -3062,15 +3215,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -3078,22 +3229,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -3114,8 +3262,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -3125,15 +3272,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -3141,8 +3286,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -3150,23 +3294,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -3183,23 +3324,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -3208,15 +3346,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -3226,25 +3362,20 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.18",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.1.18"
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty"
             ]
         },
         "io.projectreactor:reactor-core": {
@@ -3255,14 +3386,12 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -3281,36 +3410,28 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3321,41 +3442,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3373,32 +3486,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3419,14 +3528,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3440,55 +3547,40 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3500,7 +3592,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -3508,7 +3599,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -3522,14 +3612,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -3537,60 +3625,38 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-webflux": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -3600,8 +3666,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3611,8 +3676,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3623,7 +3687,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3631,7 +3694,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3639,22 +3701,19 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3671,10 +3730,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -3683,14 +3739,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3706,7 +3761,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3780,72 +3834,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3864,8 +3916,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -3877,15 +3928,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -3893,22 +3942,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -3928,8 +3974,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -3938,15 +3983,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -3954,8 +3997,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -3963,23 +4005,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -3995,23 +4034,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -4020,29 +4056,23 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.18",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.1.18"
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -4053,35 +4083,30 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4090,16 +4115,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -4111,23 +4134,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4142,14 +4162,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4163,19 +4181,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4188,12 +4200,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4204,18 +4214,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4226,9 +4232,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -4241,7 +4245,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4250,24 +4253,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4283,14 +4283,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4316,21 +4314,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4340,15 +4335,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4357,18 +4350,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -4377,40 +4365,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4418,24 +4396,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4445,15 +4417,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4468,28 +4438,24 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -4498,45 +4464,33 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "4.4.0",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -4546,8 +4500,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4557,8 +4510,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4569,7 +4521,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4577,7 +4528,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4585,26 +4535,19 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4621,10 +4564,788 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.github.ben-manes.caffeine:caffeine"
             ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty": {
+            "locked": "1.1.18"
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty",
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "io.projectreactor:reactor-test",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -4645,15 +5366,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -4669,7 +5389,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4751,48 +5470,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -4800,25 +5517,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4850,8 +5567,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -4864,15 +5580,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -4880,22 +5594,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -4916,8 +5627,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -4927,15 +5637,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -4943,8 +5651,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -4952,23 +5659,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -4985,23 +5689,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -5010,15 +5711,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -5028,25 +5727,20 @@
             ]
         },
         "io.projectreactor.netty:reactor-netty": {
-            "locked": "1.1.18",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.1.18"
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -5059,43 +5753,37 @@
                 "io.projectreactor.netty:reactor-netty-http",
                 "io.projectreactor:reactor-test",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -5103,16 +5791,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -5131,44 +5817,38 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5183,19 +5863,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -5206,9 +5881,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -5221,12 +5894,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -5237,19 +5908,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -5260,12 +5927,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -5287,32 +5952,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -5327,7 +5988,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5338,24 +5998,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -5363,16 +6020,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -5390,14 +6045,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5426,21 +6079,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -5454,15 +6104,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -5471,19 +6119,14 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -5492,40 +6135,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -5533,24 +6166,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -5562,7 +6189,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -5570,7 +6196,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -5586,21 +6211,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5610,7 +6232,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -5620,21 +6241,18 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5642,7 +6260,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -1,105 +1,20 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "ch.qos.logback:logback-classic": {
-            "locked": "1.4.14",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.boot:spring-boot-starter-logging"
-            ]
-        },
-        "ch.qos.logback:logback-core": {
-            "locked": "1.4.14",
-            "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-annotations",
-                "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin"
-            ]
-        },
+    "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -114,8 +29,150 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -158,14 +215,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -173,41 +228,30 @@
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -217,9 +261,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -231,14 +273,12 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -248,48 +288,34 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -297,7 +323,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -308,7 +333,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -316,7 +340,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -329,7 +352,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -337,27 +359,302 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -410,33 +707,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -445,8 +731,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -454,8 +739,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -463,22 +747,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -492,13 +773,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -513,8 +793,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -557,14 +836,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -572,15 +849,11 @@
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -595,30 +868,23 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -628,9 +894,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -676,14 +940,12 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -693,48 +955,34 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -742,7 +990,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -753,7 +1000,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -761,7 +1007,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -774,7 +1019,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -782,28 +1026,73 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -811,15 +1100,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -835,8 +1122,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -846,8 +1132,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -858,7 +1143,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -866,7 +1150,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -875,7 +1158,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -884,15 +1166,13 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -909,10 +1189,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -933,14 +1210,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -956,7 +1232,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1023,48 +1298,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1072,25 +1345,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1099,43 +1372,35 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1143,16 +1408,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1171,7 +1434,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1184,8 +1446,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1195,18 +1456,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1214,35 +1473,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1257,19 +1511,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1280,9 +1529,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1293,12 +1540,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1309,19 +1554,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1332,12 +1573,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1358,32 +1597,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1398,7 +1633,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1409,24 +1643,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1434,16 +1665,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1461,14 +1690,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1526,21 +1753,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1554,15 +1778,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1571,19 +1793,14 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -1592,40 +1809,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1633,17 +1840,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1651,7 +1853,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1663,7 +1864,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -1671,7 +1871,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1686,7 +1885,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1694,14 +1892,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1711,7 +1907,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -1720,14 +1915,12 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1735,23 +1928,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1771,10 +1957,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1786,9 +1970,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1800,33 +1982,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1834,33 +2009,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1871,25 +2030,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1897,50 +2050,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1955,20 +2078,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1976,36 +2095,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2020,20 +2123,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2041,36 +2140,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2085,20 +2168,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2106,33 +2185,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2147,26 +2212,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2174,55 +2233,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2238,8 +2261,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2247,8 +2269,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2256,16 +2277,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -2273,8 +2292,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2300,14 +2318,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2322,8 +2339,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2373,14 +2389,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2389,22 +2403,17 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "net.datafaker:datafaker": {
             "locked": "2.2.2",
@@ -2421,37 +2430,29 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2461,41 +2462,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2512,32 +2505,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2558,14 +2547,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2579,48 +2566,34 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2628,7 +2601,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2640,7 +2612,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -2648,7 +2619,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2661,7 +2631,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2669,7 +2638,6 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2678,52 +2646,31 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2732,8 +2679,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2743,8 +2689,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2755,7 +2700,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2763,7 +2707,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2771,22 +2714,19 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2803,10 +2743,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -2815,13 +2752,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2837,7 +2773,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2896,72 +2831,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2969,28 +2902,22 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2999,16 +2926,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -3020,23 +2945,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3044,21 +2966,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -3073,14 +2992,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3094,19 +3011,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3117,12 +3028,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3133,18 +3042,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3155,9 +3060,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3170,7 +3073,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3179,24 +3081,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3212,14 +3111,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3244,21 +3141,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3268,15 +3162,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3285,18 +3177,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -3305,40 +3192,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3346,17 +3223,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3364,7 +3236,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3375,7 +3246,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -3383,7 +3253,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3398,7 +3267,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3406,21 +3274,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -3429,45 +3294,33 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "4.4.0",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -3476,8 +3329,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3487,8 +3339,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3499,7 +3350,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3507,7 +3357,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3515,25 +3364,19 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3550,10 +3393,603 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.github.ben-manes.caffeine:caffeine"
             ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
         },
         "com.github.curious-odd-man:rgxgen": {
             "locked": "2.0",
@@ -3574,14 +4010,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3597,7 +4032,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3664,48 +4098,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3713,25 +4145,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3740,43 +4172,35 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3784,16 +4208,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3812,30 +4234,26 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3843,35 +4261,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3886,19 +4299,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3909,9 +4317,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3922,12 +4328,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3938,19 +4342,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3961,12 +4361,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3987,32 +4385,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -4027,7 +4421,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4038,24 +4431,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -4063,16 +4453,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4090,14 +4478,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4126,21 +4512,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4154,15 +4537,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4171,19 +4552,14 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -4192,40 +4568,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4233,17 +4599,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4251,7 +4612,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4263,7 +4623,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -4271,7 +4630,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4286,7 +4644,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4294,14 +4651,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4311,7 +4666,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc"
@@ -4320,14 +4674,12 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4335,7 +4687,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -1,80 +1,20 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-annotations",
-                "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.module:jackson-module-kotlin"
-            ]
-        },
+    "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -89,8 +29,118 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -124,32 +174,22 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-web"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
+            "locked": "6.0.0"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -158,9 +198,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -172,34 +210,24 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-web"
             ]
@@ -207,15 +235,168 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
+            "locked": "6.1.6"
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-web"
             ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-beans",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -266,18 +447,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -286,31 +458,27 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -323,13 +491,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -344,8 +511,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -379,22 +545,17 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-web"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -408,15 +569,10 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -425,9 +581,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -473,34 +627,24 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-web"
             ]
@@ -508,14 +652,61 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -523,15 +714,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -547,8 +736,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -556,8 +744,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -565,24 +752,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -608,14 +792,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -631,7 +814,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -679,48 +861,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -728,25 +908,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -755,42 +935,34 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -798,16 +970,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -826,7 +996,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -843,32 +1012,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -877,19 +1042,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -899,9 +1059,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -910,12 +1068,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -926,19 +1082,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -949,12 +1101,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -975,32 +1125,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1015,7 +1161,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1026,24 +1171,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1051,16 +1193,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1078,14 +1218,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1143,21 +1281,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1171,15 +1306,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1188,38 +1321,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1227,17 +1350,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1245,7 +1363,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1257,7 +1374,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -1265,7 +1381,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1280,7 +1395,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1288,14 +1402,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1303,20 +1415,15 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1324,23 +1431,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1360,10 +1460,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1375,9 +1473,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1389,33 +1485,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1423,33 +1512,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1460,25 +1533,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1486,50 +1553,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1544,20 +1581,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1565,36 +1598,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1609,20 +1626,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1630,36 +1643,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1674,20 +1671,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1695,33 +1688,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1736,26 +1715,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1763,40 +1736,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -1813,8 +1752,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1822,8 +1760,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1831,24 +1768,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -1874,14 +1808,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1896,8 +1829,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -1938,14 +1870,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -1954,8 +1884,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1973,20 +1902,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1995,41 +1918,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2046,32 +1961,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2092,8 +2003,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2103,27 +2013,18 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2132,14 +2033,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2150,59 +2049,39 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2210,31 +2089,27 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2247,13 +2122,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2269,7 +2143,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2310,72 +2183,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2383,27 +2254,21 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2412,16 +2277,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2433,23 +2296,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2464,14 +2324,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2479,19 +2337,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2500,12 +2352,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2516,18 +2366,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2538,9 +2384,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2553,7 +2397,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2562,24 +2405,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2595,14 +2435,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2627,21 +2465,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2651,15 +2486,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2668,38 +2501,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2707,17 +2530,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2725,7 +2543,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2736,7 +2553,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -2744,7 +2560,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2759,7 +2574,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2767,41 +2581,510 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.servlet:jakarta.servlet-api": {
+            "locked": "6.0.0"
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -2810,15 +3093,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2834,8 +3115,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2843,8 +3123,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2852,24 +3131,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2895,14 +3171,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2918,7 +3193,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2966,48 +3240,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3015,25 +3287,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3042,42 +3314,34 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.servlet:jakarta.servlet-api": {
-            "locked": "6.0.0",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.0.0"
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3085,16 +3349,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3113,37 +3375,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3152,19 +3409,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3174,9 +3426,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3185,12 +3435,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3201,19 +3449,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3224,12 +3468,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3250,32 +3492,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3290,7 +3528,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3301,24 +3538,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3326,16 +3560,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3353,14 +3585,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3389,21 +3619,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3417,15 +3644,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3434,38 +3659,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3473,17 +3688,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3491,7 +3701,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3503,7 +3712,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -3511,7 +3719,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3526,7 +3733,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3534,14 +3740,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3549,20 +3753,15 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3570,7 +3769,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -1,36 +1,17 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
+    "apiDependenciesMetadata": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -40,10 +21,54 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -59,27 +84,18 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -90,34 +106,24 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -126,14 +132,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -145,29 +149,133 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-context"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -218,26 +326,16 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -247,10 +345,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -266,14 +363,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -290,15 +385,8 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -343,34 +431,24 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -379,14 +457,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -398,28 +474,73 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -427,15 +548,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -443,31 +562,27 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -480,10 +595,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -497,7 +611,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -513,48 +626,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -562,25 +673,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -588,29 +699,25 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -618,16 +725,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -640,7 +745,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -657,32 +761,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -691,19 +791,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -712,20 +807,16 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -736,19 +827,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -759,10 +846,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -778,16 +863,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -802,7 +885,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -813,24 +895,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -838,16 +917,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -865,14 +942,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -928,21 +1003,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -954,15 +1026,13 @@
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -971,38 +1041,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1010,24 +1070,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1037,7 +1091,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -1045,7 +1098,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1060,64 +1112,49 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1137,10 +1174,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1152,9 +1187,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1166,33 +1199,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1200,33 +1226,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1237,25 +1247,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1263,50 +1267,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1321,20 +1295,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1342,36 +1312,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1386,20 +1340,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1407,36 +1357,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1451,20 +1385,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1472,33 +1402,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1513,26 +1429,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1540,48 +1450,13 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -1591,10 +1466,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1610,27 +1484,18 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -1641,35 +1506,25 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1678,14 +1533,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -1697,58 +1550,36 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "6.1.6"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -1756,31 +1587,27 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -1793,10 +1620,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1810,7 +1636,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1826,72 +1651,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1899,21 +1722,18 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1922,16 +1742,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -1943,23 +1761,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1974,14 +1789,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1989,30 +1802,22 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2023,18 +1828,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2045,9 +1846,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2060,7 +1859,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2069,24 +1867,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2102,14 +1897,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2134,21 +1927,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2158,15 +1948,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2175,38 +1963,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2214,24 +1992,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2241,7 +2013,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2249,7 +2020,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2264,65 +2034,54 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2330,31 +2089,27 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2367,10 +2122,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2384,7 +2138,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2400,74 +2153,40 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-jvm"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-agent-api"
-            ]
-        },
-        "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
+                "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-core"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-dsl"
-            ]
-        },
-        "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2475,29 +2194,495 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-api"
+            ]
+        },
+        "io.mockk:mockk-agent-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-dsl-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-core-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-core"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-dsl-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-dsl"
+            ]
+        },
+        "io.mockk:mockk-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -2505,16 +2690,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2527,37 +2710,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2566,19 +2744,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2587,20 +2760,16 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2611,19 +2780,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2634,10 +2799,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2653,16 +2816,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2677,7 +2838,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2688,24 +2848,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2713,16 +2870,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2740,14 +2895,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2774,21 +2927,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2800,15 +2950,13 @@
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2817,38 +2965,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2856,24 +2994,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2883,7 +3015,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2891,7 +3022,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2906,48 +3036,39 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
@@ -1,42 +1,28 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -51,8 +37,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -93,20 +78,15 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -114,9 +94,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -128,40 +106,27 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -169,7 +134,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -180,7 +144,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -188,7 +151,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -200,7 +162,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -208,22 +169,178 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -274,32 +391,19 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -314,8 +418,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -356,14 +459,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -380,18 +481,13 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -437,40 +533,27 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -478,7 +561,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -489,7 +571,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -497,7 +578,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -509,7 +589,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -517,21 +596,67 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -539,15 +664,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -564,8 +687,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -573,8 +695,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -582,16 +703,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -599,8 +718,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -626,15 +744,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -650,7 +767,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -714,48 +830,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -763,25 +877,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -791,36 +905,31 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -828,16 +937,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -856,7 +963,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -873,32 +979,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -907,19 +1009,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -929,9 +1026,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -942,12 +1037,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -958,19 +1051,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -981,12 +1070,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1007,32 +1094,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1047,7 +1130,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1058,24 +1140,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1083,16 +1162,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1110,14 +1187,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1175,21 +1250,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1203,15 +1275,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1220,38 +1290,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1259,17 +1319,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1277,7 +1332,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1289,7 +1343,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1298,7 +1351,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1314,7 +1366,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1322,14 +1373,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1338,7 +1387,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1346,21 +1394,18 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1368,23 +1413,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1404,10 +1442,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1419,9 +1455,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1433,33 +1467,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1467,33 +1494,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1504,25 +1515,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1530,50 +1535,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1588,20 +1563,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1609,36 +1580,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1653,20 +1608,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1674,36 +1625,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1718,20 +1653,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1739,33 +1670,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1780,26 +1697,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1807,40 +1718,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -1858,8 +1735,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1867,8 +1743,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1876,16 +1751,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -1893,8 +1766,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -1920,15 +1792,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1943,8 +1814,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2001,14 +1871,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2018,8 +1886,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2037,20 +1904,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2061,41 +1922,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2112,32 +1965,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2158,8 +2007,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2169,33 +2017,21 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2203,7 +2039,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2215,7 +2050,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -2224,7 +2058,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2237,7 +2070,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2245,7 +2077,6 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2254,7 +2085,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -2262,65 +2092,42 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2336,7 +2143,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2384,72 +2190,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2457,21 +2261,18 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2480,16 +2281,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2501,23 +2300,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2532,14 +2328,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2547,12 +2341,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -2561,11 +2351,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2576,18 +2364,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2598,9 +2382,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2613,7 +2395,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2622,24 +2403,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2655,14 +2433,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2687,21 +2463,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2711,15 +2484,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2728,38 +2499,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2767,17 +2528,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2785,7 +2541,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2796,7 +2551,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -2804,7 +2558,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2819,7 +2572,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2827,41 +2579,471 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -2870,15 +3052,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2895,8 +3075,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2904,8 +3083,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2913,16 +3091,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -2930,8 +3106,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2957,15 +3132,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2981,7 +3155,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3045,48 +3218,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3094,25 +3265,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3122,36 +3293,31 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3159,16 +3325,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3187,37 +3351,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3226,19 +3385,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3248,9 +3402,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3261,12 +3413,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3277,19 +3427,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3300,12 +3446,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3326,32 +3470,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3366,7 +3506,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3377,24 +3516,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3402,16 +3538,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3429,14 +3563,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3465,21 +3597,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3493,15 +3622,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3510,38 +3637,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3549,17 +3666,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3567,7 +3679,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3579,7 +3690,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3588,7 +3698,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3604,7 +3713,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3612,14 +3720,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3628,7 +3734,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3636,21 +3741,18 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-graphql-sse"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3658,7 +3760,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
@@ -1,28 +1,18 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
@@ -32,31 +22,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -69,14 +55,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -91,8 +76,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -133,14 +117,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -148,19 +130,13 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -170,9 +146,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -185,27 +159,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -213,7 +178,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -223,14 +187,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -242,7 +204,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -250,22 +211,220 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -316,18 +475,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -337,31 +487,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -374,14 +520,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -396,8 +541,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -438,14 +582,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -453,8 +595,7 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "net.sf.jopt-simple:jopt-simple": {
@@ -469,15 +610,10 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -487,9 +623,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -536,27 +670,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -564,7 +689,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -574,14 +698,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -593,7 +715,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -601,21 +722,67 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -623,15 +790,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -648,8 +813,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -657,8 +821,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -666,24 +829,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -709,15 +869,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -733,7 +892,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -788,48 +946,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -837,25 +993,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -865,28 +1021,24 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -894,15 +1046,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -910,16 +1060,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -938,7 +1086,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -955,18 +1102,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -974,35 +1119,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1011,19 +1151,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1033,9 +1168,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1045,12 +1178,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1061,19 +1192,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1084,12 +1211,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1110,32 +1235,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1150,7 +1271,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1161,24 +1281,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1186,16 +1303,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1213,14 +1328,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1278,21 +1391,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1306,15 +1416,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1323,44 +1431,31 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1368,17 +1463,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1386,7 +1476,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1398,7 +1487,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1407,7 +1495,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1423,7 +1510,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1431,14 +1517,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1446,28 +1530,22 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1475,23 +1553,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1511,10 +1582,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1526,9 +1595,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1540,33 +1607,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1574,33 +1634,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1611,25 +1655,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1637,50 +1675,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1695,20 +1703,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1716,36 +1720,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1760,20 +1748,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1781,36 +1765,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1825,20 +1793,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1846,33 +1810,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1887,26 +1837,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1914,40 +1858,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -1965,8 +1875,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1974,8 +1883,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1983,24 +1891,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2026,15 +1931,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2049,8 +1953,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2098,14 +2001,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2114,8 +2015,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2133,20 +2033,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2156,41 +2050,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2207,32 +2093,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2253,8 +2135,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2264,20 +2145,12 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2285,7 +2158,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2296,7 +2168,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -2304,7 +2175,6 @@
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2317,7 +2187,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2325,7 +2194,6 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2333,59 +2201,37 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2394,31 +2240,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2431,14 +2273,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2454,7 +2295,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2502,72 +2342,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2576,28 +2414,24 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2605,7 +2439,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2614,16 +2447,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2635,23 +2466,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2659,21 +2487,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -2688,14 +2513,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2703,19 +2526,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2725,12 +2542,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2741,18 +2556,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2763,9 +2574,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2778,7 +2587,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2787,24 +2595,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2820,14 +2625,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2853,21 +2656,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2877,15 +2677,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2894,44 +2692,31 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2939,17 +2724,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2957,7 +2737,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2968,7 +2747,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -2976,7 +2754,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2991,7 +2768,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2999,41 +2775,554 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor:reactor-test"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3042,15 +3331,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3067,8 +3354,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3076,8 +3362,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3085,24 +3370,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -3128,15 +3410,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3152,7 +3433,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3207,48 +3487,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3256,25 +3534,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3284,28 +3562,24 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3313,15 +3587,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3329,16 +3601,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3357,23 +3627,20 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3381,35 +3648,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3418,19 +3680,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3440,9 +3697,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3452,12 +3707,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3468,19 +3721,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3491,12 +3740,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3517,32 +3764,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3557,7 +3800,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3568,24 +3810,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3593,16 +3832,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3620,14 +3857,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3656,21 +3891,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3684,15 +3916,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3701,44 +3931,31 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3746,17 +3963,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3764,7 +3976,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3776,7 +3987,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3785,7 +3995,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3801,7 +4010,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3809,14 +4017,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3824,28 +4030,22 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3853,7 +4053,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -1,42 +1,28 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -51,8 +37,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -93,20 +78,15 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -114,9 +94,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -128,40 +106,27 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -169,7 +134,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -180,7 +144,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -188,7 +151,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -200,7 +162,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -208,22 +169,178 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -274,32 +391,19 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -314,8 +418,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -356,14 +459,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -380,18 +481,13 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -437,40 +533,27 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -478,7 +561,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -489,7 +571,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -497,7 +578,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -509,7 +589,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -517,21 +596,67 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -539,15 +664,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -564,8 +687,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -573,8 +695,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -582,16 +703,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -599,8 +718,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -626,15 +744,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -650,7 +767,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -714,48 +830,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -763,25 +877,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -791,36 +905,31 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -828,16 +937,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -856,7 +963,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -873,32 +979,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -907,19 +1009,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -929,9 +1026,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -942,12 +1037,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -958,19 +1051,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -981,12 +1070,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1007,32 +1094,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1047,7 +1130,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1058,24 +1140,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1083,16 +1162,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1110,14 +1187,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1175,21 +1250,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1203,15 +1275,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1220,38 +1290,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1259,17 +1319,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1277,7 +1332,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1289,7 +1343,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1298,7 +1351,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1314,7 +1366,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1322,14 +1373,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1338,7 +1387,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1346,21 +1394,18 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1368,23 +1413,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1404,10 +1442,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1419,9 +1455,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1433,33 +1467,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1467,33 +1494,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1504,25 +1515,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1530,50 +1535,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1588,20 +1563,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1609,36 +1580,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1653,20 +1608,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1674,36 +1625,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1718,20 +1653,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1739,33 +1670,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1780,26 +1697,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1807,40 +1718,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -1858,8 +1735,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1867,8 +1743,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1876,16 +1751,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -1893,8 +1766,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -1920,15 +1792,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1943,8 +1814,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2001,14 +1871,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2018,8 +1886,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2037,20 +1904,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2061,41 +1922,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2112,32 +1965,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2158,8 +2007,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2169,33 +2017,21 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2203,7 +2039,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2215,7 +2050,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -2224,7 +2058,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2237,7 +2070,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2245,7 +2077,6 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2254,7 +2085,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -2262,65 +2092,42 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2336,7 +2143,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2384,72 +2190,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2457,21 +2261,18 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2480,16 +2281,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2501,23 +2300,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2532,14 +2328,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2547,12 +2341,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -2561,11 +2351,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2576,18 +2364,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2598,9 +2382,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2613,7 +2395,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2622,24 +2403,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2655,14 +2433,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2687,21 +2463,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2711,15 +2484,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2728,38 +2499,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2767,17 +2528,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2785,7 +2541,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2796,7 +2551,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -2804,7 +2558,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2819,7 +2572,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2827,41 +2579,471 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -2870,15 +3052,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2895,8 +3075,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2904,8 +3083,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2913,16 +3091,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -2930,8 +3106,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2957,15 +3132,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2981,7 +3155,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3045,48 +3218,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3094,25 +3265,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3122,36 +3293,31 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3159,16 +3325,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3187,37 +3351,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3226,19 +3385,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3248,9 +3402,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3261,12 +3413,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3277,19 +3427,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3300,12 +3446,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3326,32 +3470,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3366,7 +3506,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3377,24 +3516,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3402,16 +3538,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3429,14 +3563,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3465,21 +3597,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3493,15 +3622,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3510,38 +3637,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3549,17 +3666,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3567,7 +3679,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3579,7 +3690,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3588,7 +3698,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3604,7 +3713,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3612,14 +3720,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3628,7 +3734,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3636,21 +3741,18 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-sse"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3658,7 +3760,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -1,28 +1,18 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
@@ -32,31 +22,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -69,14 +55,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -91,8 +76,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -133,14 +117,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -148,19 +130,13 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -170,9 +146,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -185,27 +159,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -213,7 +178,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -223,14 +187,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -242,7 +204,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -250,22 +211,220 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -316,18 +475,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -337,31 +487,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -374,14 +520,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -396,8 +541,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -438,14 +582,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -453,8 +595,7 @@
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "net.sf.jopt-simple:jopt-simple": {
@@ -469,15 +610,10 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -487,9 +623,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -536,27 +670,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -564,7 +689,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -574,14 +698,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -593,7 +715,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -601,21 +722,67 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -623,15 +790,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -648,8 +813,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -657,8 +821,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -666,24 +829,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -709,15 +869,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -733,7 +892,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -788,48 +946,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -837,25 +993,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -865,28 +1021,24 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -894,15 +1046,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -910,16 +1060,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -938,7 +1086,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -955,18 +1102,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -974,35 +1119,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1011,19 +1151,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1033,9 +1168,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1045,12 +1178,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1061,19 +1192,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1084,12 +1211,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1110,32 +1235,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1150,7 +1271,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1161,24 +1281,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1186,16 +1303,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1213,14 +1328,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1278,21 +1391,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1306,15 +1416,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1323,44 +1431,31 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1368,17 +1463,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1386,7 +1476,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1398,7 +1487,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1407,7 +1495,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1423,7 +1510,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1431,14 +1517,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1446,28 +1530,22 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1475,23 +1553,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1511,10 +1582,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1526,9 +1595,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1540,33 +1607,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1574,33 +1634,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1611,25 +1655,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1637,50 +1675,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1695,20 +1703,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1716,36 +1720,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1760,20 +1748,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1781,36 +1765,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1825,20 +1793,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1846,33 +1810,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1887,26 +1837,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1914,40 +1858,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -1965,8 +1875,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1974,8 +1883,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1983,24 +1891,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2026,15 +1931,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2049,8 +1953,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2098,14 +2001,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2114,8 +2015,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2133,20 +2033,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2156,41 +2050,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2207,32 +2093,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2253,8 +2135,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2264,20 +2145,12 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2285,7 +2158,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2296,7 +2168,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -2304,7 +2175,6 @@
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2317,7 +2187,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2325,7 +2194,6 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2333,59 +2201,37 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2394,31 +2240,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2431,14 +2273,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2454,7 +2295,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2502,72 +2342,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2576,28 +2414,24 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "io.projectreactor:reactor-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-test"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2605,7 +2439,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2614,16 +2447,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2635,23 +2466,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2659,21 +2487,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -2688,14 +2513,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2703,19 +2526,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2725,12 +2542,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2741,18 +2556,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2763,9 +2574,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2778,7 +2587,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2787,24 +2595,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2820,14 +2625,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2853,21 +2656,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2877,15 +2677,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2894,44 +2692,31 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2939,17 +2724,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2957,7 +2737,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2968,7 +2747,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
@@ -2976,7 +2754,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2991,7 +2768,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -2999,41 +2775,554 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor:reactor-test"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3042,15 +3331,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3067,8 +3354,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3076,8 +3362,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3085,24 +3370,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -3128,15 +3410,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3152,7 +3433,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3207,48 +3487,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3256,25 +3534,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3284,28 +3562,24 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3313,15 +3587,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3329,16 +3601,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3357,23 +3627,20 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3381,35 +3648,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3418,19 +3680,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3440,9 +3697,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3452,12 +3707,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3468,19 +3721,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3491,12 +3740,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3517,32 +3764,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3557,7 +3800,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3568,24 +3810,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3593,16 +3832,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3620,14 +3857,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3656,21 +3891,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3684,15 +3916,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3701,44 +3931,31 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3746,17 +3963,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3764,7 +3976,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3776,7 +3987,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3785,7 +3995,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3801,7 +4010,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3809,14 +4017,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3824,28 +4030,22 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-webmvc": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3853,7 +4053,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -1,28 +1,18 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         }
     },
     "compileClasspath": {
@@ -33,8 +23,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -42,8 +31,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -51,22 +39,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -80,14 +65,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -102,8 +86,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -152,33 +135,23 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "2.1.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
+            "locked": "2.1.1"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -189,9 +162,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -203,47 +174,33 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -253,7 +210,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -261,7 +217,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -273,29 +228,251 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework:spring-context"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -346,18 +523,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -368,8 +536,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -377,8 +544,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -386,22 +552,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -415,14 +578,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -437,8 +599,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -487,23 +648,18 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "2.1.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "2.1.1"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -517,15 +673,10 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -536,9 +687,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -584,47 +733,33 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -634,7 +769,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -642,7 +776,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -654,28 +787,73 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -683,15 +861,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -708,8 +884,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -719,8 +894,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -731,7 +905,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -739,7 +912,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -748,7 +920,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -757,15 +928,13 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -794,15 +963,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -818,7 +986,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -882,48 +1049,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -931,25 +1096,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -958,21 +1123,18 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -980,15 +1142,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -996,16 +1156,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1024,7 +1182,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1041,18 +1198,16 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1060,35 +1215,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1097,19 +1247,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1119,9 +1264,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1132,12 +1275,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1148,19 +1289,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1171,12 +1308,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1197,32 +1332,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1237,7 +1368,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1248,24 +1378,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1273,16 +1400,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1300,14 +1425,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1365,21 +1488,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1393,15 +1513,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1411,18 +1529,13 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -1431,40 +1544,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1472,17 +1575,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1490,7 +1588,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1502,7 +1599,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -1511,7 +1607,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1527,7 +1622,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -1535,14 +1629,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1551,7 +1643,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -1561,7 +1652,6 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -1569,14 +1659,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1584,23 +1672,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1620,10 +1701,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1635,9 +1714,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1649,33 +1726,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1683,33 +1753,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1720,25 +1774,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1746,50 +1794,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1804,20 +1822,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1825,36 +1839,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1869,20 +1867,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1890,36 +1884,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1934,20 +1912,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1955,33 +1929,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1996,26 +1956,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2023,40 +1977,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -2074,8 +1994,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2083,8 +2002,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2092,16 +2010,14 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -2109,8 +2025,7 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2136,15 +2051,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2159,8 +2073,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2217,14 +2130,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2233,8 +2144,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2252,20 +2162,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2276,41 +2180,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2327,32 +2223,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2373,8 +2265,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2384,41 +2275,30 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2429,7 +2309,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2437,7 +2316,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2449,14 +2327,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2465,7 +2341,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2473,45 +2348,27 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2521,8 +2378,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2532,8 +2388,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2544,7 +2399,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2552,7 +2406,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2560,22 +2413,19 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -2592,14 +2442,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2615,7 +2464,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2671,72 +2519,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2744,14 +2590,12 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -2759,7 +2603,6 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2768,16 +2611,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2789,23 +2630,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2813,21 +2651,18 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
@@ -2842,14 +2677,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2857,19 +2690,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2880,12 +2707,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2896,18 +2721,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2918,9 +2739,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2933,7 +2752,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2942,24 +2760,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2975,14 +2790,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3007,21 +2820,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3031,15 +2841,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3048,18 +2856,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -3068,40 +2871,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3109,17 +2902,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3127,7 +2915,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3138,7 +2925,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -3147,7 +2933,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3163,7 +2948,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3171,21 +2955,18 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -3195,27 +2976,594 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-core": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.apache.tomcat.embed:tomcat-embed-websocket",
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-el": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apache.tomcat.embed:tomcat-embed-websocket": {
+            "locked": "10.1.20",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-tomcat"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-tomcat": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-web": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-webmvc"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-web",
+                "org.springframework:spring-webmvc",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-webmvc": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-web"
+            ]
+        },
+        "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3224,15 +3572,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3249,8 +3595,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3260,8 +3605,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3272,7 +3616,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3280,7 +3623,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3289,7 +3631,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3298,15 +3639,13 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3335,15 +3674,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3359,7 +3697,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3423,48 +3760,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3472,25 +3807,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -3499,21 +3834,18 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
@@ -3521,15 +3853,13 @@
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3537,16 +3867,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3565,23 +3893,20 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3589,35 +3914,30 @@
             "locked": "10.1.20",
             "transitive": [
                 "org.apache.tomcat.embed:tomcat-embed-websocket",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-el": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.apache.tomcat.embed:tomcat-embed-websocket": {
             "locked": "10.1.20",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-tomcat"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3626,19 +3946,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3648,9 +3963,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3661,12 +3974,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3677,19 +3988,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3700,12 +4007,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3726,32 +4031,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3766,7 +4067,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3777,24 +4077,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3802,16 +4099,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3829,14 +4124,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3865,21 +4158,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3893,15 +4183,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3911,18 +4199,13 @@
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-web"
@@ -3931,40 +4214,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-tomcat": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3972,17 +4245,12 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -3990,7 +4258,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4002,7 +4269,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webmvc",
                 "org.springframework:spring-websocket"
             ]
@@ -4011,7 +4277,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4027,7 +4292,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-webmvc"
             ]
@@ -4035,14 +4299,12 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4051,7 +4313,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-web",
                 "org.springframework:spring-webmvc",
@@ -4061,7 +4322,6 @@
         "org.springframework:spring-webmvc": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-web"
             ]
         },
@@ -4069,14 +4329,12 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscriptions-websockets"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4084,7 +4342,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -1,28 +1,69 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
+        }
+    },
+    "apiDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
         }
     },
     "compileClasspath": {
@@ -32,31 +73,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -69,14 +106,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -91,8 +127,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -133,34 +168,24 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "2.1.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
+            "locked": "2.1.1"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -170,9 +195,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -184,53 +207,36 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.2.4"
         },
         "org.springframework.security:spring-security-crypto": {
             "locked": "6.2.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -238,7 +244,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -249,7 +254,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-websocket"
             ]
@@ -258,7 +262,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -271,7 +274,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -279,22 +281,292 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
+        },
+        "org.springframework.security:spring-security-core": {
+            "locked": "6.2.4"
+        },
+        "org.springframework.security:spring-security-crypto": {
+            "locked": "6.2.4",
+            "transitive": [
+                "org.springframework.security:spring-security-core"
+            ]
+        },
+        "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
             ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
         }
     },
     "jmh": {
@@ -345,18 +617,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -366,31 +629,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -403,14 +662,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -425,8 +683,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -467,24 +724,19 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "2.1.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "2.1.1"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -498,15 +750,10 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -516,9 +763,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-reflect",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-reflect"
             ]
         },
         "org.jetbrains:annotations": {
@@ -564,53 +809,36 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.2.4"
         },
         "org.springframework.security:spring-security-crypto": {
             "locked": "6.2.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -618,7 +846,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -629,7 +856,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-websocket"
             ]
@@ -638,7 +864,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -651,7 +876,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -659,21 +883,67 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -681,15 +951,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -706,8 +974,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -715,8 +982,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -724,24 +990,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -767,15 +1030,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -791,7 +1053,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -846,48 +1107,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -895,70 +1154,62 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -966,16 +1217,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -994,7 +1243,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1011,32 +1259,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1045,19 +1289,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1067,9 +1306,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1079,12 +1316,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1095,19 +1330,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1118,12 +1349,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1144,32 +1373,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1184,7 +1409,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1195,24 +1419,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1220,16 +1441,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1247,14 +1466,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1312,21 +1529,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1340,15 +1554,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1357,38 +1569,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1396,24 +1598,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -1424,7 +1620,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -1432,7 +1627,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1447,21 +1641,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1469,21 +1660,18 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1491,23 +1679,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -1527,10 +1708,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -1542,9 +1721,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1556,33 +1733,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1590,33 +1760,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1627,25 +1781,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1653,50 +1801,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1711,20 +1829,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1732,36 +1846,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1776,20 +1874,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1797,36 +1891,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1841,20 +1919,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1862,33 +1936,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1903,26 +1963,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1930,40 +1984,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -1981,8 +2001,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1990,8 +2009,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1999,24 +2017,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2042,15 +2057,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2065,8 +2079,7 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -2114,14 +2127,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -2130,8 +2141,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2149,20 +2159,14 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2172,41 +2176,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2223,32 +2219,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2269,8 +2261,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -2280,40 +2271,27 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot-autoconfigure"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2324,7 +2302,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2332,7 +2309,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -2344,14 +2320,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -2359,52 +2333,33 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -2413,31 +2368,27 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2450,14 +2401,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2473,7 +2423,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2521,108 +2470,99 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "io.projectreactor.kotlin:reactor-kotlin-extensions",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.kotlin:reactor-kotlin-extensions"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2631,16 +2571,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2652,23 +2590,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2683,14 +2618,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2698,19 +2631,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2720,12 +2647,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2736,18 +2661,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2758,9 +2679,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2773,7 +2692,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2782,24 +2700,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2815,14 +2730,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2848,21 +2761,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2872,15 +2782,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2889,38 +2797,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2928,24 +2826,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2955,7 +2847,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2963,7 +2854,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2978,48 +2868,531 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor.kotlin:reactor-kotlin-extensions": {
+            "locked": "1.2.2"
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.kotlin:reactor-kotlin-extensions"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-websocket"
+            ]
+        },
+        "org.springframework:spring-websocket": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -3028,15 +3401,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3053,8 +3424,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3062,8 +3432,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3071,24 +3440,21 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -3114,15 +3480,14 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3138,7 +3503,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3193,48 +3557,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -3242,70 +3604,62 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
-            "locked": "1.2.2",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.2.2"
         },
         "io.projectreactor:reactor-core": {
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.kotlin:reactor-kotlin-extensions",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -3313,16 +3667,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -3341,37 +3693,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3380,19 +3727,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -3402,9 +3744,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3414,12 +3754,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -3430,19 +3768,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -3453,12 +3787,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3479,32 +3811,28 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3519,7 +3847,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3530,24 +3857,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3555,16 +3879,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3582,14 +3904,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3618,21 +3938,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3646,15 +3963,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3663,38 +3978,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3702,24 +4007,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -3730,7 +4029,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -3738,7 +4036,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -3753,21 +4050,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3775,21 +4069,18 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3797,7 +4088,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -1,43 +1,23 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
+    "apiDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -47,8 +27,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -58,8 +37,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -69,7 +47,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -77,7 +54,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -85,7 +61,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -93,7 +68,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -109,14 +83,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -132,8 +105,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -218,14 +190,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -244,8 +214,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -257,15 +226,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -273,22 +240,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -308,8 +272,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -318,15 +281,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -334,8 +295,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -343,23 +303,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -375,23 +332,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -400,21 +354,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -425,35 +376,28 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -466,29 +410,19 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.jetbrains:annotations": {
-            "locked": "13.0",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-stdlib"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -498,32 +432,25 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -531,44 +458,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -578,15 +494,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -599,21 +513,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -622,14 +533,1090 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -682,33 +1669,22 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -718,8 +1694,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -729,8 +1704,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -740,7 +1714,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -748,7 +1721,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -756,7 +1728,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -764,7 +1735,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -780,14 +1750,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -803,8 +1772,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -889,14 +1857,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -915,8 +1881,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -928,15 +1893,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -944,22 +1907,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -979,8 +1939,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -989,15 +1948,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1005,8 +1962,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1014,23 +1970,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1046,23 +1999,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1071,21 +2021,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -1096,14 +2043,12 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -1120,23 +2065,18 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -1149,9 +2089,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1198,14 +2136,12 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1215,32 +2151,25 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -1248,44 +2177,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -1295,15 +2213,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -1316,21 +2232,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -1339,15 +2252,64 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -1355,15 +2317,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1381,8 +2341,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1392,8 +2351,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1404,7 +2362,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1413,7 +2370,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1423,7 +2379,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1435,8 +2390,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -1444,7 +2398,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -1473,7 +2426,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1481,8 +2434,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1499,7 +2451,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1599,48 +2550,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -1648,25 +2597,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1698,8 +2647,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -1712,15 +2660,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -1728,22 +2674,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -1764,8 +2707,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -1775,15 +2717,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -1791,8 +2731,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -1800,23 +2739,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -1833,23 +2769,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -1858,15 +2791,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -1878,8 +2809,7 @@
         "io.projectreactor.netty:reactor-netty": {
             "locked": "1.1.18",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
@@ -1887,15 +2817,13 @@
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -1908,36 +2836,31 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1945,16 +2868,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1973,7 +2894,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1986,8 +2906,7 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.commons:commons-math3": {
@@ -1997,32 +2916,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2031,19 +2946,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2054,9 +2964,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2071,12 +2979,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2087,19 +2993,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2110,12 +3012,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2137,36 +3037,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -2178,7 +3074,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2189,24 +3084,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2214,16 +3106,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2241,14 +3131,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2306,21 +3194,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2334,15 +3219,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2351,20 +3234,15 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -2373,40 +3251,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2414,24 +3282,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -2443,7 +3305,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -2451,7 +3312,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2467,21 +3327,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2492,7 +3349,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -2503,21 +3359,18 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2525,23 +3378,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -2561,10 +3407,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -2576,9 +3420,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2590,33 +3432,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2624,33 +3459,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -2661,25 +3480,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2687,50 +3500,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2745,20 +3528,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2766,36 +3545,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2810,20 +3573,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2831,36 +3590,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -2875,20 +3618,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2896,33 +3635,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -2937,26 +3662,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2964,55 +3683,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -3030,8 +3713,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3041,8 +3723,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3053,7 +3734,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3062,7 +3742,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3072,7 +3751,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3084,8 +3762,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -3093,7 +3770,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3122,7 +3798,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3130,8 +3806,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3147,8 +3822,7 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs": {
@@ -3241,14 +3915,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -3280,8 +3952,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -3294,15 +3965,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -3310,22 +3979,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -3346,8 +4012,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -3357,15 +4022,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -3373,8 +4036,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -3382,23 +4044,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -3415,23 +4074,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -3440,15 +4096,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -3460,8 +4114,7 @@
         "io.projectreactor.netty:reactor-netty": {
             "locked": "1.1.18",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
@@ -3469,15 +4122,13 @@
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -3490,14 +4141,12 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
@@ -3516,44 +4165,35 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -3568,41 +4208,33 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3620,36 +4252,32 @@
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -3667,14 +4295,12 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3688,34 +4314,27 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
@@ -3723,44 +4342,33 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+            "locked": "3.2.5"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -3772,7 +4380,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -3780,7 +4387,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -3794,14 +4400,12 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
@@ -3812,7 +4416,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -3823,53 +4426,34 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.fasterxml.jackson.core:jackson-annotations": {
@@ -3879,8 +4463,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -3890,8 +4473,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -3901,7 +4483,6 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3909,7 +4490,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3917,7 +4497,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3925,7 +4504,6 @@
             "locked": "2.15.4",
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -3941,14 +4519,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -3965,7 +4542,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4057,72 +4633,70 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4141,8 +4715,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -4154,15 +4727,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -4170,22 +4741,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -4205,8 +4773,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -4215,15 +4782,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -4231,8 +4796,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -4240,23 +4804,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -4272,23 +4833,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -4297,21 +4855,18 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
             "locked": "1.1.18",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -4322,28 +4877,24 @@
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4352,16 +4903,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -4373,23 +4922,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4404,14 +4950,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4419,12 +4963,8 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
@@ -4438,11 +4978,9 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4453,18 +4991,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4475,9 +5009,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -4490,7 +5022,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4499,24 +5030,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4532,14 +5060,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4565,21 +5091,18 @@
             "locked": "1.0.4",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "io.projectreactor:reactor-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor:reactor-core"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4589,15 +5112,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4606,18 +5127,13 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -4626,40 +5142,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4667,24 +5173,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -4694,15 +5194,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -4717,28 +5215,24 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux"
@@ -4747,21 +5241,768 @@
         "org.springframework:spring-webflux": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testImplementationDependenciesMetadata": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names",
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jdk8": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-parameter-names": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom",
+                "org.springframework.boot:spring-boot-starter-json"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-parameter-names"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-client": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-reactive": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-subscription-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-codec": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns"
+            ]
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-handler-proxy",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-codec-socks": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler-proxy"
+            ]
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-buffer",
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-resolver-dns",
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-handler-proxy": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core"
+            ]
+        },
+        "io.netty:netty-resolver": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport"
+            ]
+        },
+        "io.netty:netty-resolver-dns": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-resolver-dns-classes-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-resolver-dns-native-macos"
+            ]
+        },
+        "io.netty:netty-resolver-dns-native-macos": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-codec",
+                "io.netty:netty-codec-dns",
+                "io.netty:netty-codec-http",
+                "io.netty:netty-codec-http2",
+                "io.netty:netty-codec-socks",
+                "io.netty:netty-handler",
+                "io.netty:netty-handler-proxy",
+                "io.netty:netty-resolver-dns",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll",
+                "io.netty:netty-transport-native-unix-common"
+            ]
+        },
+        "io.netty:netty-transport-classes-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.netty:netty-transport-native-unix-common": {
+            "locked": "4.1.109.Final",
+            "transitive": [
+                "io.netty:netty-handler",
+                "io.netty:netty-resolver-dns-classes-macos",
+                "io.netty:netty-transport-classes-epoll",
+                "io.netty:netty-transport-native-epoll"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-core": {
+            "locked": "1.1.18",
+            "transitive": [
+                "io.projectreactor.netty:reactor-netty-http"
+            ]
+        },
+        "io.projectreactor.netty:reactor-netty-http": {
+            "locked": "1.1.18",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-reactor-netty"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor.netty:reactor-netty-core",
+                "io.projectreactor.netty:reactor-netty-http",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs",
+                "com.netflix.graphql.dgs:graphql-dgs-client",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-reactive",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-json": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-reactor-netty": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-starter-webflux": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-json",
+                "org.springframework.boot:spring-boot-starter-webflux",
+                "org.springframework:spring-webflux"
+            ]
+        },
+        "org.springframework:spring-webflux": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-webflux"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -4770,15 +6011,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -4796,8 +6035,7 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4807,8 +6045,7 @@
                 "com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4819,7 +6056,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
                 "com.fasterxml.jackson.module:jackson-module-parameter-names",
                 "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4828,7 +6064,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4838,7 +6073,6 @@
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4850,8 +6084,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-reactive",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-parameter-names": {
@@ -4859,7 +6092,6 @@
             "transitive": [
                 "com.fasterxml.jackson:jackson-bom",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json"
             ]
         },
@@ -4888,7 +6120,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4896,8 +6128,7 @@
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -4914,7 +6145,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5014,48 +6244,46 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -5063,25 +6291,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -5113,8 +6341,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-codec": {
@@ -5127,15 +6354,13 @@
                 "io.netty:netty-codec-socks",
                 "io.netty:netty-handler",
                 "io.netty:netty-handler-proxy",
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-dns": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns"
             ]
         },
         "io.netty:netty-codec-http": {
@@ -5143,22 +6368,19 @@
             "transitive": [
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-handler-proxy",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-http2": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-codec-socks": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-handler-proxy",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-handler-proxy"
             ]
         },
         "io.netty:netty-common": {
@@ -5179,8 +6401,7 @@
                 "io.netty:netty-transport",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-handler": {
@@ -5190,15 +6411,13 @@
                 "io.netty:netty-codec-http",
                 "io.netty:netty-codec-http2",
                 "io.netty:netty-resolver-dns",
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-handler-proxy": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.projectreactor.netty:reactor-netty-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-core"
             ]
         },
         "io.netty:netty-resolver": {
@@ -5206,8 +6425,7 @@
             "transitive": [
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns",
-                "io.netty:netty-transport",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport"
             ]
         },
         "io.netty:netty-resolver-dns": {
@@ -5215,23 +6433,20 @@
             "transitive": [
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-resolver-dns-classes-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-resolver-dns-native-macos",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-resolver-dns-native-macos"
             ]
         },
         "io.netty:netty-resolver-dns-native-macos": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport": {
@@ -5248,23 +6463,20 @@
                 "io.netty:netty-resolver-dns",
                 "io.netty:netty-transport-classes-epoll",
                 "io.netty:netty-transport-native-epoll",
-                "io.netty:netty-transport-native-unix-common",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-unix-common"
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
             "locked": "4.1.109.Final",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty-core",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
@@ -5273,15 +6485,13 @@
                 "io.netty:netty-handler",
                 "io.netty:netty-resolver-dns-classes-macos",
                 "io.netty:netty-transport-classes-epoll",
-                "io.netty:netty-transport-native-epoll",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.projectreactor.kotlin:reactor-kotlin-extensions": {
             "locked": "1.2.2",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-reactive"
             ]
         },
         "io.projectreactor.netty.incubator:reactor-netty-incubator-quic": {
@@ -5293,8 +6503,7 @@
         "io.projectreactor.netty:reactor-netty": {
             "locked": "1.1.18",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure"
             ]
         },
         "io.projectreactor.netty:reactor-netty-core": {
@@ -5302,15 +6511,13 @@
             "transitive": [
                 "io.projectreactor.netty.incubator:reactor-netty-incubator-quic",
                 "io.projectreactor.netty:reactor-netty",
-                "io.projectreactor.netty:reactor-netty-http",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.projectreactor.netty:reactor-netty-http"
             ]
         },
         "io.projectreactor.netty:reactor-netty-http": {
             "locked": "1.1.18",
             "transitive": [
                 "io.projectreactor.netty:reactor-netty",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-reactor-netty"
             ]
         },
@@ -5323,36 +6530,31 @@
                 "io.projectreactor.netty:reactor-netty-core",
                 "io.projectreactor.netty:reactor-netty-http",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-webflux"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -5360,16 +6562,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -5388,44 +6588,38 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.13.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5434,19 +6628,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -5457,9 +6646,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -5474,12 +6661,10 @@
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -5490,19 +6675,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -5513,12 +6694,10 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -5540,36 +6719,32 @@
                 "io.mockk:mockk-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
-            "locked": "23.0.0",
+            "locked": "24.1.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "org.jetbrains.kotlin:kotlin-stdlib",
@@ -5581,7 +6756,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5592,24 +6766,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -5617,16 +6788,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -5644,14 +6813,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5680,21 +6847,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -5708,15 +6872,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -5725,20 +6887,15 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-starter-webflux"
@@ -5747,40 +6904,30 @@
         "org.springframework.boot:spring-boot-starter-json": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-reactor-netty": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-starter-webflux": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -5788,24 +6935,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web",
@@ -5817,7 +6958,6 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-websocket"
             ]
         },
@@ -5825,7 +6965,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -5841,21 +6980,18 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5866,7 +7002,6 @@
                 "com.netflix.graphql.dgs:graphql-dgs-client",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-boot-oss-autoconfigure",
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webmvc",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-json",
                 "org.springframework.boot:spring-boot-starter-webflux",
                 "org.springframework:spring-webflux",
@@ -5877,21 +7012,18 @@
             "locked": "6.1.6",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-spring-webflux-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-webflux"
             ]
         },
         "org.springframework:spring-websocket": {
             "locked": "6.1.6",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-subscription-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5899,7 +7031,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -1,115 +1,19 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "com.apollographql.federation:federation-graphql-java-support": {
-            "locked": "4.4.0",
-            "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson.module:jackson-module-kotlin": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-annotations",
-                "com.fasterxml.jackson.core:jackson-core",
-                "com.fasterxml.jackson.core:jackson-databind",
-                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson.module:jackson-module-kotlin"
-            ]
-        },
-        "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.google.errorprone:error_prone_annotations": {
-            "locked": "2.21.1",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "com.google.protobuf:protobuf-java": {
-            "locked": "3.25.2",
-            "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support"
-            ]
-        },
+    "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -122,8 +26,285 @@
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0"
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4"
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4"
+        },
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4"
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0"
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1"
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.7.3"
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.7.3"
+        },
+        "org.springframework.security:spring-security-core": {
+            "locked": "6.2.4"
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6"
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "com.github.ben-manes.caffeine:caffeine": {
+            "locked": "3.1.8"
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5"
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "3.37.0",
+            "transitive": [
+                "com.github.ben-manes.caffeine:caffeine"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "io.projectreactor:reactor-core"
+            ]
+        },
+        "org.springframework.security:spring-security-core": {
+            "locked": "6.2.4"
+        },
+        "org.springframework.security:spring-security-crypto": {
+            "locked": "6.2.4",
+            "transitive": [
+                "org.springframework.security:spring-security-core"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.2",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-mocking": {
@@ -154,15 +335,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -171,31 +349,13 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
-        },
-        "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "2.1.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.checkerframework:checker-qual": {
-            "locked": "3.37.0",
-            "transitive": [
-                "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -203,47 +363,43 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:atomicfu",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "org.jetbrains.kotlinx:atomicfu": {
+            "locked": "0.21.0",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
@@ -253,38 +409,20 @@
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
-            "locked": "1.7.3",
-            "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.jetbrains:annotations": {
-            "locked": "23.0.0",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.reactivestreams:reactive-streams": {
@@ -292,67 +430,36 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
-        "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.security:spring-security-crypto": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.security:spring-security-core"
+                "com.graphql-java:java-dataloader"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.security:spring-security-core"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -363,69 +470,42 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
-                "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         }
     },
-    "java21AnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "java21ApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "java21CompileClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "io.micrometer:context-propagation": {
             "locked": "1.1.1"
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -433,37 +513,25 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -473,48 +541,91 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework:spring-core"
+            ]
+        }
+    },
+    "java21ImplementationDependenciesMetadata": {
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1"
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6"
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
                 "org.springframework:spring-core"
             ]
         }
     },
     "java21RuntimeClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "io.micrometer:context-propagation": {
             "locked": "1.1.1"
         },
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -522,37 +633,25 @@
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -562,45 +661,27 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
-        }
-    },
-    "java21TestAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "java21TestCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -615,8 +696,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -624,8 +704,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -633,22 +712,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -668,13 +744,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -694,7 +769,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -732,73 +806,71 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -808,35 +880,30 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -845,16 +912,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -866,23 +931,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -897,14 +959,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -912,19 +972,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -932,12 +986,10 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -948,20 +1000,16 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -972,13 +1020,11 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -996,46 +1042,40 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1050,7 +1090,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1059,24 +1098,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1092,14 +1128,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1126,21 +1160,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1151,15 +1182,13 @@
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1168,38 +1197,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1207,30 +1226,21 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.2.4"
         },
         "org.springframework.security:spring-security-crypto": {
             "locked": "6.2.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -1238,7 +1248,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -1249,7 +1258,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
@@ -1257,7 +1265,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.security:spring-security-core",
@@ -1272,7 +1279,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -1280,51 +1286,42 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "java21TestRuntimeClasspath": {
+    "java21TestImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -1339,8 +1336,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -1348,8 +1344,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -1357,22 +1352,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -1385,12 +1377,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
-        "com.github.curious-odd-man:rgxgen": {
-            "locked": "2.0",
-            "transitive": [
-                "net.datafaker:datafaker"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
             "locked": "3.25.2",
             "transitive": [
@@ -1398,14 +1384,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:graphql-java-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -1425,7 +1409,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1463,75 +1446,41 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-jvm"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-agent-api"
-            ]
-        },
-        "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
+                "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-core"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-dsl"
-            ]
-        },
-        "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1541,43 +1490,654 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib",
+                "org.jetbrains.kotlinx:atomicfu",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "org.jetbrains.kotlinx:atomicfu": {
+            "locked": "0.21.0",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.security:spring-security-core": {
+            "locked": "6.2.4"
+        },
+        "org.springframework.security:spring-security-crypto": {
+            "locked": "6.2.4",
+            "transitive": [
+                "org.springframework.security:spring-security-core"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.security:spring-security-core"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "java21TestRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.github.curious-odd-man:rgxgen": {
+            "locked": "2.0",
+            "transitive": [
+                "net.datafaker:datafaker"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.2",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.graphql-java:graphql-java-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-api"
+            ]
+        },
+        "io.mockk:mockk-agent-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-dsl-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-core-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-core"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-dsl-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-dsl"
+            ]
+        },
+        "io.mockk:mockk-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor:reactor-test",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -1585,16 +2145,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -1613,37 +2171,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1652,19 +2205,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -1673,9 +2221,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -1683,12 +2229,10 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1699,20 +2243,16 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1723,13 +2263,11 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -1751,46 +2289,40 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1806,7 +2338,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1817,24 +2348,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -1842,16 +2370,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1869,14 +2395,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1905,21 +2429,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1933,15 +2454,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1950,38 +2469,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1989,30 +2498,21 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.2.4"
         },
         "org.springframework.security:spring-security-crypto": {
             "locked": "6.2.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -2020,7 +2520,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2031,7 +2530,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
@@ -2039,7 +2537,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.security:spring-security-core",
@@ -2054,7 +2551,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -2062,27 +2558,21 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2090,7 +2580,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
@@ -2143,18 +2632,9 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
@@ -2170,8 +2650,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2179,8 +2658,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2188,22 +2666,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2217,10 +2692,7 @@
             ]
         },
         "com.github.ben-manes.caffeine:caffeine": {
-            "locked": "3.1.8",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.1.8"
         },
         "com.google.errorprone:error_prone_annotations": {
             "locked": "2.21.1",
@@ -2235,13 +2707,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -2254,8 +2725,7 @@
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-mocking": {
@@ -2286,14 +2756,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
@@ -2303,15 +2771,11 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
-            "locked": "2.1.1",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "2.1.1"
         },
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "5.0.4",
@@ -2331,15 +2795,10 @@
                 "com.github.ben-manes.caffeine:caffeine"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2347,41 +2806,33 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2397,31 +2848,27 @@
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2470,41 +2917,28 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.2.4"
         },
         "org.springframework.security:spring-security-crypto": {
             "locked": "6.2.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -2512,7 +2946,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -2522,14 +2955,12 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
@@ -2541,7 +2972,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -2549,14 +2979,61 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
+            "locked": "6.1.6"
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
             ]
         }
     },
@@ -2564,15 +3041,13 @@
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -2587,8 +3062,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -2596,8 +3070,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -2605,22 +3078,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -2646,14 +3116,13 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -2673,7 +3142,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2711,49 +3179,47 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -2761,25 +3227,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2789,43 +3255,37 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -2833,16 +3293,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -2861,7 +3319,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2878,32 +3335,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2912,19 +3365,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2933,9 +3381,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -2943,12 +3389,10 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2959,20 +3403,16 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2983,13 +3423,11 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -3011,46 +3449,40 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3066,7 +3498,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3077,24 +3508,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -3102,16 +3530,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -3129,14 +3555,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3194,21 +3618,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -3222,15 +3643,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -3239,38 +3658,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -3278,30 +3687,21 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.2.4"
         },
         "org.springframework.security:spring-security-crypto": {
             "locked": "6.2.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -3309,7 +3709,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -3320,7 +3719,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
@@ -3328,7 +3726,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.security:spring-security-core",
@@ -3343,7 +3740,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -3351,27 +3747,21 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -3379,23 +3769,16 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -3415,10 +3798,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -3430,9 +3811,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -3444,33 +3823,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3478,33 +3850,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -3515,25 +3871,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3541,50 +3891,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJava21": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3599,20 +3919,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3620,36 +3936,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJava21Test": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3664,20 +3964,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3685,36 +3981,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3729,20 +4009,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3750,36 +4026,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3794,20 +4054,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3815,36 +4071,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -3859,20 +4099,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3880,33 +4116,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -3921,26 +4143,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -3948,40 +4164,6 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
@@ -3997,8 +4179,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4006,8 +4187,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4015,22 +4195,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -4056,13 +4233,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -4075,8 +4251,7 @@
         "com.jayway.jsonpath:json-path": {
             "locked": "2.9.0",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.netflix.graphql.dgs:graphql-dgs-mocking": {
@@ -4107,14 +4282,12 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
@@ -4123,8 +4296,7 @@
             "locked": "3.6.5",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "net.datafaker:datafaker": {
@@ -4142,19 +4314,13 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.jayway.jsonpath:json-path"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4162,41 +4328,33 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -4212,31 +4370,27 @@
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains:annotations": {
@@ -4257,8 +4411,7 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.slf4j:slf4j-api": {
@@ -4268,42 +4421,29 @@
                 "com.graphql-java:graphql-java",
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
-                "com.netflix.graphql.dgs:graphql-dgs-mocking",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-mocking"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "org.springframework:spring-context": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-beans",
                 "org.springframework:spring-context",
@@ -4314,58 +4454,36 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies"
+                "net.datafaker:datafaker"
             ]
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -4380,8 +4498,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -4389,8 +4506,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -4398,22 +4514,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -4433,13 +4546,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -4459,7 +4571,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4497,73 +4608,71 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -4573,35 +4682,30 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4610,16 +4714,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -4631,23 +4733,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4662,14 +4761,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4677,19 +4774,13 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -4697,12 +4788,10 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -4713,20 +4802,16 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -4737,13 +4822,11 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -4761,46 +4844,40 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
             ]
         },
         "org.jetbrains:annotations": {
@@ -4815,7 +4892,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4824,24 +4900,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -4857,14 +4930,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -4891,21 +4962,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -4916,15 +4984,13 @@
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -4933,38 +4999,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -4972,30 +5028,21 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.2.4"
         },
         "org.springframework.security:spring-security-crypto": {
             "locked": "6.2.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -5003,7 +5050,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5014,7 +5060,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
@@ -5022,7 +5067,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.security:spring-security-core",
@@ -5037,7 +5081,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -5045,51 +5088,42 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
         "com.apollographql.federation:federation-graphql-java-support": {
@@ -5104,8 +5138,7 @@
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-core": {
@@ -5113,8 +5146,7 @@
             "transitive": [
                 "com.fasterxml.jackson.core:jackson-databind",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.core:jackson-databind": {
@@ -5122,22 +5154,19 @@
             "transitive": [
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
                 "com.fasterxml.jackson.module:jackson-module-kotlin",
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -5150,12 +5179,6 @@
                 "com.fasterxml.jackson.module:jackson-module-kotlin"
             ]
         },
-        "com.github.curious-odd-man:rgxgen": {
-            "locked": "2.0",
-            "transitive": [
-                "net.datafaker:datafaker"
-            ]
-        },
         "com.google.protobuf:protobuf-java": {
             "locked": "3.25.2",
             "transitive": [
@@ -5163,14 +5186,12 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
-                "com.graphql-java:graphql-java-extended-scalars",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "com.netflix.graphql.dgs:graphql-error-types",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-error-types"
             ]
         },
         "com.graphql-java:graphql-java-extended-scalars": {
@@ -5190,7 +5211,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5228,75 +5248,41 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context",
                 "org.springframework:spring-web"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-jvm"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-agent-api"
-            ]
-        },
-        "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
+                "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-core"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-dsl"
-            ]
-        },
-        "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -5306,43 +5292,654 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "io.projectreactor:reactor-test",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "io.projectreactor:reactor-test": {
             "locked": "3.6.5",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-reflect": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types",
+                "org.jetbrains.kotlin:kotlin-reflect",
+                "org.jetbrains.kotlin:kotlin-stdlib-common",
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib",
+                "org.jetbrains.kotlinx:atomicfu",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "org.jetbrains.kotlinx:atomicfu": {
+            "locked": "0.21.0",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
+            ]
+        },
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
+            "locked": "1.7.3",
+            "transitive": [
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "io.projectreactor:reactor-core",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.security:spring-security-core": {
+            "locked": "6.2.4"
+        },
+        "org.springframework.security:spring-security-crypto": {
+            "locked": "6.2.4",
+            "transitive": [
+                "org.springframework.security:spring-security-core"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.security:spring-security-core"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test",
+                "org.springframework:spring-web"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-web": {
+            "locked": "6.1.6"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.apollographql.federation:federation-graphql-java-support": {
+            "locked": "4.4.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin",
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson.module:jackson-module-kotlin": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations",
+                "com.fasterxml.jackson.core:jackson-core",
+                "com.fasterxml.jackson.core:jackson-databind",
+                "com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+                "com.fasterxml.jackson.module:jackson-module-kotlin"
+            ]
+        },
+        "com.github.curious-odd-man:rgxgen": {
+            "locked": "2.0",
+            "transitive": [
+                "net.datafaker:datafaker"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.25.2",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.apollographql.federation:federation-graphql-java-support",
+                "com.graphql-java:graphql-java-extended-scalars",
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.graphql-java:graphql-java-extended-scalars": {
+            "locked": "21.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-mocking": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-mocking",
+                "com.netflix.graphql.dgs:graphql-error-types"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-error-types": {
+            "project": true,
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:context-propagation": {
+            "locked": "1.1.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework.security:spring-security-core",
+                "org.springframework:spring-context",
+                "org.springframework:spring-web"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-api"
+            ]
+        },
+        "io.mockk:mockk-agent-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-dsl-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-core-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-core"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-dsl-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-dsl"
+            ]
+        },
+        "io.mockk:mockk-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "io.projectreactor:reactor-core": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "io.projectreactor:reactor-test",
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
+            ]
+        },
+        "io.projectreactor:reactor-test": {
+            "locked": "3.6.5",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -5350,16 +5947,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.datafaker:datafaker": {
@@ -5378,37 +5973,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5417,19 +6007,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -5438,9 +6023,7 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
@@ -5448,12 +6031,10 @@
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "com.netflix.graphql.dgs:graphql-error-types",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -5464,20 +6045,16 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -5488,13 +6065,11 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -5516,46 +6091,40 @@
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
                 "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactive": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactor"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-reactor": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-test",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test"
             ]
         },
         "org.jetbrains:annotations": {
@@ -5571,7 +6140,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5582,24 +6150,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -5607,16 +6172,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -5634,14 +6197,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5670,21 +6231,18 @@
             "transitive": [
                 "com.graphql-java:graphql-java",
                 "io.projectreactor:reactor-core",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-reactive"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -5698,15 +6256,13 @@
                 "com.jayway.jsonpath:json-path",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -5715,38 +6271,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -5754,30 +6300,21 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        },
         "org.springframework.security:spring-security-core": {
-            "locked": "6.2.4",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.2.4"
         },
         "org.springframework.security:spring-security-crypto": {
             "locked": "6.2.4",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -5785,7 +6322,6 @@
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context",
@@ -5796,7 +6332,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core"
             ]
         },
@@ -5804,7 +6339,6 @@
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.security:spring-security-core",
@@ -5819,7 +6353,6 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.security:spring-security-core",
                 "org.springframework:spring-context"
             ]
@@ -5827,27 +6360,21 @@
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework:spring-web": {
-            "locked": "6.1.6",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "6.1.6"
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -5855,7 +6382,6 @@
             "locked": "2.2",
             "transitive": [
                 "net.datafaker:datafaker",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -1,49 +1,17 @@
 {
     "annotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.springframework.boot:spring-boot-autoconfigure-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
             "locked": "3.2.5"
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.springframework.boot:spring-boot-configuration-processor": {
+            "locked": "3.2.5"
         }
     },
-    "compileClasspath": {
-        "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
-        },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4",
-            "transitive": [
-                "com.fasterxml.jackson.core:jackson-annotations"
-            ]
-        },
+    "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -56,15 +24,53 @@
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
         },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileClasspath": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
+            ]
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -75,22 +81,61 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "compileOnlyDependenciesMetadata": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.15.4",
+            "transitive": [
+                "com.fasterxml.jackson.core:jackson-annotations"
+            ]
+        }
+    },
+    "implementationDependenciesMetadata": {
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "com.graphql-java:java-dataloader"
+            ]
         }
     },
     "jmh": {
@@ -141,26 +186,16 @@
             ]
         }
     },
-    "jmhAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
+    "jmhApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.15.4",
             "transitive": [
-                "com.fasterxml.jackson:jackson-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.fasterxml.jackson:jackson-bom"
             ]
         },
         "com.fasterxml.jackson:jackson-bom": {
@@ -170,10 +205,9 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -198,15 +232,8 @@
                 "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -251,47 +278,84 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
+            ]
+        }
+    },
+    "jmhImplementationDependenciesMetadata": {
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.4",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
+        "org.apache.commons:commons-math3": {
+            "locked": "3.6.1",
+            "transitive": [
+                "org.openjdk.jmh:jmh-core"
+            ]
         },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.37",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-annprocess",
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode",
+                "org.openjdk.jmh:jmh-generator-reflection"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-annprocess": {
+            "locked": "1.37"
+        },
+        "org.openjdk.jmh:jmh-generator-asm": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.36"
+        },
+        "org.openjdk.jmh:jmh-generator-reflection": {
+            "locked": "1.36",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm",
+                "org.openjdk.jmh:jmh-generator-bytecode"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.0",
+            "transitive": [
+                "org.openjdk.jmh:jmh-generator-asm"
+            ]
         }
     },
     "jmhRuntimeClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -305,7 +369,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -321,47 +384,45 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-dsl-jvm",
@@ -369,25 +430,25 @@
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -395,29 +456,25 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -425,16 +482,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -447,7 +502,6 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -464,32 +518,28 @@
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -498,19 +548,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -518,20 +563,16 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -542,19 +583,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -565,10 +602,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -584,16 +619,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -608,7 +641,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -619,24 +651,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -644,16 +673,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -671,14 +698,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -734,21 +759,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -760,15 +782,13 @@
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -777,38 +797,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -816,24 +826,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -841,15 +845,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -862,51 +864,40 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
     "kotlinBuildToolsApiClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-build-common": {
             "locked": "1.9.24",
@@ -926,10 +917,8 @@
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-compiler-runner": {
@@ -941,9 +930,7 @@
         "org.jetbrains.kotlin:kotlin-daemon-client": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -955,33 +942,26 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-build-tools-impl",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-compiler-runner",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-runner"
             ]
         },
         "org.jetbrains:annotations": {
@@ -989,33 +969,17 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
             "locked": "1.9.24",
@@ -1026,25 +990,19 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1052,50 +1010,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathJmh": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1110,20 +1038,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1131,36 +1055,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathMain": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1175,20 +1083,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1196,36 +1100,20 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinCompilerPluginClasspathTest": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-common": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
@@ -1240,20 +1128,16 @@
         "org.jetbrains.kotlin:kotlin-scripting-jvm": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-scripting-common",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable",
                 "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable",
-                "org.jetbrains.kotlin:kotlin-scripting-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-scripting-jvm"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1261,33 +1145,19 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "kotlinKlibCommonizerClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "org.jetbrains.intellij.deps:trove4j": {
             "locked": "1.0.20200330",
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-daemon-embeddable": {
@@ -1302,26 +1172,20 @@
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-script-runtime": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-compiler-embeddable"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-compiler-embeddable",
-                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1329,51 +1193,13 @@
             "transitive": [
                 "org.jetbrains.kotlin:kotlin-stdlib"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "kotlinNativeCompilerPluginClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "nebulaRecommenderBom": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "runtimeClasspath": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1386,15 +1212,8 @@
         "com.netflix.graphql.dgs:graphql-dgs-platform": {
             "project": true
         },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "1.9.24",
-            "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "1.9.24"
         },
         "org.jetbrains:annotations": {
             "locked": "13.0",
@@ -1405,62 +1224,34 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.13",
             "transitive": [
                 "com.graphql-java:graphql-java",
-                "com.graphql-java:java-dataloader",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:java-dataloader"
             ]
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
-        }
-    },
-    "testAnnotationProcessor": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
-        },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         }
     },
     "testCompileClasspath": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1474,7 +1265,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1490,71 +1280,69 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent-api"
             ]
         },
         "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-core"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-jvm"
             ]
         },
         "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk-dsl"
             ]
         },
         "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -1562,21 +1350,18 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1585,16 +1370,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -1606,23 +1389,20 @@
         "net.minidev:json-smart": {
             "locked": "2.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1637,14 +1417,12 @@
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1652,21 +1430,15 @@
             "locked": "2.2",
             "transitive": [
                 "org.awaitility:awaitility",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -1677,18 +1449,14 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -1699,9 +1467,7 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib"
             ]
         },
         "org.jetbrains:annotations": {
@@ -1714,7 +1480,6 @@
             "locked": "5.10.2",
             "transitive": [
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1723,24 +1488,21 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
                 "org.junit.jupiter:junit-jupiter-params",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -1756,14 +1518,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1788,21 +1548,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -1812,15 +1569,13 @@
                 "ch.qos.logback:logback-classic",
                 "com.graphql-java:java-dataloader",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -1829,38 +1584,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -1868,24 +1613,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -1893,15 +1632,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -1914,62 +1651,51 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }
     },
-    "testRuntimeClasspath": {
+    "testImplementationDependenciesMetadata": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.4.14",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "ch.qos.logback:logback-core": {
             "locked": "1.4.14",
             "transitive": [
-                "ch.qos.logback:logback-classic",
-                "org.springframework.boot:spring-boot-dependencies"
+                "ch.qos.logback:logback-classic"
             ]
         },
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.15.4"
-        },
         "com.graphql-java:graphql-java": {
-            "locked": "21.5",
+            "locked": "21.4",
             "transitive": [
-                "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
         },
         "com.graphql-java:java-dataloader": {
@@ -1983,7 +1709,6 @@
             "locked": "2.9.0",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -1999,73 +1724,39 @@
         "io.micrometer:micrometer-commons": {
             "locked": "1.12.5",
             "transitive": [
-                "io.micrometer:micrometer-observation",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.micrometer:micrometer-observation"
             ]
         },
         "io.micrometer:micrometer-observation": {
             "locked": "1.12.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "io.mockk:mockk": {
-            "locked": "1.13.10"
+            "locked": "1.13.11"
         },
         "io.mockk:mockk-agent": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-jvm"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-agent-api": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-agent-api-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-agent-api"
-            ]
-        },
-        "io.mockk:mockk-agent-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
+                "io.mockk:mockk",
                 "io.mockk:mockk-agent"
             ]
         },
         "io.mockk:mockk-core": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
-                "io.mockk:mockk-agent-jvm",
-                "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-core-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-core"
+                "io.mockk:mockk"
             ]
         },
         "io.mockk:mockk-dsl": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-jvm"
-            ]
-        },
-        "io.mockk:mockk-dsl-jvm": {
-            "locked": "1.13.10",
-            "transitive": [
-                "io.mockk:mockk-dsl"
-            ]
-        },
-        "io.mockk:mockk-jvm": {
-            "locked": "1.13.10",
+            "locked": "1.13.11",
             "transitive": [
                 "io.mockk:mockk"
             ]
@@ -2073,29 +1764,437 @@
         "jakarta.activation:jakarta.activation-api": {
             "locked": "2.1.3",
             "transitive": [
-                "jakarta.xml.bind:jakarta.xml.bind-api",
-                "org.springframework.boot:spring-boot-dependencies"
+                "jakarta.xml.bind:jakarta.xml.bind-api"
             ]
         },
         "jakarta.annotation:jakarta.annotation-api": {
             "locked": "2.1.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "jakarta.xml.bind:jakarta.xml.bind-api": {
             "locked": "4.0.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.assertj:assertj-core",
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.bytebuddy:byte-buddy-agent": {
+            "locked": "1.14.13",
+            "transitive": [
+                "org.mockito:mockito-core"
+            ]
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "net.minidev:json-smart"
+            ]
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-api": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.apache.logging.log4j:log4j-to-slf4j"
+            ]
+        },
+        "org.apache.logging.log4j:log4j-to-slf4j": {
+            "locked": "2.21.1",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.24.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.awaitility:awaitility": {
+            "locked": "4.2.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2",
+            "transitive": [
+                "org.awaitility:awaitility",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "1.9.24",
+            "transitive": [
+                "org.jetbrains.kotlin:kotlin-stdlib-common"
+            ]
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "1.9.24",
+            "transitive": [
+                "io.mockk:mockk",
+                "io.mockk:mockk-agent",
+                "io.mockk:mockk-agent-api",
+                "io.mockk:mockk-core",
+                "io.mockk:mockk-dsl",
+                "org.jetbrains.kotlin:kotlin-stdlib"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit:junit-bom",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.jupiter:junit-jupiter-params": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit:junit-bom"
+            ]
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.10.2",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter",
+                "org.junit.jupiter:junit-jupiter-api",
+                "org.junit.jupiter:junit-jupiter-params",
+                "org.junit.platform:junit-platform-commons"
+            ]
+        },
+        "org.mockito:mockito-core": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.mockito:mockito-junit-jupiter",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.mockito:mockito-junit-jupiter": {
+            "locked": "5.7.0",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0",
+            "transitive": [
+                "org.junit.jupiter:junit-jupiter-api"
+            ]
+        },
+        "org.ow2.asm:asm": {
+            "locked": "9.6",
+            "transitive": [
+                "net.minidev:accessors-smart"
+            ]
+        },
+        "org.reactivestreams:reactive-streams": {
+            "locked": "1.0.4",
+            "transitive": [
+                "com.graphql-java:graphql-java"
+            ]
+        },
+        "org.skyscreamer:jsonassert": {
+            "locked": "1.5.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.slf4j:jul-to-slf4j": {
+            "locked": "2.0.13",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "2.0.13",
+            "transitive": [
+                "ch.qos.logback:logback-classic",
+                "com.graphql-java:java-dataloader",
+                "org.apache.logging.log4j:log4j-to-slf4j",
+                "org.slf4j:jul-to-slf4j"
+            ]
+        },
+        "org.springframework.boot:spring-boot": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-autoconfigure",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-logging": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "org.springframework.boot:spring-boot-starter-test": {
+            "locked": "3.2.5"
+        },
+        "org.springframework.boot:spring-boot-test": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework.boot:spring-boot-test-autoconfigure"
+            ]
+        },
+        "org.springframework.boot:spring-boot-test-autoconfigure": {
+            "locked": "3.2.5",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.springframework:spring-aop": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-beans": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-aop",
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-context": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot"
+            ]
+        },
+        "org.springframework:spring-core": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot",
+                "org.springframework.boot:spring-boot-starter",
+                "org.springframework.boot:spring-boot-starter-test",
+                "org.springframework:spring-aop",
+                "org.springframework:spring-beans",
+                "org.springframework:spring-context",
+                "org.springframework:spring-expression",
+                "org.springframework:spring-test"
+            ]
+        },
+        "org.springframework:spring-expression": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "org.springframework:spring-jcl": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework:spring-core"
+            ]
+        },
+        "org.springframework:spring-test": {
+            "locked": "6.1.6",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.9.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "org.yaml:snakeyaml": {
+            "locked": "2.2",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.4.14",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter-logging"
+            ]
+        },
+        "ch.qos.logback:logback-core": {
+            "locked": "1.4.14",
+            "transitive": [
+                "ch.qos.logback:logback-classic"
+            ]
+        },
+        "com.graphql-java:graphql-java": {
+            "locked": "21.4",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.graphql-java:java-dataloader": {
+            "locked": "3.2.2",
+            "transitive": [
+                "com.graphql-java:graphql-java",
+                "com.netflix.graphql.dgs:graphql-dgs-platform"
+            ]
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.9.0",
+            "transitive": [
+                "com.netflix.graphql.dgs:graphql-dgs-platform",
+                "org.springframework.boot:spring-boot-starter-test"
+            ]
+        },
+        "com.netflix.graphql.dgs:graphql-dgs-platform": {
+            "project": true
+        },
+        "com.vaadin.external.google:android-json": {
+            "locked": "0.0.20131108.vaadin1",
+            "transitive": [
+                "org.skyscreamer:jsonassert"
+            ]
+        },
+        "io.micrometer:micrometer-commons": {
+            "locked": "1.12.5",
+            "transitive": [
+                "io.micrometer:micrometer-observation"
+            ]
+        },
+        "io.micrometer:micrometer-observation": {
+            "locked": "1.12.5",
+            "transitive": [
+                "org.springframework:spring-context"
+            ]
+        },
+        "io.mockk:mockk": {
+            "locked": "1.13.11"
+        },
+        "io.mockk:mockk-agent": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-agent-api-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-api"
+            ]
+        },
+        "io.mockk:mockk-agent-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent"
+            ]
+        },
+        "io.mockk:mockk-core": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-agent-jvm",
+                "io.mockk:mockk-dsl-jvm",
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-core-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-core"
+            ]
+        },
+        "io.mockk:mockk-dsl": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-jvm"
+            ]
+        },
+        "io.mockk:mockk-dsl-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk-dsl"
+            ]
+        },
+        "io.mockk:mockk-jvm": {
+            "locked": "1.13.11",
+            "transitive": [
+                "io.mockk:mockk"
+            ]
+        },
+        "jakarta.activation:jakarta.activation-api": {
+            "locked": "2.1.3",
+            "transitive": [
+                "jakarta.xml.bind:jakarta.xml.bind-api"
+            ]
+        },
+        "jakarta.annotation:jakarta.annotation-api": {
+            "locked": "2.1.1",
+            "transitive": [
+                "org.springframework.boot:spring-boot-starter"
+            ]
+        },
+        "jakarta.xml.bind:jakarta.xml.bind-api": {
+            "locked": "4.0.2",
+            "transitive": [
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "junit:junit": {
             "locked": "4.13.2",
             "transitive": [
-                "io.mockk:mockk-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "net.bytebuddy:byte-buddy": {
@@ -2103,16 +2202,14 @@
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
                 "org.assertj:assertj-core",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
             "locked": "1.14.13",
             "transitive": [
                 "io.mockk:mockk-agent-jvm",
-                "org.mockito:mockito-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-core"
             ]
         },
         "net.minidev:accessors-smart": {
@@ -2125,37 +2222,32 @@
             "locked": "2.5.1",
             "transitive": [
                 "com.jayway.jsonpath:json-path",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.apache.logging.log4j:log4j-api": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.apache.logging.log4j:log4j-to-slf4j"
             ]
         },
         "org.apache.logging.log4j:log4j-to-slf4j": {
-            "locked": "2.23.1",
+            "locked": "2.21.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
         "org.assertj:assertj-core": {
             "locked": "3.24.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2164,19 +2256,14 @@
             "transitive": [
                 "org.awaitility:awaitility",
                 "org.hamcrest:hamcrest-core",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.hamcrest:hamcrest-core": {
             "locked": "2.2",
             "transitive": [
-                "junit:junit",
-                "org.springframework.boot:spring-boot-dependencies"
+                "junit:junit"
             ]
-        },
-        "org.jetbrains.kotlin:kotlin-bom": {
-            "locked": "1.9.24"
         },
         "org.jetbrains.kotlin:kotlin-reflect": {
             "locked": "1.9.24",
@@ -2184,20 +2271,16 @@
                 "io.mockk:mockk-agent-jvm",
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
-                "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "io.mockk:mockk-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-reflect",
                 "org.jetbrains.kotlin:kotlin-stdlib-common",
                 "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-common": {
@@ -2208,19 +2291,15 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7": {
             "locked": "1.9.24",
             "transitive": [
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
             ]
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
@@ -2231,10 +2310,8 @@
                 "io.mockk:mockk-core-jvm",
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlin:kotlin-bom",
                 "org.jetbrains.kotlin:kotlin-stdlib",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-bom": {
@@ -2250,16 +2327,14 @@
             "transitive": [
                 "io.mockk:mockk-dsl-jvm",
                 "io.mockk:mockk-jvm",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-bom"
             ]
         },
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": {
             "locked": "1.7.3",
             "transitive": [
                 "org.jetbrains.kotlinx:kotlinx-coroutines-bom",
-                "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.jetbrains.kotlinx:kotlinx-coroutines-core"
             ]
         },
         "org.jetbrains:annotations": {
@@ -2274,7 +2349,6 @@
             "transitive": [
                 "io.mockk:mockk-jvm",
                 "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2285,24 +2359,21 @@
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
                 "org.junit:junit-bom",
-                "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
             "locked": "5.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-commons": {
@@ -2310,16 +2381,14 @@
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.platform:junit-platform-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit.platform:junit-platform-engine": {
             "locked": "1.10.2",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
-                "org.junit:junit-bom",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.junit:junit-bom"
             ]
         },
         "org.junit:junit-bom": {
@@ -2337,14 +2406,12 @@
             "locked": "5.7.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.7.0",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
@@ -2371,21 +2438,18 @@
         "org.reactivestreams:reactive-streams": {
             "locked": "1.0.4",
             "transitive": [
-                "com.graphql-java:graphql-java",
-                "org.springframework.boot:spring-boot-dependencies"
+                "com.graphql-java:graphql-java"
             ]
         },
         "org.skyscreamer:jsonassert": {
             "locked": "1.5.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.slf4j:jul-to-slf4j": {
             "locked": "2.0.13",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-logging"
             ]
         },
@@ -2397,15 +2461,13 @@
                 "com.graphql-java:java-dataloader",
                 "com.jayway.jsonpath:json-path",
                 "org.apache.logging.log4j:log4j-to-slf4j",
-                "org.slf4j:jul-to-slf4j",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.slf4j:jul-to-slf4j"
             ]
         },
         "org.springframework.boot:spring-boot": {
             "locked": "3.2.5",
             "transitive": [
                 "org.springframework.boot:spring-boot-autoconfigure",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
@@ -2414,38 +2476,28 @@
         "org.springframework.boot:spring-boot-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
         },
-        "org.springframework.boot:spring-boot-dependencies": {
-            "locked": "3.2.5"
-        },
         "org.springframework.boot:spring-boot-starter": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.springframework.boot:spring-boot-starter-logging": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "3.2.5",
-            "transitive": [
-                "org.springframework.boot:spring-boot-dependencies"
-            ]
+            "locked": "3.2.5"
         },
         "org.springframework.boot:spring-boot-test": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework.boot:spring-boot-test-autoconfigure"
             ]
@@ -2453,24 +2505,18 @@
         "org.springframework.boot:spring-boot-test-autoconfigure": {
             "locked": "3.2.5",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
-        },
-        "org.springframework.cloud:spring-cloud-dependencies": {
-            "locked": "2023.0.1"
         },
         "org.springframework:spring-aop": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-beans": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-aop",
                 "org.springframework:spring-context"
             ]
@@ -2478,15 +2524,13 @@
         "org.springframework:spring-context": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies"
+                "org.springframework.boot:spring-boot"
             ]
         },
         "org.springframework:spring-core": {
             "locked": "6.1.6",
             "transitive": [
                 "org.springframework.boot:spring-boot",
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter",
                 "org.springframework.boot:spring-boot-starter-test",
                 "org.springframework:spring-aop",
@@ -2499,35 +2543,30 @@
         "org.springframework:spring-expression": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-context"
             ]
         },
         "org.springframework:spring-jcl": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework:spring-core"
             ]
         },
         "org.springframework:spring-test": {
             "locked": "6.1.6",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.xmlunit:xmlunit-core": {
             "locked": "2.9.1",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter-test"
             ]
         },
         "org.yaml:snakeyaml": {
             "locked": "2.2",
             "transitive": [
-                "org.springframework.boot:spring-boot-dependencies",
                 "org.springframework.boot:spring-boot-starter"
             ]
         }


### PR DESCRIPTION
After upgrading to Gradle 8.7 dependency locks could no longer be created. I changed the build to use Spring's dependency recommender plugin to declare the BOMs. I *think* this is the right setup.