### PR TITLE
Fix handling of @InputArgument for Java objects with optionals.

### DIFF
--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultInputObjectMapper.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DefaultInputObjectMapper.kt
@@ -70,7 +70,6 @@ class DefaultInputObjectMapper(customInputObjectMapper: InputObjectMapper? = nul
                 return mapper.mapToKotlinObject(sourceMap, targetType.type.kotlin)
             }
 
-
             if (targetType.resolvableType.hasGenerics()) {
                 val unwrappedTarget = TypeDescriptor(targetType.resolvableType.getGeneric(), null, targetType.annotations)
                 val target = mapper.mapToJavaObject(sourceMap, unwrappedTarget.type)

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JInputOptionalObject.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/JInputOptionalObject.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public class JInputOptionalObject {
+
+    private Optional<String> simpleString;
+    private LocalDateTime someDate;
+    private Optional<SomeObject> someObject;
+
+    public String getSimpleString() {
+        return simpleString.get();
+    }
+
+    public void setSimpleString(String simpleString) {
+        this.simpleString = Optional.of(simpleString);
+    }
+
+    public LocalDateTime getSomeDate() {
+        return someDate;
+    }
+
+    public void setSomeDate(LocalDateTime someDate) {
+        this.someDate = someDate;
+    }
+
+    public SomeObject getSomeObject() {
+        return someObject.get();
+    }
+
+    public void setSomeObject(SomeObject someObject) {
+        this.someObject = Optional.of(someObject);
+    }
+
+    public static class SomeObject {
+
+        private String key1;
+        private LocalDateTime key2;
+        private Optional<SubObject> key3;
+
+        public String getKey1() {
+            return key1;
+        }
+
+        public void setKey1(String key1) {
+            this.key1 = key1;
+        }
+
+        public LocalDateTime getKey2() {
+            return key2;
+        }
+
+        public void setKey2(LocalDateTime key2) {
+            this.key2 = key2;
+        }
+
+        public SubObject getKey3() {
+            return key3.get();
+        }
+
+        public void setKey3(SubObject key3) {
+            this.key3 = Optional.of(key3);
+        }
+    }
+
+    public static class SubObject {
+        private String subkey1;
+
+        public String getSubkey1() {
+            return subkey1;
+        }
+
+        public void setSubkey1(String subkey1) {
+            this.subkey1 = subkey1;
+        }
+    }
+}
+

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
@@ -102,6 +102,7 @@ internal class InputObjectMapperTest {
         assertThat(mapToObject.someObject.key2).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key3).isNull()
     }
+
     @Test
     fun mapToJavaClassWithOptionals() {
         val mapToObject = inputObjectMapper.mapToJavaObject(inputWithOptionals, JInputOptionalObject::class.java)

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
@@ -23,6 +23,7 @@ import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObject
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithKotlinProperty
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithMap
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithSet
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputOptionalObject
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -46,6 +47,12 @@ internal class InputObjectMapperTest {
         "simpleString" to null,
         "someDate" to currentDate,
         "someObject" to mapOf("key1" to "value1", "key2" to currentDate, "key3" to null)
+    )
+
+    private val inputWithOptionals = mutableMapOf(
+        "simpleString" to "abcd",
+        "someDate" to currentDate,
+        "someObject" to mapOf("key1" to "value1", "key2" to currentDate, "key3" to mapOf("subkey1" to "hi"))
     )
 
     private val inputObjectMapper: InputObjectMapper = DefaultInputObjectMapper()
@@ -94,6 +101,15 @@ internal class InputObjectMapperTest {
         assertThat(mapToObject.someObject.key1).isEqualTo("value1")
         assertThat(mapToObject.someObject.key2).isEqualTo(currentDate)
         assertThat(mapToObject.someObject.key3).isNull()
+    }
+    @Test
+    fun mapToJavaClassWithOptionals() {
+        val mapToObject = inputObjectMapper.mapToJavaObject(inputWithOptionals, JInputOptionalObject::class.java)
+        assertThat(mapToObject.simpleString).isEqualTo("abcd")
+        assertThat(mapToObject.someDate).isEqualTo(currentDate)
+        assertThat(mapToObject.someObject.key1).isEqualTo("value1")
+        assertThat(mapToObject.someObject.key2).isEqualTo(currentDate)
+        assertThat(mapToObject.someObject.key3?.subkey1).isEqualTo("hi")
     }
 
     @Test


### PR DESCRIPTION


Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
This PR fixes handling of @InputArgument for optionals. The current implementation of the DefaultInputObjectMapper does not handling converting from map to optionals, resulting in the following error when used: 
```
**Failed to convert from type [java.util.LinkedHashMap<?, ?>] to type [@com.netflix.graphql.dgs.InputArgument 
```
Conversion of String to Optional<String>, for e.g works fine since Spring's `ObjectToOptionalConverter` handles this fine: https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/main/java/org/springframework/core/convert/support/ObjectToOptionalConverter.java

Adding similar logic to the `DefaultInputObjectMapper` to handle optionals based on this code: https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/main/java/org/springframework/core/convert/support/ObjectToOptionalConverter.java#L76



_Describe the new behavior from this PR, and why it's needed_
Issue #1925 
