### PR TITLE
Add graphql-dgs-reactive to the compile classpath

### DIFF
--- a/graphql-dgs-spring-graphql-starter/build.gradle.kts
+++ b/graphql-dgs-spring-graphql-starter/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     api(project(":graphql-dgs-spring-boot-oss-autoconfigure"))
     api(project(":graphql-dgs-spring-graphql"))
     api(project(":graphql-dgs-client"))
+    api(project(":graphql-dgs-reactive"))
     api(project(":graphql-error-types"))
     api("org.springframework.boot:spring-boot-starter-graphql")
 }


### PR DESCRIPTION
Pull Request type
----

- [] Bugfix

Changes in this PR
----

Add `graphql-dgs-reactive` dependency to the compile class-path when using DGS Spring GraphQL Starter.
Issue #2023 

