### PR TITLE
Support mapping to record classes

### DIFF
--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/RecordInput.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/internal/java/test/inputobjects/RecordInput.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.internal.java.test.inputobjects;
+
+public record RecordInput(String foo, boolean bar, Integer baz) { }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputObjectMapperTest.kt
@@ -24,6 +24,7 @@ import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithK
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithMap
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithOptional
 import com.netflix.graphql.dgs.internal.java.test.inputobjects.JInputObjectWithSet
+import com.netflix.graphql.dgs.internal.java.test.inputobjects.RecordInput
 import org.assertj.core.api.Assertions.COLLECTION
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -274,9 +275,24 @@ internal class InputObjectMapperTest {
 
     @Test
     fun `mapping to a Kotlin class with a value class field works`() {
-        val result = inputObjectMapper.mapToKotlinObject(mapOf("foo" to ValueClass("the-value"), "bar" to 12345), InputWithValueClass::class)
+        val result = inputObjectMapper.mapToKotlinObject(
+            mapOf("foo" to ValueClass("the-value"), "bar" to 12345),
+            InputWithValueClass::class
+        )
         assertThat(result.foo).isEqualTo(ValueClass("the-value"))
         assertThat(result.bar).isEqualTo(12345)
+    }
+
+    @Test
+    fun `The mapper supports mapping to records`() {
+        val result = inputObjectMapper.mapToJavaObject(mapOf("foo" to "foo-value", "bar" to true, "baz" to 12345), RecordInput::class.java)
+        assertThat(result).isEqualTo(RecordInput("foo-value", true, 12345))
+    }
+
+    @Test
+    fun `The mapper supports mapping to classes with record fields`() {
+        val result = inputObjectMapper.mapToKotlinObject(mapOf("record" to mapOf("foo" to "foo-value", "bar" to true, "baz" to 12345)), KotlinClassWithRecord::class)
+        assertThat(result).isEqualTo(KotlinClassWithRecord(record = RecordInput("foo-value", true, 12345)))
     }
 
     data class KotlinInputObject(val simpleString: String?, val someDate: LocalDateTime, val someObject: KotlinSomeObject)
@@ -298,4 +314,6 @@ internal class InputObjectMapperTest {
 
     @JvmInline
     value class ValueClass(val value: String)
+
+    data class KotlinClassWithRecord(val record: RecordInput)
 }


### PR DESCRIPTION
Add support to DefaultInputObjectMapper to handle mapping to Java record classes.

