### PR TITLE
Fix deserialization of GraphQLErrorDebugInfo

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLError.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLError.kt
@@ -44,12 +44,11 @@ data class GraphQLErrorExtensions(
     @JsonProperty val classification: Any = ""
 )
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 data class GraphQLErrorDebugInfo(
     @JsonProperty val subquery: String = "",
     @JsonProperty val variables: Map<String, Any> = emptyMap(),
-    @JsonAnySetter @get:JsonAnyGetter
-    val additionalInformation: Map<String, Any> = hashMapOf()
+    @field:JsonAnySetter @get:JsonAnyGetter
+    val additionalInformation: Map<String, Any?> = hashMapOf()
 )
 
 /**

--- a/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ErrorsTest.kt
+++ b/graphql-dgs-client/src/test/kotlin/com/netflix/graphql/dgs/client/ErrorsTest.kt
@@ -17,7 +17,6 @@
 package com.netflix.graphql.dgs.client
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -179,7 +178,6 @@ class ErrorsTest {
     }
 
     @Test
-    @Disabled("Broken by Jackson 2.17 https://github.com/FasterXML/jackson-databind/issues/4508")
     fun errorWithDebugInfo() {
         val jsonResponse = """
             {


### PR DESCRIPTION
A recent Jackson upgrade broke deserialization of GraphQLErrorDebugInfo, and the recent fix broke the existing behavior of collecting unknown properties into the additionalInformation field. Add an explicit qualifier for the JsonAnySetter annotation so that it gets applied to the backing field and restores the old behavior, and re-enable the test case now that it passes.
