### PR TITLE
Register jdk8 module in DgsSSESubscriptionHandler

### DIFF
--- a/graphql-dgs-subscriptions-sse/build.gradle.kts
+++ b/graphql-dgs-subscriptions-sse/build.gradle.kts
@@ -17,6 +17,7 @@
 dependencies {
     implementation(project(":graphql-dgs"))
     implementation(project(":graphql-dgs-subscription-types"))
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework:spring-web")
     implementation("org.springframework:spring-webmvc")

--- a/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
+++ b/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt
@@ -16,7 +16,7 @@
 
 package com.netflix.graphql.dgs.subscriptions.sse
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.types.subscription.QueryPayload
 import com.netflix.graphql.types.subscription.SSEDataPayload
@@ -32,6 +32,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.http.codec.ServerSentEvent
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -139,7 +140,7 @@ open class DgsSSESubscriptionHandler(open val dgsQueryExecutor: DgsQueryExecutor
     }
 
     companion object {
-        private val mapper = jacksonObjectMapper()
+        private val mapper: ObjectMapper = Jackson2ObjectMapperBuilder.json().build()
         private val logger: Logger = LoggerFactory.getLogger(DgsSSESubscriptionHandler::class.java)
     }
 }


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----
- Add configuration for Jdk8 Module to jackson object mapper  
- Added implementation dependency for bringing in jackson's Jdk8Module

_Describe the new behavior from this PR, and why it's needed_
Internally the use case arose for needing to serialize java 8 Optionals in SSE subscription calls. Since the object mapper in DgsSSESubscriptionHandler is not configured for the Jdk8 module an error was thrown when that type was part of the payload [here](https://github.com/Netflix/dgs-framework/blob/57977c665c775048fc5028527e752037a8ffcba6/graphql-dgs-subscriptions-sse/src/main/kotlin/com/netflix/graphql/dgs/subscriptions/sse/DgsSSESubscriptionHandler.kt#L113).

Testing done
----

Tested on app which had the serialization error. 

