### PR TITLE
Rename serverWebExchangeContextFilter to dgsServerWebExchangeContextFilter

### DIFF
--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -250,7 +250,7 @@ open class DgsSpringGraphQLAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean
-        open fun serverWebExchangeContextFilter(): ServerWebExchangeContextFilter = ServerWebExchangeContextFilter()
+        open fun dgsServerWebExchangeContextFilter(): ServerWebExchangeContextFilter = ServerWebExchangeContextFilter()
     }
 
     @Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
This is a workaround for compatibility with Spring Hateoas.

Spring Hateoas [doesn't do proper autoconfiguration](https://github.com/spring-projects/spring-boot/issues/16020), instead they have a custom mechanism for this. Unfortunately this mechanism doesn't play nice with bean conditionals, leading to a duplicate bean exception on `serverWebExchangeContextFilter`, even though this bean is `@ConditionalOnMissingBean` in DGS.

While this isn't directly a problem for DGS, there are many projects that use Spring Hateoas, often as a transitive through spring-data-rest. Because this is a simple workaround it's probably worth just renaming the bean in DGS.