### PR TITLE
Remove incorrect toString() for URL in RestClientGraphQLClient error handling

### DIFF
--- a/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/RestClientGraphQLClient.kt
+++ b/graphql-dgs-client/src/main/kotlin/com/netflix/graphql/dgs/client/RestClientGraphQLClient.kt
@@ -99,7 +99,7 @@ class RestClientGraphQLClient(
         if (!responseEntity.statusCode.is2xxSuccessful) {
             throw GraphQLClientException(
                 statusCode = responseEntity.statusCode.value(),
-                url = restClient.toString(),
+                url = "",
                 response = responseEntity.body ?: "",
                 request = serializedRequest,
             )


### PR DESCRIPTION
Fix for #2059.

By default, the error handling for failing HTTP requests is done by `RestClient` itself, so the extra error check we have in code is typically not used. Added a test for this.

If a non-default status code handler is configured on the `RestClient`, it might still fall through, so I kept the existing error handling. However, I removed the incorrect `toString()` use for the `url` field in the exception. 
In a `RestClient` you can't actually see what URL it is configured for, so we don't have access to the URL during error handling in this case. This is acceptable because this exception only throws when the user overrides the handling, and not handle a status code correctly.