### PR TITLE
Add mapping for dgs graphql path property to spring-graphql integration

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLEnvironmentPostProcessor.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLEnvironmentPostProcessor.kt
@@ -31,6 +31,7 @@ class DgsSpringGraphQLEnvironmentPostProcessor : EnvironmentPostProcessor {
 
         properties["spring.graphql.graphiql.enabled"] = environment.getProperty("dgs.graphql.graphiql.enabled") ?: true
         properties["spring.graphql.graphiql.path"] = environment.getProperty("dgs.graphql.graphiql.path") ?: "/graphiql"
+        properties["spring.graphql.path"] = environment.getProperty("dgs.graphql.path") ?: "/graphql"
         properties["spring.graphql.websocket.connection-init-timeout"] = environment.getProperty("dgs.graphql.websocket.connection-init-timeout") ?: "10s"
 
         environment.getProperty("dgs.graphql.websocket.path")?.let {

--- a/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLEnvironmentPostProcessorTest.kt
+++ b/graphql-dgs-spring-graphql/src/test/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLEnvironmentPostProcessorTest.kt
@@ -56,12 +56,28 @@ class DgsSpringGraphQLEnvironmentPostProcessorTest {
     }
 
     @Test
+    fun `Default for graphql-path`() {
+        DgsSpringGraphQLEnvironmentPostProcessor().postProcessEnvironment(env, application)
+
+        Assertions.assertThat(env.getProperty("spring.graphql.path")).isEqualTo("/graphql")
+    }
+
+    @Test
     fun `DGS setting should propagate to spring graphql for graphiql-path`() {
         env.setProperty("dgs.graphql.graphiql.path", "/somepath")
 
         DgsSpringGraphQLEnvironmentPostProcessor().postProcessEnvironment(env, application)
 
         Assertions.assertThat(env.getProperty("spring.graphql.graphiql.path")).isEqualTo("/somepath")
+    }
+
+    @Test
+    fun `DGS setting should propagate to spring graphql for graphql-path`() {
+        env.setProperty("dgs.graphql.path", "/somepath")
+
+        DgsSpringGraphQLEnvironmentPostProcessor().postProcessEnvironment(env, application)
+
+        Assertions.assertThat(env.getProperty("spring.graphql.path")).isEqualTo("/somepath")
     }
 
     @Test


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Spring graphql has a [config property for graphql path,](https://docs.spring.io/spring-boot/appendix/application-properties/index.html#application-properties.web.spring.graphql.path) this change adds a mapping for the dgs-frameworks's graphql path property in the dgs spring-graphql integration.

Issue # [1931](https://github.com/Netflix/dgs-framework/issues/1931)

Testing Done
----

- Tested manually by adding `dgs.graphql.path: /dummy/graphql` to graphql-dgs-spring-graphql-example-java example app's applicaltion.yml and testing via curl commands to default path `/graphql` and custom path `/dummy/graphql`.
- Added code tests.

