### PR TITLE
Fix incorrect conditional around wiring of execution strategies

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -130,9 +130,10 @@ open class DgsSpringGraphQLAutoConfiguration {
                 if (preparsedDocumentProvider.isPresent) {
                     graphQlBuilder
                         .preparsedDocumentProvider(preparsedDocumentProvider.get())
-                        .queryExecutionStrategy(queryExecutionStrategy)
-                        .mutationExecutionStrategy(mutationExecutionStrategy)
                 }
+                graphQlBuilder
+                    .queryExecutionStrategy(queryExecutionStrategy)
+                    .mutationExecutionStrategy(mutationExecutionStrategy)
             }
         }
     }


### PR DESCRIPTION
Wiring of the execution strategy was incorrectly conditional on wiring of a `PreparsedDocumentProvider`. These wirings should be independent. 