### PR TITLE
Fix GraphQLContext propagation to data loaders with spring-graphql starter

### DIFF
--- a/graphql-dgs-spring-graphql-example-java/src/test/java/com/netflix/graphql/dgs/example/datafetcher/GraphQLContextContributorTest.java
+++ b/graphql-dgs-spring-graphql-example-java/src/test/java/com/netflix/graphql/dgs/example/datafetcher/GraphQLContextContributorTest.java
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.graphql.dgs.example.datafetcher;import com.netflix.graphql.dgs.DgsQueryExecutor;
-import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
-import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
-import com.netflix.graphql.dgs.example.context.MyContextBuilder;
-import com.netflix.graphql.dgs.example.datafetcher.HelloDataFetcher;
-import com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor;
-import com.netflix.graphql.dgs.example.shared.dataLoader.ExampleLoaderWithContext;
-import com.netflix.graphql.dgs.example.shared.dataLoader.ExampleLoaderWithGraphQLContext;
+package com.netflix.graphql.dgs.example.datafetcher;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.example.shared.datafetcher.RequestHeadersDataFetcher;
-import com.netflix.graphql.dgs.example.shared.instrumentation.ExampleInstrumentationDependingOnContextContributor;
 import com.netflix.graphql.dgs.example.shared.datafetcher.MovieDataFetcher;
-import com.netflix.graphql.dgs.pagination.DgsPaginationAutoConfiguration;
 import com.netflix.graphql.dgs.test.EnableDgsTest;
-import graphql.scalars.ExtendedScalars;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/graphql-dgs-spring-graphql-example-java/src/test/java/com/netflix/graphql/dgs/example/datafetcher/GraphQLContextContributorTest.java
+++ b/graphql-dgs-spring-graphql-example-java/src/test/java/com/netflix/graphql/dgs/example/datafetcher/GraphQLContextContributorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.graphql.dgs.example.datafetcher;import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
+import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
+import com.netflix.graphql.dgs.example.context.MyContextBuilder;
+import com.netflix.graphql.dgs.example.datafetcher.HelloDataFetcher;
+import com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor;
+import com.netflix.graphql.dgs.example.shared.dataLoader.ExampleLoaderWithContext;
+import com.netflix.graphql.dgs.example.shared.dataLoader.ExampleLoaderWithGraphQLContext;
+import com.netflix.graphql.dgs.example.shared.datafetcher.RequestHeadersDataFetcher;
+import com.netflix.graphql.dgs.example.shared.instrumentation.ExampleInstrumentationDependingOnContextContributor;
+import com.netflix.graphql.dgs.example.shared.datafetcher.MovieDataFetcher;
+import com.netflix.graphql.dgs.pagination.DgsPaginationAutoConfiguration;
+import com.netflix.graphql.dgs.test.EnableDgsTest;
+import graphql.scalars.ExtendedScalars;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import static com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor.CONTEXT_CONTRIBUTOR_HEADER_NAME;
+import static com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor.CONTEXT_CONTRIBUTOR_HEADER_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableDgsTest
+@TestAppTestSlice
+@SpringBootTest(classes = {SpringGraphQLDataFetchers.class, com.netflix.graphql.dgs.example.datafetcher.HelloDataFetcher.class, WithHeader.class, WithCookie.class, MovieDataFetcher.class, RequestHeadersDataFetcher.class})
+public class GraphQLContextContributorTest {
+
+    @Autowired
+    DgsQueryExecutor queryExecutor;
+
+    @Test
+    void moviesExtensionShouldHaveContributedEnabledExtension() {
+        final MockHttpServletRequest mockServletRequest = new MockHttpServletRequest();
+        mockServletRequest.addHeader(CONTEXT_CONTRIBUTOR_HEADER_NAME, CONTEXT_CONTRIBUTOR_HEADER_VALUE);
+        ServletWebRequest servletWebRequest = new ServletWebRequest(mockServletRequest);
+        String contributorEnabled = queryExecutor.executeAndExtractJsonPath("{ movies { director } }", "extensions.contributorEnabled", servletWebRequest);
+        assertThat(contributorEnabled).isEqualTo("true");
+    }
+
+    @Test
+    void withDataloaderContext() {
+        String message = queryExecutor.executeAndExtractJsonPath("{withDataLoaderContext}", "data.withDataLoaderContext");
+        assertThat(message).isEqualTo("Custom state! A");
+    }
+
+    @Test
+    void withDataloaderGraphQLContext() {
+        final MockHttpServletRequest mockServletRequest = new MockHttpServletRequest();
+        mockServletRequest.addHeader(CONTEXT_CONTRIBUTOR_HEADER_NAME, CONTEXT_CONTRIBUTOR_HEADER_VALUE);
+        ServletWebRequest servletWebRequest = new ServletWebRequest(mockServletRequest);
+        String contributorEnabled = queryExecutor.executeAndExtractJsonPath("{ withDataLoaderGraphQLContext }", "data.withDataLoaderGraphQLContext", servletWebRequest);
+        assertThat(contributorEnabled).isEqualTo("true");
+    }
+}

--- a/graphql-dgs-spring-graphql-example-java/src/test/java/com/netflix/graphql/dgs/example/datafetcher/TestAppTestSlice.java
+++ b/graphql-dgs-spring-graphql-example-java/src/test/java/com/netflix/graphql/dgs/example/datafetcher/TestAppTestSlice.java
@@ -20,6 +20,7 @@ import com.netflix.graphql.dgs.autoconfig.DgsExtendedScalarsAutoConfiguration;
 import com.netflix.graphql.dgs.example.context.MyContextBuilder;
 import com.netflix.graphql.dgs.example.shared.context.ExampleGraphQLContextContributor;
 import com.netflix.graphql.dgs.example.shared.dataLoader.ExampleLoaderWithContext;
+import com.netflix.graphql.dgs.example.shared.dataLoader.ExampleLoaderWithGraphQLContext;
 import com.netflix.graphql.dgs.example.shared.dataLoader.MessageDataLoader;
 import com.netflix.graphql.dgs.example.shared.instrumentation.ExampleInstrumentationDependingOnContextContributor;
 import com.netflix.graphql.dgs.pagination.DgsPaginationAutoConfiguration;
@@ -36,6 +37,7 @@ import java.lang.annotation.*;
 @Import({MessageDataLoader.class,
         UploadScalar.class,
         ExampleLoaderWithContext.class,
+        ExampleLoaderWithGraphQLContext.class,
         ExampleGraphQLContextContributor.class,
         ExampleInstrumentationDependingOnContextContributor.class,
         MyContextBuilder.class

--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -120,6 +120,7 @@ open class DgsSpringGraphQLAutoConfiguration {
     ): GraphQlSourceBuilderCustomizer =
         GraphQlSourceBuilderCustomizer { builder ->
             builder.configureGraphQl { graphQlBuilder ->
+
                 if (preparsedDocumentProvider.isPresent) {
                     graphQlBuilder
                         .preparsedDocumentProvider(preparsedDocumentProvider.get())
@@ -176,11 +177,13 @@ open class DgsSpringGraphQLAutoConfiguration {
         open fun dgsGraphQlInterceptor(
             dgsDataLoaderProvider: DgsDataLoaderProvider,
             dgsDefaultContextBuilder: DefaultDgsGraphQLContextBuilder,
+            graphQLContextContributors: List<GraphQLContextContributor>,
         ): DgsWebMvcGraphQLInterceptor =
             DgsWebMvcGraphQLInterceptor(
                 dgsDataLoaderProvider,
                 dgsDefaultContextBuilder,
                 dgsSpringGraphQLConfigurationProperties,
+                graphQLContextContributors,
             )
     }
 

--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/autoconfig/DgsSpringGraphQLAutoConfiguration.kt
@@ -120,7 +120,6 @@ open class DgsSpringGraphQLAutoConfiguration {
     ): GraphQlSourceBuilderCustomizer =
         GraphQlSourceBuilderCustomizer { builder ->
             builder.configureGraphQl { graphQlBuilder ->
-
                 if (preparsedDocumentProvider.isPresent) {
                     graphQlBuilder
                         .preparsedDocumentProvider(preparsedDocumentProvider.get())
@@ -160,12 +159,14 @@ open class DgsSpringGraphQLAutoConfiguration {
         dgsContextBuilder: DefaultDgsGraphQLContextBuilder,
         dgsDataLoaderProvider: DgsDataLoaderProvider,
         requestCustomizer: ObjectProvider<DgsQueryExecutorRequestCustomizer>,
+        graphQLContextContributors: List<GraphQLContextContributor>,
     ): DgsQueryExecutor =
         SpringGraphQLDgsQueryExecutor(
             executionService,
             dgsContextBuilder,
             dgsDataLoaderProvider,
             requestCustomizer = requestCustomizer.getIfAvailable(DgsQueryExecutorRequestCustomizer::DEFAULT_REQUEST_CUSTOMIZER),
+            graphQLContextContributors,
         )
 
     @Configuration(proxyBeanMethods = false)

--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/webmvc/DgsWebMvcGraphQLInterceptor.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/webmvc/DgsWebMvcGraphQLInterceptor.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.graphql.dgs.springgraphql.webmvc
 
-import com.netflix.graphql.dgs.context.DgsContext
 import com.netflix.graphql.dgs.context.GraphQLContextContributor
 import com.netflix.graphql.dgs.internal.DefaultDgsGraphQLContextBuilder
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
@@ -31,7 +30,6 @@ import org.springframework.web.context.request.ServletRequestAttributes
 import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
 import reactor.core.publisher.Mono
-import java.util.concurrent.CompletableFuture
 
 class DgsWebMvcGraphQLInterceptor(
     private val dgsDataLoaderProvider: DgsDataLoaderProvider,
@@ -58,18 +56,19 @@ class DgsWebMvcGraphQLInterceptor(
             } else {
                 dgsContextBuilder.build(DgsWebMvcRequestData(request.extensions, request.headers))
             }
-        val dataLoaderRegistry = dgsDataLoaderProvider.buildRegistryWithContextSupplier {
-            val graphQLContext = request.toExecutionInput().graphQLContext
-            if (graphQLContextContributors.isNotEmpty()) {
-                val extensions = request.extensions
-                val requestData = dgsContext.requestData
-                val builderForContributors = GraphQLContext.newContext()
-                graphQLContextContributors.forEach { it.contribute(builderForContributors, extensions, requestData) }
-                graphQLContext.putAll(builderForContributors)
-            }
+        val dataLoaderRegistry =
+            dgsDataLoaderProvider.buildRegistryWithContextSupplier {
+                val graphQLContext = request.toExecutionInput().graphQLContext
+                if (graphQLContextContributors.isNotEmpty()) {
+                    val extensions = request.extensions
+                    val requestData = dgsContext.requestData
+                    val builderForContributors = GraphQLContext.newContext()
+                    graphQLContextContributors.forEach { it.contribute(builderForContributors, extensions, requestData) }
+                    graphQLContext.putAll(builderForContributors)
+                }
 
-            graphQLContext
-        }
+                graphQLContext
+            }
 
         request.configureExecutionInput { _, builder ->
             builder
@@ -78,9 +77,6 @@ class DgsWebMvcGraphQLInterceptor(
                 .dataLoaderRegistry(dataLoaderRegistry)
                 .build()
         }
-
-
-
 
         return if (dgsSpringConfigurationProperties.webmvc.asyncdispatch.enabled) {
             chain.next(request).doFinally {

--- a/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/webmvc/DgsWebMvcGraphQLInterceptor.kt
+++ b/graphql-dgs-spring-graphql/src/main/kotlin/com/netflix/graphql/dgs/springgraphql/webmvc/DgsWebMvcGraphQLInterceptor.kt
@@ -16,6 +16,8 @@
 
 package com.netflix.graphql.dgs.springgraphql.webmvc
 
+import com.netflix.graphql.dgs.context.DgsContext
+import com.netflix.graphql.dgs.context.GraphQLContextContributor
 import com.netflix.graphql.dgs.internal.DefaultDgsGraphQLContextBuilder
 import com.netflix.graphql.dgs.internal.DgsDataLoaderProvider
 import com.netflix.graphql.dgs.internal.DgsWebMvcRequestData
@@ -35,6 +37,7 @@ class DgsWebMvcGraphQLInterceptor(
     private val dgsDataLoaderProvider: DgsDataLoaderProvider,
     private val dgsContextBuilder: DefaultDgsGraphQLContextBuilder,
     private val dgsSpringConfigurationProperties: DgsSpringGraphQLConfigurationProperties,
+    private val graphQLContextContributors: List<GraphQLContextContributor>,
 ) : WebGraphQlInterceptor {
     override fun intercept(
         request: WebGraphQlRequest,
@@ -55,8 +58,18 @@ class DgsWebMvcGraphQLInterceptor(
             } else {
                 dgsContextBuilder.build(DgsWebMvcRequestData(request.extensions, request.headers))
             }
-        val graphQLContextFuture = CompletableFuture<GraphQLContext>()
-        val dataLoaderRegistry = dgsDataLoaderProvider.buildRegistryWithContextSupplier { graphQLContextFuture.get() }
+        val dataLoaderRegistry = dgsDataLoaderProvider.buildRegistryWithContextSupplier {
+            val graphQLContext = request.toExecutionInput().graphQLContext
+            if (graphQLContextContributors.isNotEmpty()) {
+                val extensions = request.extensions
+                val requestData = dgsContext.requestData
+                val builderForContributors = GraphQLContext.newContext()
+                graphQLContextContributors.forEach { it.contribute(builderForContributors, extensions, requestData) }
+                graphQLContext.putAll(builderForContributors)
+            }
+
+            graphQLContext
+        }
 
         request.configureExecutionInput { _, builder ->
             builder
@@ -65,7 +78,9 @@ class DgsWebMvcGraphQLInterceptor(
                 .dataLoaderRegistry(dataLoaderRegistry)
                 .build()
         }
-        graphQLContextFuture.complete(request.toExecutionInput().graphQLContext)
+
+
+
 
         return if (dgsSpringConfigurationProperties.webmvc.asyncdispatch.enabled) {
             chain.next(request).doFinally {


### PR DESCRIPTION

Fix for https://github.com/Netflix/dgs-framework/issues/2058. 

With the spring-graphql starter we are no longer able to access and pass the instance of `executionInput` that is modified with contributed graphql context to the `buildRegistryWithContextSupplier` method. 

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):
