### PR TITLE
support bean method-level @DgsDataLoader annotations

### DIFF
--- a/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsInputArgumentConfiguration.kt
+++ b/graphql-dgs-spring-boot-oss-autoconfigure/src/main/kotlin/com/netflix/graphql/dgs/autoconfig/DgsInputArgumentConfiguration.kt
@@ -24,6 +24,7 @@ import com.netflix.graphql.dgs.internal.method.DataFetchingEnvironmentArgumentRe
 import com.netflix.graphql.dgs.internal.method.FallbackEnvironmentArgumentResolver
 import com.netflix.graphql.dgs.internal.method.InputArgumentResolver
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
@@ -36,7 +37,8 @@ open class DgsInputArgumentConfiguration {
     open fun inputArgumentResolver(inputObjectMapper: InputObjectMapper): ArgumentResolver = InputArgumentResolver(inputObjectMapper)
 
     @Bean
-    open fun dataFetchingEnvironmentArgumentResolver(): ArgumentResolver = DataFetchingEnvironmentArgumentResolver()
+    open fun dataFetchingEnvironmentArgumentResolver(context: ApplicationContext): ArgumentResolver =
+        DataFetchingEnvironmentArgumentResolver(context)
 
     @Bean
     open fun coroutineArgumentResolver(): ArgumentResolver = ContinuationArgumentResolver()

--- a/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
+++ b/graphql-dgs/src/main/java/com/netflix/graphql/dgs/DgsDataLoader.java
@@ -17,7 +17,6 @@
 package com.netflix.graphql.dgs;
 
 import com.netflix.graphql.dgs.internal.utils.DataLoaderNameUtil;
-import org.dataloader.registries.DispatchPredicate;
 import org.springframework.stereotype.Component;
 
 import java.lang.annotation.ElementType;
@@ -31,7 +30,7 @@ import java.lang.annotation.Target;
  * The class or field must implement one of the BatchLoader interfaces.
  * See https://netflix.github.io/dgs/data-loaders/
  */
-@Target({ElementType.TYPE, ElementType.FIELD})
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Component
 @Inherited

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsCodeRegistryBuilder.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/DgsCodeRegistryBuilder.kt
@@ -23,6 +23,7 @@ import graphql.schema.DataFetchingEnvironment
 import graphql.schema.FieldCoordinates
 import graphql.schema.GraphQLCodeRegistry
 import graphql.schema.GraphQLFieldDefinition
+import org.springframework.context.ApplicationContext
 
 /**
  * Utility wrapper for [GraphQLCodeRegistry.Builder] which provides
@@ -32,6 +33,7 @@ import graphql.schema.GraphQLFieldDefinition
 class DgsCodeRegistryBuilder(
     private val dataFetcherResultProcessors: List<DataFetcherResultProcessor>,
     private val graphQLCodeRegistry: GraphQLCodeRegistry.Builder,
+    private val ctx: ApplicationContext,
 ) {
     fun dataFetcher(
         coordinates: FieldCoordinates,
@@ -67,7 +69,7 @@ class DgsCodeRegistryBuilder(
             if (dfe is DgsDataFetchingEnvironment) {
                 dfe
             } else {
-                DgsDataFetchingEnvironment(dfe)
+                DgsDataFetchingEnvironment(dfe, ctx)
             }
         return processor.process(result, env)
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsDataLoaderProvider.kt
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.aop.support.AopUtils
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.context.ApplicationContext
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.type.StandardMethodMetadata
 import org.springframework.util.ReflectionUtils
 import java.time.Duration
 import java.util.concurrent.Executors
@@ -134,18 +136,36 @@ class DgsDataLoaderProvider(
 
     private fun addDataLoaderComponents() {
         val dataLoaders = applicationContext.getBeansWithAnnotation(DgsDataLoader::class.java)
-        dataLoaders.values.forEach { dgsComponent ->
-            val javaClass = AopUtils.getTargetClass(dgsComponent)
+        dataLoaders.forEach { (beanName, beanInstance) ->
+            val javaClass = AopUtils.getTargetClass(beanInstance)
+
+            // check for class-level annotations
             val annotation = javaClass.getAnnotation(DgsDataLoader::class.java)
-            val predicateField = javaClass.declaredFields.find { it.isAnnotationPresent(DgsDispatchPredicate::class.java) }
-            if (predicateField != null) {
-                ReflectionUtils.makeAccessible(predicateField)
-                val dispatchPredicate = predicateField.get(dgsComponent)
-                if (dispatchPredicate is DispatchPredicate) {
-                    addDataLoaders(dgsComponent, javaClass, annotation, dispatchPredicate)
+            if (annotation != null) {
+                val predicateField =
+                    javaClass.declaredFields.find { it.isAnnotationPresent(DgsDispatchPredicate::class.java) }
+                if (predicateField != null) {
+                    ReflectionUtils.makeAccessible(predicateField)
+                    val dispatchPredicate = predicateField.get(beanInstance)
+                    if (dispatchPredicate is DispatchPredicate) {
+                        addDataLoaders(beanInstance, javaClass, annotation, dispatchPredicate)
+                    }
+                } else {
+                    addDataLoaders(beanInstance, javaClass, annotation, null)
                 }
             } else {
-                addDataLoaders(dgsComponent, javaClass, annotation, null)
+                // Check for method-level bean annotations in configuration classes
+                if (applicationContext is ConfigurableApplicationContext) {
+                    val beanDefinition = applicationContext.beanFactory.getBeanDefinition(beanName)
+                    if (beanDefinition.source is StandardMethodMetadata) {
+                        val methodMetadata = beanDefinition.source as StandardMethodMetadata
+                        val method = methodMetadata.introspectedMethod
+                        val methodAnnotation = method.getAnnotation(DgsDataLoader::class.java)
+                        if (methodAnnotation != null) {
+                            addDataLoaders(beanInstance, javaClass, methodAnnotation, null)
+                        }
+                    }
+                }
             }
         }
     }

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/DgsSchemaProvider.kt
@@ -183,7 +183,7 @@ class DgsSchemaProvider(
         val runtimeWiringBuilder =
             RuntimeWiring.newRuntimeWiring().codeRegistry(codeRegistryBuilder).fieldVisibility(fieldVisibility)
 
-        val dgsCodeRegistryBuilder = DgsCodeRegistryBuilder(dataFetcherResultProcessors, codeRegistryBuilder)
+        val dgsCodeRegistryBuilder = DgsCodeRegistryBuilder(dataFetcherResultProcessors, codeRegistryBuilder, applicationContext)
 
         dgsComponents
             .asSequence()
@@ -217,6 +217,7 @@ class DgsSchemaProvider(
                 DefaultDgsFederationResolver(
                     entityFetcherRegistry,
                     dataFetcherExceptionHandler,
+                    applicationContext,
                 )
             }
 
@@ -269,7 +270,7 @@ class DgsSchemaProvider(
         codeRegistryBuilder: GraphQLCodeRegistry.Builder,
         registry: TypeDefinitionRegistry,
     ) {
-        val dgsCodeRegistryBuilder = DgsCodeRegistryBuilder(dataFetcherResultProcessors, codeRegistryBuilder)
+        val dgsCodeRegistryBuilder = DgsCodeRegistryBuilder(dataFetcherResultProcessors, codeRegistryBuilder, applicationContext)
 
         dgsComponent
             .annotatedMethods<DgsCodeRegistry>()

--- a/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/DataFetchingEnvironmentArgumentResolver.kt
+++ b/graphql-dgs/src/main/kotlin/com/netflix/graphql/dgs/internal/method/DataFetchingEnvironmentArgumentResolver.kt
@@ -18,13 +18,16 @@ package com.netflix.graphql.dgs.internal.method
 
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
 import graphql.schema.DataFetchingEnvironment
+import org.springframework.context.ApplicationContext
 import org.springframework.core.MethodParameter
 
 /**
  * Resolves method arguments for parameters of type [DataFetchingEnvironment]
  * or [DgsDataFetchingEnvironment].
  */
-class DataFetchingEnvironmentArgumentResolver : ArgumentResolver {
+class DataFetchingEnvironmentArgumentResolver(
+    private val ctx: ApplicationContext,
+) : ArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean =
         parameter.parameterType == DgsDataFetchingEnvironment::class.java ||
             parameter.parameterType == DataFetchingEnvironment::class.java
@@ -34,7 +37,7 @@ class DataFetchingEnvironmentArgumentResolver : ArgumentResolver {
         dfe: DataFetchingEnvironment,
     ): Any {
         if (parameter.parameterType == DgsDataFetchingEnvironment::class.java && dfe !is DgsDataFetchingEnvironment) {
-            return DgsDataFetchingEnvironment(dfe)
+            return DgsDataFetchingEnvironment(dfe, ctx)
         }
         return dfe
     }

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/ExampleBatchLoaderFromBean.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/ExampleBatchLoaderFromBean.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs;
+
+import org.dataloader.BatchLoader;
+import org.dataloader.DataLoader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+@Configuration
+public class ExampleBatchLoaderFromBean {
+
+    @DgsDataLoader
+    @Bean
+    public DataLoaderBeanClass batchLoaderBean() {
+       return new DataLoaderBeanClass();
+    }
+
+    @DgsComponent
+    @Bean
+    public HelloFetcherWithFromBean helloFetcherFromBean() {
+        return new HelloFetcherWithFromBean();
+    }
+
+    class DataLoaderBeanClass implements BatchLoader<String, String> {
+
+        @Override
+        public CompletionStage<List<String>> load(List<String> keys) {
+            List<String> values = new ArrayList<>();
+            values.add("a");
+            values.add("b");
+            values.add("c");
+            return CompletableFuture.supplyAsync(() -> values);
+        }
+    }
+
+    class HelloFetcherWithFromBean {
+
+        @DgsData(parentType = "Query", field = "hello")
+        public CompletableFuture<String> someFetcher(DgsDataFetchingEnvironment dfe) {
+            // validate data loader retrieval by type
+            DataLoader<String, String> loader = dfe.getDataLoader(DataLoaderBeanClass.class);
+            loader.load("a");
+            loader.load("b");
+            return loader.load("c");
+        }
+    }
+}

--- a/graphql-dgs/src/test/java/com/netflix/graphql/dgs/ExampleBatchLoaderFromBeanName.java
+++ b/graphql-dgs/src/test/java/com/netflix/graphql/dgs/ExampleBatchLoaderFromBeanName.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs;
+
+import org.dataloader.BatchLoader;
+import org.dataloader.DataLoader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+@Configuration
+public class ExampleBatchLoaderFromBeanName {
+
+    @DgsDataLoader(name = "batchLoaderBeanFromBean")
+    @Bean
+    public DataLoaderBeanClass batchLoaderBean() {
+       return new DataLoaderBeanClass();
+    }
+
+    @DgsComponent
+    @Bean
+    public HelloFetcherWithFromBean helloFetcherFromBean() {
+        return new HelloFetcherWithFromBean();
+    }
+
+    class DataLoaderBeanClass implements BatchLoader<String, String> {
+
+        @Override
+        public CompletionStage<List<String>> load(List<String> keys) {
+            List<String> values = new ArrayList<>();
+            values.add("a");
+            values.add("b");
+            values.add("c");
+            return CompletableFuture.supplyAsync(() -> values);
+        }
+    }
+
+    class HelloFetcherWithFromBean {
+
+        @DgsData(parentType = "Query", field = "hello")
+        public CompletableFuture<String> someFetcher(DgsDataFetchingEnvironment dfe) {
+            // validate data loader retrieval by name
+            DataLoader<String, String> loader = dfe.getDataLoader("batchLoaderBeanFromBean");
+            loader.load("a");
+            loader.load("b");
+            return loader.load("c");
+        }
+    }
+}

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DataFetcherWithDirectivesTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DataFetcherWithDirectivesTest.kt
@@ -73,7 +73,10 @@ class DataFetcherWithDirectivesTest {
                 applicationContext = applicationContextMock,
                 federationResolver = Optional.empty(),
                 existingTypeDefinitionRegistry = Optional.empty(),
-                methodDataFetcherFactory = MethodDataFetcherFactory(listOf(DataFetchingEnvironmentArgumentResolver())),
+                methodDataFetcherFactory =
+                    MethodDataFetcherFactory(
+                        listOf(DataFetchingEnvironmentArgumentResolver(applicationContextMock)),
+                    ),
             )
 
         val schema =

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DefaultDgsFederationResolverTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DefaultDgsFederationResolverTest.kt
@@ -106,7 +106,7 @@ class DefaultDgsFederationResolverTest {
             val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
 
             val type =
-                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                     .typeResolver()
                     .getType(
                         TypeResolutionParameters
@@ -130,7 +130,7 @@ class DefaultDgsFederationResolverTest {
             val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
 
             val type =
-                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                     .typeResolver()
                     .getType(
                         TypeResolutionParameters
@@ -159,7 +159,7 @@ class DefaultDgsFederationResolverTest {
 
             val graphQLSchema: GraphQLSchema = buildGraphQLSchema(schema)
             val customTypeResolver =
-                object : DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler)) {
+                object : DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock) {
                     override fun typeMapping(): Map<Class<*>, String> = mapOf(Movie::class.java to "DgsMovie")
                 }
 
@@ -180,7 +180,7 @@ class DefaultDgsFederationResolverTest {
             val dataFetchingEnvironment = constructDFE(arguments)
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -197,7 +197,7 @@ class DefaultDgsFederationResolverTest {
             val dataFetchingEnvironment = constructDFE(arguments)
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -291,7 +291,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -351,7 +351,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -422,7 +422,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -449,7 +449,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -488,7 +488,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -572,7 +572,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(customExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(customExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -624,7 +624,7 @@ class DefaultDgsFederationResolverTest {
             val dataFetchingEnvironment = constructDFE(arguments)
 
             val result =
-                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                     .entitiesFetcher()
                     .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
 
@@ -670,7 +670,7 @@ class DefaultDgsFederationResolverTest {
             val dataFetchingEnvironment = constructDFE(arguments)
 
             val result =
-                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                     .entitiesFetcher()
                     .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
 
@@ -758,7 +758,7 @@ class DefaultDgsFederationResolverTest {
 
             // Invoke the entitiesFetcher to get the result
             val result =
-                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(customExceptionHandler))
+                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(customExceptionHandler), applicationContextMock)
                     .entitiesFetcher()
                     .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
 
@@ -821,7 +821,7 @@ class DefaultDgsFederationResolverTest {
             val dataFetchingEnvironment = constructDFE(arguments)
 
             val result =
-                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.empty())
+                DefaultDgsFederationResolver(entityFetcherRegistry, Optional.empty(), applicationContextMock)
                     .entitiesFetcher()
                     .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
 
@@ -844,7 +844,7 @@ class DefaultDgsFederationResolverTest {
 
             val result =
                 (
-                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler))
+                    DefaultDgsFederationResolver(entityFetcherRegistry, Optional.of(dgsExceptionHandler), applicationContextMock)
                         .entitiesFetcher()
                         .get(dataFetchingEnvironment) as CompletableFuture<DataFetcherResult<List<*>>>
                 )
@@ -889,6 +889,7 @@ class DefaultDgsFederationResolverTest {
                 .executionStepInfo(executionStepInfo)
                 .mergedField(MergedField.newMergedField(Field("Movie")).build())
                 .build(),
+            applicationContextMock,
         )
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentIsArgumentSet.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentIsArgumentSet.kt
@@ -43,7 +43,7 @@ class DgsDataFetchingEnvironmentIsArgumentSet {
                     methodDataFetcherFactory =
                         MethodDataFetcherFactory(
                             listOf(
-                                DataFetchingEnvironmentArgumentResolver(),
+                                DataFetchingEnvironmentArgumentResolver(context),
                                 InputArgumentResolver(
                                     DefaultInputObjectMapper(),
                                 ),

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataFetchingEnvironmentTest.kt
@@ -116,7 +116,7 @@ internal class DgsDataFetchingEnvironmentTest {
     @Test
     fun getDataLoaderWithBasicDfe() {
         contextRunner.withBeans(HelloFetcherWithBasicDfe::class, ExampleBatchLoader::class).run { context ->
-           validateDataLoader(context)
+            validateDataLoader(context)
         }
     }
 

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsDataLoaderProviderTest.kt
@@ -209,6 +209,7 @@ class DgsDataLoaderProviderTest {
                             .newDataFetchingEnvironment()
                             .dataLoaderRegistry(dataLoaderRegistry)
                             .build(),
+                        context,
                     ).getDataLoader<Any, Any>(ExampleBatchLoaderWithoutName::class.java)
                 Assertions.assertNotNull(dataLoader)
             }

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/DgsSchemaProviderTest.kt
@@ -91,7 +91,7 @@ internal class DgsSchemaProviderTest {
                 MethodDataFetcherFactory(
                     listOf(
                         InputArgumentResolver(DefaultInputObjectMapper()),
-                        DataFetchingEnvironmentArgumentResolver(),
+                        DataFetchingEnvironmentArgumentResolver(applicationContext),
                     ),
                 ),
             componentFilter = componentFilter,

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/InterfaceDataFetchersTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/InterfaceDataFetchersTest.kt
@@ -99,7 +99,10 @@ class InterfaceDataFetchersTest {
                 applicationContext = applicationContextMock,
                 federationResolver = Optional.empty(),
                 existingTypeDefinitionRegistry = Optional.empty(),
-                methodDataFetcherFactory = MethodDataFetcherFactory(listOf(DataFetchingEnvironmentArgumentResolver())),
+                methodDataFetcherFactory =
+                    MethodDataFetcherFactory(
+                        listOf(DataFetchingEnvironmentArgumentResolver(applicationContextMock)),
+                    ),
             )
         val schema =
             provider

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/context/DgsContextTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/context/DgsContextTest.kt
@@ -78,7 +78,7 @@ internal class DgsContextTest {
                     MethodDataFetcherFactory(
                         listOf(
                             InputArgumentResolver(DefaultInputObjectMapper()),
-                            DataFetchingEnvironmentArgumentResolver(),
+                            DataFetchingEnvironmentArgumentResolver(context),
                         ),
                     ),
             )

--- a/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
+++ b/graphql-dgs/src/test/kotlin/com/netflix/graphql/dgs/internal/InputArgumentTest.kt
@@ -88,7 +88,7 @@ internal class InputArgumentTest {
                 MethodDataFetcherFactory(
                     listOf(
                         InputArgumentResolver(DefaultInputObjectMapper()),
-                        DataFetchingEnvironmentArgumentResolver(),
+                        DataFetchingEnvironmentArgumentResolver(applicationContext),
                         FallbackEnvironmentArgumentResolver(DefaultInputObjectMapper()),
                     ),
                 ),


### PR DESCRIPTION
Pull request checklist
----

- [ X] Please read our [contributor guide](https://github.com/Netflix/dgs-framework/blob/master/CONTRIBUTING.md)
- [ ] Consider creating a discussion on the [discussion forum](https://github.com/Netflix/dgs-framework/discussions)
  first
- [ X] Make sure the PR doesn't introduce backward compatibility issues
- [ X] Make sure to have sufficient test cases

Pull Request type
----

- [ ] Bugfix
- [X ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

Changes in this PR
----

This PR adds support for method-level annotations of `@DgsDataLoader` so their creation can be made via a bean definition of `@DgsComponent`.  The specific change needed for this is to correctly create the DataLoader holder from both the class and the bean method annotation metadata.  The other is in the DFE which retrieves the correct data loader.  Previous code assumed class/field anotations would always be present via reflection, so a special case was added for looking it up from the bean definition using the ApplicationContext, which must now be wired through to the DFE.

Issue # [2028](https://github.com/Netflix/dgs-framework/issues/2028)

Alternatives considered
----

_Describe alternative implementation you have considered_

