### PR TITLE
Add new DgsDataFetchingEnvironment.isArgumentSet

### DIFF
--- a/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/RatingMutation.java
+++ b/graphql-dgs-example-shared/src/main/java/com/netflix/graphql/dgs/example/shared/datafetcher/RatingMutation.java
@@ -18,13 +18,18 @@ package com.netflix.graphql.dgs.example.shared.datafetcher;
 
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
 import com.netflix.graphql.dgs.InputArgument;
 import com.netflix.graphql.dgs.example.shared.types.Rating;
 
 @DgsComponent
 public class RatingMutation {
     @DgsData(parentType = "Mutation", field = "addRating")
-    public Rating addRating(@InputArgument("input") RatingInput ratingInput) {
+    public Rating addRating(@InputArgument("input") RatingInput ratingInput, DgsDataFetchingEnvironment dfe) {
+        if(!dfe.isArgumentSet("input", "title")) {
+            throw new IllegalArgumentException("Title must be explicitly provided");
+        }
+
         if(ratingInput.getStars() < 0) {
             throw new IllegalArgumentException("Stars must be 1-5");
         }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
@@ -67,16 +67,14 @@ class DgsDataFetchingEnvironment(
      * Check if an argument is explicitly set.
      * For complex object arguments, use the isArgumentSet("root", "nested", "property") syntax.
      */
-    fun isArgumentSet(vararg path: String): Boolean {
-        return isArgumentSet(path.asSequence())
-    }
+    fun isArgumentSet(vararg path: String): Boolean = isArgumentSet(path.asSequence())
 
     private fun isArgumentSet(keys: Sequence<String>): Boolean {
         var args: Map<*, *> = dfe.executionStepInfo.arguments
         var value: Any?
         for (key in keys) {
-            //Explicitly check contains to support explicit null values
-            if(!args.contains(key)) return false
+            // Explicitly check contains to support explicit null values
+            if (!args.contains(key)) return false
             value = args[key]
             if (value !is Map<*, *>) {
                 return true
@@ -86,5 +84,3 @@ class DgsDataFetchingEnvironment(
         return true
     }
 }
-
-

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironment.kt
@@ -54,7 +54,7 @@ class DgsDataFetchingEnvironment(
     }
 
     fun isArgumentSet(path: String): Boolean {
-        val pathParts = path.split(".", "->")
+        val pathParts = path.split(".", "->").map { s -> s.trim() }
         return isArgumentSet(*pathParts.toTypedArray())
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentIsArgumentSet.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentIsArgumentSet.kt
@@ -129,12 +129,21 @@ class DgsDataFetchingEnvironmentIsArgumentSet {
 
     @DgsComponent
     class HelloFetcher {
+        /**
+         * Check if a top level argument was provided explicitly.
+         * An explicit null value should also return true.
+         */
         @DgsMutation
         fun inputTester(
             @InputArgument topLevelArg: String?,
             dfe: DgsDataFetchingEnvironment,
         ): Boolean = dfe.isArgumentSet("topLevelArg")
 
+        /**
+         * Check properties of complex input type if they were provided explicitly.
+         * An explicit null value should also return true.
+         * This example uses var args for the property path (e.g. isArgumentSet("personInput", "address", "city"))
+         */
         @DgsMutation
         fun complexInputTester(
             @InputArgument personInput: PersonInput?,
@@ -146,13 +155,18 @@ class DgsDataFetchingEnvironmentIsArgumentSet {
             return InputTestResult(nameIsSet, cityIsSet)
         }
 
+        /**
+         * Check properties of complex input type if they were provided explicitly.
+         * An explicit null value should also return true.
+         * This example uses the . and -> delimiters for the property paths (e.g. isArgumentSet(personInput->address->city))
+         */
         @DgsMutation
         fun complexInputTesterWithDelimiter(
             @InputArgument personInput: PersonInput?,
             dfe: DgsDataFetchingEnvironment,
         ): InputTestResult {
             val nameIsSet = dfe.isArgumentSet("personInput.name")
-            val cityIsSet = dfe.isArgumentSet("personInput->address->city")
+            val cityIsSet = dfe.isArgumentSet("personInput->address -> city")
 
             return InputTestResult(nameIsSet, cityIsSet)
         }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentIsArgumentSet.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentIsArgumentSet.kt
@@ -165,8 +165,8 @@ class DgsDataFetchingEnvironmentIsArgumentSet {
             @InputArgument personInput: PersonInput?,
             dfe: DgsDataFetchingEnvironment,
         ): InputTestResult {
-            val nameIsSet = dfe.isArgumentSet("personInput.name")
-            val cityIsSet = dfe.isArgumentSet("personInput->address -> city")
+            val nameIsSet = dfe.isNestedArgumentSet("personInput.name")
+            val cityIsSet = dfe.isNestedArgumentSet("personInput->address -> city")
 
             return InputTestResult(nameIsSet, cityIsSet)
         }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentIsArgumentSet.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentIsArgumentSet.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs
+
+import com.netflix.graphql.dgs.internal.DefaultInputObjectMapper
+import com.netflix.graphql.dgs.internal.DgsSchemaProvider
+import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentResolver
+import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
+import com.netflix.graphql.dgs.internal.method.MethodDataFetcherFactory
+import graphql.ExecutionInput
+import graphql.GraphQL
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.util.*
+
+class DgsDataFetchingEnvironmentIsArgumentSet {
+    private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun `DgsDataFetcherEnvironment isArgumentSet should support top level arguments, complex arguments, and explicit nulls`() {
+        contextRunner.withBean(HelloFetcher::class.java).run { context ->
+            val schemaProvider =
+                DgsSchemaProvider(
+                    applicationContext = context,
+                    federationResolver = Optional.empty(),
+                    existingTypeDefinitionRegistry = Optional.empty(),
+                    methodDataFetcherFactory =
+                        MethodDataFetcherFactory(
+                            listOf(
+                                DataFetchingEnvironmentArgumentResolver(),
+                                InputArgumentResolver(
+                                    DefaultInputObjectMapper(),
+                                ),
+                            ),
+                        ),
+                )
+            val schema =
+                schemaProvider
+                    .schema(
+                        """
+                        type Mutation {
+                            inputTester(topLevelArg: String): Boolean
+                            complexInputTester(personInput: PersonInput): InputTestResult
+                            complexInputTesterWithDelimiter(personInput: PersonInput): InputTestResult
+                        }
+                        
+                        type InputTestResult {
+                            name: Boolean
+                            city: Boolean
+                        }
+                        
+                        input PersonInput {
+                            name: String
+                            address: Address
+                        }
+                        
+                        input Address {
+                            city: String
+                        }
+                        """.trimIndent(),
+                    ).graphQLSchema
+            val build = GraphQL.newGraphQL(schema).build()
+            val executionInput: ExecutionInput =
+                ExecutionInput
+                    .newExecutionInput()
+                    .query(
+                        """mutation {
+                        |   providedTopLevel: inputTester(topLevelArg: "test")
+                        |   notProvidedTopLevel: inputTester
+                        |   explicitNullTopLevel: inputTester(topLevelArg: null)
+                        |   noPersonProvided: complexInputTester { name, city }
+                        |   nameProvided: complexInputTester(personInput: {name: "DGS" }) { name, city }
+                        |   nameAndCityProvided: complexInputTester(personInput: {name: "DGS", address: {city: "San Jose"} }) { name, city }
+                        |   explicitNullCity: complexInputTester(personInput: {address: {city: null} }) { name, city }
+                        |   complexInputTesterWithDelimiter(personInput: {name: "DGS", address: {city: "San Jose"} }) { name, city }
+                        |}
+                        |
+                        """.trimMargin(),
+                    ).build()
+            val executionResult = build.execute(executionInput)
+            assertTrue(executionResult.isDataPresent)
+            val result = executionResult.getData() as Map<String, String>
+            assertEquals(true, result["providedTopLevel"], "Explicitly provided top level argument")
+            assertEquals(false, result["notProvidedTopLevel"], "Not provided top level argument")
+            assertEquals(true, result["explicitNullTopLevel"], "Explicitly null value provided for top level argument")
+            assertEquals(
+                mapOf(Pair("name", false), Pair("city", false)),
+                result["noPersonProvided"] as Map<*, *>,
+                "Complex input type not provided at all",
+            )
+            assertEquals(
+                mapOf(Pair("name", true), Pair("city", false)),
+                result["nameProvided"] as Map<*, *>,
+                "Complex input type with first level property provided",
+            )
+            assertEquals(
+                mapOf(Pair("name", true), Pair("city", true)),
+                result["nameAndCityProvided"] as Map<*, *>,
+                "Complex input type with multiple levels of properties provided",
+            )
+            assertEquals(
+                mapOf(Pair("name", false), Pair("city", true)),
+                result["explicitNullCity"] as Map<*, *>,
+                "Explicit null value for a nested property",
+            )
+            assertEquals(
+                mapOf(Pair("name", true), Pair("city", true)),
+                result["complexInputTesterWithDelimiter"] as Map<*, *>,
+                "Paths can be expressed with . and ->",
+            )
+        }
+    }
+
+    @DgsComponent
+    class HelloFetcher {
+        @DgsMutation
+        fun inputTester(
+            @InputArgument topLevelArg: String?,
+            dfe: DgsDataFetchingEnvironment,
+        ): Boolean = dfe.isArgumentSet("topLevelArg")
+
+        @DgsMutation
+        fun complexInputTester(
+            @InputArgument personInput: PersonInput?,
+            dfe: DgsDataFetchingEnvironment,
+        ): InputTestResult {
+            val nameIsSet = dfe.isArgumentSet("personInput", "name")
+            val cityIsSet = dfe.isArgumentSet("personInput", "address", "city")
+
+            return InputTestResult(nameIsSet, cityIsSet)
+        }
+
+        @DgsMutation
+        fun complexInputTesterWithDelimiter(
+            @InputArgument personInput: PersonInput?,
+            dfe: DgsDataFetchingEnvironment,
+        ): InputTestResult {
+            val nameIsSet = dfe.isArgumentSet("personInput.name")
+            val cityIsSet = dfe.isArgumentSet("personInput->address->city")
+
+            return InputTestResult(nameIsSet, cityIsSet)
+        }
+    }
+
+    data class PersonInput(
+        val name: String?,
+        val address: Address?,
+    )
+
+    data class Address(
+        val city: String?,
+    )
+
+    data class InputTestResult(
+        val name: Boolean,
+        val city: Boolean,
+    )
+}


### PR DESCRIPTION
Utility method to check if an argument is explicitly set, usable for things like sparse updates.

Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Added an instance method `isArgumentSet` to `DgsDataFetchingEnvironment`. Given a path to an argument, it returns a boolean indicating if this argument was explicitly set.
This is important mostly for sparse update mutations where an explicitly provided null value needs to be handled differently from an argument that wasn't provided at all.
The following datafetching methods are examples of use: 

```
/**
 * Check if a top level argument was provided explicitly.
 * An explicit null value should also return true.
 */
@DgsMutation
fun inputTester(
    @InputArgument topLevelArg: String?,
    dfe: DgsDataFetchingEnvironment,
): Boolean = dfe.isArgumentSet("topLevelArg")

/**
 * Check properties of complex input type if they were provided explicitly.
 * An explicit null value should also return true.
 * This example uses var args for the property path (e.g. isArgumentSet("personInput", "address", "city"))
 */
@DgsMutation
fun complexInputTester(
    @InputArgument personInput: PersonInput?,
    dfe: DgsDataFetchingEnvironment,
): InputTestResult {
    val nameIsSet = dfe.isArgumentSet("personInput", "name")
    val cityIsSet = dfe.isArgumentSet("personInput", "address", "city")

    return InputTestResult(nameIsSet, cityIsSet)
}

/**
 * Check properties of complex input type if they were provided explicitly.
 * An explicit null value should also return true.
 * This example uses the . and -> delimiters for the property paths (e.g. isArgumentSet(personInput->address->city))
 */
@DgsMutation
fun complexInputTesterWithDelimiter(
    @InputArgument personInput: PersonInput?,
    dfe: DgsDataFetchingEnvironment,
): InputTestResult {
    val nameIsSet = dfe.isArgumentSet("personInput.name")
    val cityIsSet = dfe.isArgumentSet("personInput->address -> city")

    return InputTestResult(nameIsSet, cityIsSet)
}
```


Alternatives considered
----

This is an alternative solution to changing generated input types in CodeGen. While this solution requires arguments to be referenced by name (as a String/constant), it doesn't require all generated types to be aware of explicit setting.
This solution also works when codegen is not used, e.g. when Records are used for input types.

Another alternative is to use `@ArgumentValue` from Spring GraphQL. This doesn't automatically account for nested input arguments automatically, but could be a nice solution when types are manually created, or for top level arguments only. Once we remove the legacy DGS implementation later this year, we'll add support for `@ArgumentValue` as an additional option.

