### PR TITLE
Pin to graphql-java 22.1, fix compilation errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,10 @@ allprojects {
     // as dependencies. e.g. KOTLIN_VERSION
     extra["sb.version"] = "3.3.1"
     extra["kotlin.version"] = Versions.KOTLIN_VERSION
+    // Use graphql-java 22.1, which is the version used by spring-graphql. Once
+    // the Spring Boot BOM depends on this version, we can remove this override.
+    // See: https://github.com/spring-projects/spring-boot/issues/41219
+    extra["graphql-java.version"] = "22.1"
 }
 val internalBomModules by extra(
     listOf(

--- a/graphql-dgs-client/dependencies.lock
+++ b/graphql-dgs-client/dependencies.lock
@@ -22,7 +22,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -147,7 +147,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -384,7 +384,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -606,7 +606,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -929,7 +929,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2332,7 +2332,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -2573,7 +2573,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3463,7 +3463,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -4321,7 +4321,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-example-java-webflux/dependencies.lock
@@ -91,7 +91,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -681,7 +681,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1318,7 +1318,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2043,7 +2043,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3473,7 +3473,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -4228,7 +4228,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5091,7 +5091,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5928,7 +5928,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs-example-java/dependencies.lock
+++ b/graphql-dgs-example-java/dependencies.lock
@@ -100,7 +100,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -596,7 +596,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1139,7 +1139,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1778,7 +1778,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3359,7 +3359,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -4057,7 +4057,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5026,7 +5026,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5977,7 +5977,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs-example-shared/dependencies.lock
+++ b/graphql-dgs-example-shared/dependencies.lock
@@ -45,7 +45,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -260,7 +260,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -522,7 +522,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -887,7 +887,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -1970,7 +1970,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2368,7 +2368,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2939,7 +2939,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3487,7 +3487,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs-extended-scalars/dependencies.lock
+++ b/graphql-dgs-extended-scalars/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -89,7 +89,7 @@
     },
     "compileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -237,7 +237,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -432,7 +432,7 @@
     },
     "jmhCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -788,7 +788,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -1961,7 +1961,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2246,7 +2246,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2813,7 +2813,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3401,7 +3401,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs-extended-validation/dependencies.lock
+++ b/graphql-dgs-extended-validation/dependencies.lock
@@ -15,7 +15,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -139,7 +139,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -331,7 +331,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -570,7 +570,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -970,7 +970,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2187,7 +2187,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2516,7 +2516,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3127,7 +3127,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.graphql-java:graphql-java-extended-validation",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3759,7 +3759,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs-mocking/dependencies.lock
+++ b/graphql-dgs-mocking/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -48,7 +48,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -102,7 +102,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -203,7 +203,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -366,7 +366,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1219,7 +1219,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1285,7 +1285,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1740,7 +1740,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2131,7 +2131,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]

--- a/graphql-dgs-pagination/dependencies.lock
+++ b/graphql-dgs-pagination/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -83,7 +83,7 @@
     },
     "compileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -225,7 +225,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -414,7 +414,7 @@
     },
     "jmhCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -733,7 +733,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1736,7 +1736,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2000,7 +2000,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2478,7 +2478,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2960,7 +2960,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-reactive/dependencies.lock
+++ b/graphql-dgs-reactive/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -132,7 +132,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -568,7 +568,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -781,7 +781,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1204,7 +1204,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2249,7 +2249,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2543,7 +2543,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3124,7 +3124,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3664,7 +3664,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-spring-boot-micrometer/dependencies.lock
+++ b/graphql-dgs-spring-boot-micrometer/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -166,7 +166,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -596,7 +596,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -932,7 +932,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1216,7 +1216,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1791,7 +1791,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3014,7 +3014,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3374,7 +3374,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -4086,7 +4086,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -4773,7 +4773,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
+++ b/graphql-dgs-spring-boot-micrometer/src/test/kotlin/com/netflix/graphql/dgs/metrics/micrometer/MicrometerServletSmokeTest.kt
@@ -901,14 +901,16 @@ class MicrometerServletSmokeTest {
             @DgsData(parentType = "StringTransformation")
             fun upperCased(dfe: DataFetchingEnvironment): CompletableFuture<String>? {
                 val dataLoader = dfe.getDataLoader<String, String>("upperCaseLoader")
-                val input = dfe.getSource<Map<String, String>>()
+                    ?: throw AssertionError("upperCaseLoader not found")
+                val input = dfe.getSource<Map<String, String>>().orEmpty()
                 return dataLoader.load(input.getOrDefault("value", ""))
             }
 
             @DgsData(parentType = "StringTransformation")
             fun reversed(dfe: DataFetchingEnvironment): CompletableFuture<String>? {
                 val dataLoader = dfe.getDataLoader<String, String>("reverser")
-                val input = dfe.getSource<Map<String, String>>()
+                    ?: throw AssertionError("reverser not found")
+                val input = dfe.getSource<Map<String, String>>().orEmpty()
                 return dataLoader.load(input.getOrDefault("value", ""))
             }
 

--- a/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -114,7 +114,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -427,7 +427,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -711,7 +711,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1161,7 +1161,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2249,7 +2249,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2641,7 +2641,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3279,7 +3279,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3884,7 +3884,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/TestDataLoader.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/test/kotlin/com/netflix/graphql/dgs/autoconfig/testcomponents/TestDataLoader.kt
@@ -41,6 +41,7 @@ class FetcherUsingDataLoader {
     @DgsData(parentType = "Query", field = "names")
     fun hello(dfe: DataFetchingEnvironment): CompletableFuture<List<String>> {
         val dataLoader = dfe.getDataLoader<String, String>("testloader")
+            ?: throw AssertionError("testloader not found")
         return dataLoader.loadMany(listOf("a", "b", "c"))
     }
 }
@@ -57,6 +58,7 @@ class FetcherUsingMappedDataLoader {
     @DgsData(parentType = "Query", field = "namesFromMapped")
     fun hello(dfe: DataFetchingEnvironment): CompletableFuture<List<String>> {
         val dataLoader = dfe.getDataLoader<String, String>("testMappedLoader")
+            ?: throw AssertionError("testMappedLoader not found")
         return dataLoader.loadMany(listOf("a", "b", "c"))
     }
 }

--- a/graphql-dgs-spring-boot-starter/dependencies.lock
+++ b/graphql-dgs-spring-boot-starter/dependencies.lock
@@ -23,7 +23,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -228,7 +228,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -634,7 +634,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1087,7 +1087,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1627,7 +1627,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2820,7 +2820,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3339,7 +3339,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -4018,7 +4018,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -4670,7 +4670,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java-webflux/dependencies.lock
@@ -100,7 +100,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -749,7 +749,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1445,7 +1445,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2235,7 +2235,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3761,7 +3761,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -4599,7 +4599,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5528,7 +5528,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -6437,7 +6437,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs-spring-graphql-example-java/dependencies.lock
+++ b/graphql-dgs-spring-graphql-example-java/dependencies.lock
@@ -100,7 +100,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -783,7 +783,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1513,7 +1513,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2338,7 +2338,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -3963,7 +3963,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -4871,7 +4871,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5885,7 +5885,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -6880,7 +6880,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs-spring-graphql-starter/dependencies.lock
+++ b/graphql-dgs-spring-graphql-starter/dependencies.lock
@@ -83,7 +83,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -428,7 +428,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -779,7 +779,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1177,7 +1177,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1663,7 +1663,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2826,7 +2826,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3314,7 +3314,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3938,7 +3938,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -4536,7 +4536,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-spring-graphql/dependencies.lock
+++ b/graphql-dgs-spring-graphql/dependencies.lock
@@ -64,7 +64,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -414,7 +414,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -691,7 +691,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1109,7 +1109,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2240,7 +2240,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2606,7 +2606,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3297,7 +3297,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3947,7 +3947,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webflux-autoconfigure/dependencies.lock
@@ -22,7 +22,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -164,7 +164,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -627,7 +627,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1137,7 +1137,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1761,7 +1761,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3086,7 +3086,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3714,7 +3714,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -4549,7 +4549,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5343,7 +5343,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
+++ b/graphql-dgs-spring-webmvc-autoconfigure/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -152,7 +152,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -439,7 +439,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -773,7 +773,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1210,7 +1210,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2317,7 +2317,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2727,7 +2727,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3378,7 +3378,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3987,7 +3987,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-spring-webmvc/dependencies.lock
+++ b/graphql-dgs-spring-webmvc/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -120,7 +120,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -286,7 +286,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -491,7 +491,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -792,7 +792,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1807,7 +1807,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2097,7 +2097,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2639,7 +2639,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3148,7 +3148,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-subscription-types/dependencies.lock
+++ b/graphql-dgs-subscription-types/dependencies.lock
@@ -21,7 +21,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -66,7 +66,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -182,7 +182,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -345,7 +345,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -595,7 +595,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1465,7 +1465,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1618,7 +1618,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2121,7 +2121,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2560,7 +2560,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]

--- a/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse-autoconfigure/dependencies.lock
@@ -17,7 +17,7 @@
     },
     "compileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -184,7 +184,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -398,7 +398,7 @@
     },
     "jmhCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -744,7 +744,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1791,7 +1791,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2097,7 +2097,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2600,7 +2600,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3109,7 +3109,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-graphql-sse/dependencies.lock
@@ -55,7 +55,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -264,7 +264,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -520,7 +520,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -869,7 +869,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1930,7 +1930,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2248,7 +2248,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2834,7 +2834,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3387,7 +3387,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse-autoconfigure/dependencies.lock
@@ -17,7 +17,7 @@
     },
     "compileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -184,7 +184,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -398,7 +398,7 @@
     },
     "jmhCompileClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -744,7 +744,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1791,7 +1791,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2097,7 +2097,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2600,7 +2600,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3109,7 +3109,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-subscriptions-sse/dependencies.lock
+++ b/graphql-dgs-subscriptions-sse/dependencies.lock
@@ -55,7 +55,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -264,7 +264,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -520,7 +520,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -869,7 +869,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -1930,7 +1930,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2248,7 +2248,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2834,7 +2834,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3387,7 +3387,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets-autoconfigure/dependencies.lock
@@ -65,7 +65,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -302,7 +302,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -578,7 +578,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -963,7 +963,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2050,7 +2050,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2417,7 +2417,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3055,7 +3055,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3651,7 +3651,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-subscriptions-websockets/dependencies.lock
+++ b/graphql-dgs-subscriptions-websockets/dependencies.lock
@@ -22,7 +22,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform",
                 "com.netflix.graphql.dgs:graphql-dgs-subscription-types"
@@ -106,7 +106,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -405,7 +405,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -662,7 +662,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1030,7 +1030,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2056,7 +2056,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -2376,7 +2376,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2933,7 +2933,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3457,7 +3457,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs-webflux-starter/dependencies.lock
+++ b/graphql-dgs-webflux-starter/dependencies.lock
@@ -83,7 +83,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -619,7 +619,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1161,7 +1161,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1750,7 +1750,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2426,7 +2426,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -3797,7 +3797,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",
@@ -4494,7 +4494,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5309,7 +5309,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -6097,7 +6097,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs",

--- a/graphql-dgs/dependencies.lock
+++ b/graphql-dgs/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0"
+            "locked": "22.1"
         },
         "com.graphql-java:java-dataloader": {
             "locked": "3.3.0"
@@ -100,7 +100,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -466,7 +466,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -911,7 +911,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -1550,7 +1550,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -2122,7 +2122,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -2859,7 +2859,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -3245,7 +3245,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",
@@ -4360,7 +4360,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -4649,7 +4649,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5288,7 +5288,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.netflix.graphql.dgs:graphql-dgs-mocking",
@@ -5860,7 +5860,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.apollographql.federation:federation-graphql-java-support",
                 "com.graphql-java:graphql-java-extended-scalars",

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
@@ -34,16 +34,15 @@ class DgsDataFetchingEnvironment(private val dfe: DataFetchingEnvironment) : Dat
 
     fun <K, V> getDataLoader(loaderClass: Class<*>): DataLoader<K, V> {
         val annotation = loaderClass.getAnnotation(DgsDataLoader::class.java)
-        return if (annotation != null) {
-            dfe.getDataLoader(DataLoaderNameUtil.getDataLoaderName(loaderClass, annotation))
+        val loaderName = if (annotation != null) {
+            DataLoaderNameUtil.getDataLoaderName(loaderClass, annotation)
         } else {
             val loaders = loaderClass.fields.filter { it.isAnnotationPresent(DgsDataLoader::class.java) }
             if (loaders.size > 1) throw MultipleDataLoadersDefinedException(loaderClass)
-            val loaderField: java.lang.reflect.Field = loaders
-                .firstOrNull() ?: throw NoDataLoaderFoundException(loaderClass)
+            val loaderField = loaders.firstOrNull() ?: throw NoDataLoaderFoundException(loaderClass)
             val theAnnotation = loaderField.getAnnotation(DgsDataLoader::class.java)
-            val loaderName = theAnnotation.name
-            dfe.getDataLoader(loaderName)
+            theAnnotation.name
         }
+        return getDataLoader(loaderName) ?: throw NoDataLoaderFoundException("DataLoader with name $loaderName not found")
     }
 }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/NoDataLoaderFoundException.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/exceptions/NoDataLoaderFoundException.kt
@@ -16,4 +16,6 @@
 
 package com.netflix.graphql.dgs.exceptions
 
-class NoDataLoaderFoundException(clazz: Class<*>) : RuntimeException("No data loader found. Missing @DgsDataLoader for ${clazz.name}.")
+class NoDataLoaderFoundException(message: String) : RuntimeException(message) {
+    constructor(dataLoaderClass: Class<*>) : this("No data loader found. Missing @DgsDataLoader for ${dataLoaderClass.name}.")
+}

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/federation/DefaultDgsFederationResolver.kt
@@ -105,6 +105,7 @@ open class DefaultDgsFederationResolver() :
 
     private fun dgsEntityFetchers(env: DataFetchingEnvironment): CompletableFuture<DataFetcherResult<List<Any?>>> {
         val resultList = env.getArgument<List<Map<String, Any>>>(_Entity.argumentName)
+            .orEmpty()
             .map { values ->
                 Try.tryCall {
                     val typename = values["__typename"]

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
@@ -73,6 +73,7 @@ internal class DgsDataFetchingEnvironmentTest {
         @DgsData(parentType = "Query", field = "hello")
         fun someFetcher(dfe: DgsDataFetchingEnvironment): CompletableFuture<String> {
             val loader = dfe.getDataLoader<String, String>("exampleMappedLoader")
+                ?: throw AssertionError("exampleMappedLoader not found")
             loader.load("a")
             loader.load("b")
             return loader.load("c")
@@ -95,6 +96,7 @@ internal class DgsDataFetchingEnvironmentTest {
         @DgsData(parentType = "Query", field = "hello")
         fun someFetcher(dfe: DataFetchingEnvironment): CompletableFuture<String> {
             val loader = dfe.getDataLoader<String, String>("exampleLoader")
+                ?: throw AssertionError("exampleLoader not found")
             loader.load("a")
             loader.load("b")
             return loader.load("c")

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -967,7 +967,7 @@ internal class InputArgumentTest {
                 @InputArgument("capitalize") capitalize: Boolean,
                 @InputArgument("person") person: Person
             ): String {
-                val otherArg: String = dfe.getArgument("otherArg")
+                val otherArg: String? = dfe.getArgument("otherArg")
 
                 assertThat(capitalize).isTrue
                 assertThat(person).isNotNull.extracting { it.name }.isEqualTo("tester")
@@ -1015,7 +1015,7 @@ internal class InputArgumentTest {
                 @InputArgument("person") person: Person,
                 dfe: DataFetchingEnvironment
             ): String {
-                val otherArg: String = dfe.getArgument("otherArg")
+                val otherArg: String? = dfe.getArgument("otherArg")
 
                 val msg = if (capitalize) {
                     "Hello, ${person.name}"

--- a/graphql-error-types/dependencies.lock
+++ b/graphql-error-types/dependencies.lock
@@ -9,7 +9,7 @@
     },
     "apiDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -54,7 +54,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -107,7 +107,7 @@
     },
     "implementationDependenciesMetadata": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -205,7 +205,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -353,7 +353,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1196,7 +1196,7 @@
     },
     "runtimeClasspath": {
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1247,7 +1247,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -1692,7 +1692,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]
@@ -2073,7 +2073,7 @@
             ]
         },
         "com.graphql-java:graphql-java": {
-            "locked": "22.0",
+            "locked": "22.1",
             "transitive": [
                 "com.netflix.graphql.dgs:graphql-dgs-platform"
             ]


### PR DESCRIPTION
Override the graphql-java version from the Spring BOM to pull in 22.1, and fix the compilation errors caused by nullability annotations.