### PR TITLE
Fix: Close the scheduled data loader registry upon completion of request

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/webflux/DgsWebFluxGraphQLInterceptor.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/webflux/DgsWebFluxGraphQLInterceptor.kt
@@ -60,6 +60,10 @@ class DgsWebFluxGraphQLInterceptor(
                         .build()
                 }
                 graphQLContextFuture.complete(request.toExecutionInput().graphQLContext)
-                chain.next(request)
+                chain.next(request).doFinally {
+                    if (dataLoaderRegistry is AutoCloseable) {
+                        dataLoaderRegistry.close()
+                    }
+                }
             }
 }

--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/webmvc/DgsWebMvcGraphQLInterceptor.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/webmvc/DgsWebMvcGraphQLInterceptor.kt
@@ -67,7 +67,7 @@ class DgsWebMvcGraphQLInterceptor(
         }
         graphQLContextFuture.complete(request.toExecutionInput().graphQLContext)
 
-       return if (dgsSpringConfigurationProperties.webmvc.asyncdispatch.enabled) {
+        return if (dgsSpringConfigurationProperties.webmvc.asyncdispatch.enabled) {
             chain.next(request).doFinally {
                 if (dataLoaderRegistry is AutoCloseable) {
                     dataLoaderRegistry.close()
@@ -76,7 +76,7 @@ class DgsWebMvcGraphQLInterceptor(
         } else {
             @Suppress("BlockingMethodInNonBlockingContext")
             val response = chain.next(request).block()!!
-            if(dataLoaderRegistry is AutoCloseable) {
+            if (dataLoaderRegistry is AutoCloseable) {
                 dataLoaderRegistry.close()
             }
             return Mono.just(response)


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

Fixes a bug introduced in the spring-graphql integration. Upon completion of request execution, the scheduled data loader registry needs to be closed. Otherwise scheduled tasks for dataloader dispatching  for a request would never get cleared out. 
This is the equivalent of code in the BaseQueryExecutor: https://github.com/Netflix/dgs-framework/blob/master/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/BaseDgsQueryExecutor.kt#L132


