### PR TITLE
Add getSourceOrThrow helper method to DgsDataFetchingEnvironment

### DIFF
--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/HelloDataFetcher.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/HelloDataFetcher.java
@@ -66,8 +66,7 @@ public class HelloDataFetcher {
     @DgsData(parentType = "Query", field = "messageFromBatchLoaderWithScheduledDispatch")
     public CompletableFuture<String> getMessageScheduled(DataFetchingEnvironment env) {
         DataLoader<String, String> dataLoader = env.getDataLoader("messagesWithScheduledDispatch");
-        CompletableFuture res =  dataLoader.load("a");
-
+        CompletableFuture<String> res = dataLoader.load("a");
         return res;
     }
 
@@ -82,7 +81,7 @@ public class HelloDataFetcher {
 
     @DgsData(parentType = "Message", field = "info")
     public CompletableFuture<String> getMessageWithException(DgsDataFetchingEnvironment env) {
-        Message msg = env.getSource();
+        Message msg = env.getSourceOrThrow();
         DataLoader<String, String> dataLoader = env.getDataLoader("messagesDataLoaderWithException");
         return dataLoader.load(msg.getInfo());
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
@@ -32,6 +32,15 @@ class DgsDataFetchingEnvironment(private val dfe: DataFetchingEnvironment) : Dat
         return DgsContext.from(this)
     }
 
+    /**
+     * Get the value of the current object to be queried.
+     *
+     * @throws IllegalStateException if called on the root query
+     */
+    fun <T> getSourceOrThrow(): T {
+        return getSource() ?: throw IllegalStateException("source is null")
+    }
+
     fun <K, V> getDataLoader(loaderClass: Class<*>): DataLoader<K, V> {
         val annotation = loaderClass.getAnnotation(DgsDataLoader::class.java)
         val loaderName = if (annotation != null) {


### PR DESCRIPTION
graphql-java 22.1 added nullability annotations to DataFetchingEnvironment methods such as getSource, which can make make the call-site overly verbose from Kotlin since the caller must handle the possibility of null. In this particular case, the method always returns a non-null value unless being called from the context of the root query, so having a helper that returns a non-null value is more ergonomic.
