### PR TITLE
GraphQLResponse.getRequestDetails should return nullable

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/GraphQLResponse.kt
@@ -128,7 +128,7 @@ data class GraphQLResponse(
      * Extracts RequestDetails from the response if available.
      * Returns null otherwise.
      */
-    fun getRequestDetails(): RequestDetails {
+    fun getRequestDetails(): RequestDetails? {
         return extractValueAsObject("gatewayRequestDetails", RequestDetails::class.java)
     }
 


### PR DESCRIPTION
It can return null, so ought to have `?` so that folks using this from Kotlin don't end up with NPEs unexpectedly.